### PR TITLE
fix(molecule): retry a dropped molecule_failed stamp before giving up (#6235)

### DIFF
--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -1722,33 +1722,70 @@ func activateAttachCandidate(store beads.Store, rootID string, idMapping map[str
 	return nil
 }
 
-// markFailedReporting is markFailed with the first metadata-write error
-// surfaced instead of swallowed: the fence loser path must know when its
-// candidate was NOT neutralized, because an unmarked candidate could
-// otherwise be selected by idempotency recovery.
+// markFailedReporting is markFailed with every id whose stamp still failed
+// after the retry pass surfaced instead of swallowed: the fence loser path
+// must know when its candidate was NOT neutralized, because an unmarked
+// candidate could otherwise be selected by idempotency recovery.
 func markFailedReporting(store beads.Store, ids []string) error {
-	var firstErr error
+	stillFailed := stampMoleculeFailedTwoPass(store, ids)
+	if len(stillFailed) == 0 {
+		return nil
+	}
+	errs := make([]error, 0, len(stillFailed))
+	for _, f := range stillFailed {
+		errs = append(errs, fmt.Errorf("marking %s molecule_failed: %w", f.id, f.err))
+	}
+	return errors.Join(errs...)
+}
+
+// markFailed sets beadmeta.MoleculeFailedMetadataKey on all created beads.
+// Best-effort: any id still unmarked after the retry pass is silently left
+// as-is since we're already in an error path.
+func markFailed(store beads.Store, ids []string) {
+	stampMoleculeFailedTwoPass(store, ids)
+}
+
+// stampFailure pairs an id with the error its stamp attempt returned.
+type stampFailure struct {
+	id  string
+	err error
+}
+
+// stampMoleculeFailedTwoPass stamps molecule_failed on every id, in order.
+// A single attempt can lose exactly the id whose row is hottest at the
+// moment of the fault this whole call exists to report — often the root,
+// activated first and so the first row any conflicting writer contends
+// on — while every other id, never touched by that fault, succeeds. A
+// bead skipped this way stays fenced and unmarked, invisible to every
+// sweep and dispatch gate that filters on molecule_failed. The retry pass
+// gives that correlated fault the time the rest of the loop already took
+// to clear before giving up on an id. Returns the ids (with their retry
+// error) still unmarked after both passes.
+func stampMoleculeFailedTwoPass(store beads.Store, ids []string) []stampFailure {
+	failed := stampMoleculeFailedOnce(store, ids)
+	if len(failed) == 0 {
+		return nil
+	}
+	retryIDs := make([]string, 0, len(failed))
+	for _, f := range failed {
+		retryIDs = append(retryIDs, f.id)
+	}
+	return stampMoleculeFailedOnce(store, retryIDs)
+}
+
+// stampMoleculeFailedOnce attempts to stamp molecule_failed on every id
+// once, returning the ids whose write failed alongside the error.
+func stampMoleculeFailedOnce(store beads.Store, ids []string) []stampFailure {
+	var failed []stampFailure
 	for _, id := range ids {
 		if err := store.SetMetadataBatch(id, map[string]string{
 			beadmeta.MoleculeFailedMetadataKey: "true",
 			InstantiatingMetadataKey:           "",
-		}); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("marking %s molecule_failed: %w", id, err)
+		}); err != nil {
+			failed = append(failed, stampFailure{id: id, err: err})
 		}
 	}
-	return firstErr
-}
-
-// markFailed sets beadmeta.MoleculeFailedMetadataKey on all created beads.
-// Best-effort: errors are silently ignored since we're already in an
-// error path.
-func markFailed(store beads.Store, ids []string) {
-	for _, id := range ids {
-		_ = store.SetMetadataBatch(id, map[string]string{
-			beadmeta.MoleculeFailedMetadataKey: "true",
-			InstantiatingMetadataKey:           "",
-		})
-	}
+	return failed
 }
 
 func logicalRecipeStepID(step formula.RecipeStep) (string, bool) {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1069,6 +1069,108 @@ func TestInstantiateGraphWorkflowFailureClearsInstantiationFence(t *testing.T) {
 	}
 }
 
+// errRootActivationStore fails the root's own fenced-activation Update
+// exactly once, and separately fails the root's molecule_failed stamp
+// exactly once — the two correlated faults #6235 describes: a hot row
+// conflict on the root's activation drops through to markFailed, whose
+// very first write targets that same still-hot row and used to be dropped
+// with no retry. Every other id is untouched.
+type errRootActivationStore struct {
+	beads.Store
+	rootID             string
+	failActivateOnce   bool
+	failFirstStampOnce bool
+}
+
+func (e *errRootActivationStore) Create(b beads.Bead) (beads.Bead, error) {
+	created, err := e.Store.Create(b)
+	if err == nil && e.rootID == "" {
+		e.rootID = created.ID
+	}
+	return created, err
+}
+
+func (e *errRootActivationStore) Update(id string, opts beads.UpdateOpts) error {
+	if e.failActivateOnce && id == e.rootID {
+		e.failActivateOnce = false
+		return fmt.Errorf("injected root activation conflict")
+	}
+	return e.Store.Update(id, opts)
+}
+
+func (e *errRootActivationStore) SetMetadataBatch(id string, metadata map[string]string) error {
+	if e.failFirstStampOnce && id == e.rootID {
+		e.failFirstStampOnce = false
+		return fmt.Errorf("injected root mark-failed conflict")
+	}
+	return e.Store.SetMetadataBatch(id, metadata)
+}
+
+// TestInstantiateFailureStampsTheRootWhoseActivationFailed is the #6235
+// regression: when the root's own fenced-activation Update fails, markFailed's
+// very first write targets that same hot row and — before the two-pass
+// retry — could lose to the identical correlated fault, leaving the root
+// fenced (gc.instantiating still "true") and NOT stamped molecule_failed,
+// while every later member (never activated, so never contended) is
+// stamped and un-fenced normally. A root left in that state is invisible
+// to every dispatch/sweep gate that filters on molecule_failed.
+func TestInstantiateFailureStampsTheRootWhoseActivationFailed(t *testing.T) {
+	prev := IsGraphApplyEnabled()
+	SetGraphApplyEnabled(false)
+	t.Cleanup(func() { SetGraphApplyEnabled(prev) })
+
+	base := beads.NewMemStore()
+	store := &errRootActivationStore{Store: base, failActivateOnce: true, failFirstStampOnce: true}
+	recipe := &formula.Recipe{
+		Name: "wf",
+		Steps: []formula.RecipeStep{
+			{
+				ID:       "wf",
+				Title:    "Workflow",
+				Type:     "task",
+				IsRoot:   true,
+				Assignee: "controller",
+				Metadata: map[string]string{
+					"gc.kind":      "workflow",
+					"gc.routed_to": "gascity/control-dispatcher",
+				},
+			},
+			{
+				ID:       "wf.body",
+				Title:    "Body",
+				Type:     "task",
+				Assignee: "worker",
+				Metadata: map[string]string{
+					"gc.kind":      "scope",
+					"gc.routed_to": "gascity/worker",
+				},
+			},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "wf.body", DependsOnID: "wf", Type: "parent-child"},
+		},
+	}
+
+	_, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err == nil {
+		t.Fatal("expected error on root activation failure")
+	}
+	if store.rootID == "" {
+		t.Fatal("root id never observed")
+	}
+
+	root, getErr := base.Get(store.rootID)
+	if getErr != nil {
+		t.Fatalf("Get(root): %v", getErr)
+	}
+	if root.Metadata["molecule_failed"] != "true" {
+		t.Errorf("root molecule_failed = %q, want true", root.Metadata["molecule_failed"])
+	}
+	if root.Metadata[InstantiatingMetadataKey] != "" {
+		t.Errorf("root instantiating metadata = %q, want cleared", root.Metadata[InstantiatingMetadataKey])
+	}
+}
+
 type observingCreateStore struct {
 	*beads.MemStore
 	created []beads.Bead


### PR DESCRIPTION
## What

When a mint fails on its root's own activation — a transient conflict on the hottest row of the mint — `Instantiate` calls `markFailed(store, createdIDs)`, whose very first write targets the row that just faulted, hits the same fault, and is dropped (`_ = store.SetMetadataBatch`). Every later member, never touched by that fault, is stamped `molecule_failed=true` and un-fenced normally. Exactly one bead stays fenced (`gc.instantiating="true"`) and unmarked: the root — invisible to every dispatch and sweep gate that filters on `molecule_failed`, so never activated, voided or reported. `markFailedReporting` had the same single-attempt shape and surfaced only the first error.

Fixes #6235.

## Fix

`markFailed` and `markFailedReporting` now route through one shared two-pass stamper (`stampMoleculeFailedTwoPass`): attempt every id once in order, then retry only the ids whose write failed. The correlated fault has had the whole first pass to clear by the time the retry runs. `markFailed` keeps its best-effort contract (anything still unmarked after both passes is left as-is — we are already in an error path). `markFailedReporting` now joins **every** id still unmarked after both passes into the returned error via `errors.Join`, instead of returning only the first, so the fence-loser path can no longer be told about one dropped stamp while another is silently missing.

No change to what gets stamped or to write ordering on the happy path; a store that never fails sees exactly one write per id as before.

**New test proves the fix, not just the retry shape:** `TestInstantiateFailureStampsTheRootWhoseActivationFailed` (`internal/molecule/molecule_test.go`) wraps `beads.NewMemStore()` to inject the exact two correlated faults the issue describes — the root's fenced-activation `Update` fails once, and its subsequent `molecule_failed` `SetMetadataBatch` fails once — then runs `Instantiate` on a two-step graph workflow with graph apply disabled. Against the single-pass stamper it fails with exactly the reported symptom (root `molecule_failed=""`, still `gc.instantiating="true"`, while the body is stamped); with the two-pass stamper the root is stamped and un-fenced.

## Testing

`go test -tags gms_pure_go ./internal/molecule/... -run TestInstantiateFailureStampsTheRootWhoseActivationFailed` — pass. `gofmt -l` on the two touched files is empty; `go vet -tags gms_pure_go ./internal/molecule/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
