### PR TITLE
fix(dispatch): emit execution.step_defined once per step via a durable journal-confirmed marker (kill the ~757/min re-materialization storm without losing self-healing)

### DIFF
--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -265,6 +265,12 @@ const (
 	// see it. The offline full restate ('gc events reemit-execution') is the
 	// reemit path — it drives Projection.Events, which ignores this marker and
 	// re-states every step, so it re-materializes any aged-out definition.
+	//
+	// A host crash is the second way the two can diverge: the acknowledged
+	// append is not fsynced, so an OS crash can lose the JSONL line while this
+	// marker — written to a separate store with its own commit durability —
+	// survives. The same reemit path ('gc events reemit-execution')
+	// re-materializes the lost definition.
 	StepDefinedEmittedMetadataKey = "gc.step_defined_emitted"
 	StepIDMetadataKey             = "gc.step_id"
 	StepRefMetadataKey            = "gc.step_ref"

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -245,14 +245,26 @@ const (
 	StderrMetadataKey           = "gc.stderr"
 	StdoutMetadataKey           = "gc.stdout"
 	// StepDefinedEmittedMetadataKey records, on a graph.v2 physical step bead,
-	// that its execution.step_defined fact has already been emitted. The
-	// level-triggered projector restates the full graph every control tick;
-	// this per-step marker is what makes that restatement idempotent, so a
-	// step_defined is emitted once and a steady tick restates nothing (ga-rd8le).
-	// A step still lacking the marker — freshly created, or one whose emit
-	// crashed before the marker landed — is emitted and marked on the next tick,
-	// so every creator and recovery path self-heals. Presence alone is
-	// significant; the stamped RFC3339 value is for observability only.
+	// that its execution.step_defined fact has already been emitted AND
+	// acknowledged durable. The level-triggered projector restates the full
+	// graph every control tick; this per-step marker is what makes that
+	// restatement idempotent, so a step_defined is emitted once and a steady
+	// tick restates nothing (ga-rd8le). A step still lacking the marker —
+	// freshly created, or one whose emit was not acknowledged durable (a dropped
+	// append, or a recorder that cannot promise durability) — is emitted and
+	// marked on the next healthy tick, so every creator and recovery path
+	// self-heals. The mark is written only after the emit is acknowledged, so a
+	// dropped emit never marks the step and is safely re-emitted; presence alone
+	// is significant, and the stamped RFC3339 value is for observability only.
+	//
+	// The marker is durable on the step bead, while the emitted step_defined
+	// lives in the event journal, which retention can trim: with opt-in archive
+	// retention (events.rotation.archive_retain_age) a long-lived run's
+	// once-emitted step_defined can age out of the retained journal while this
+	// marker persists, so a consumer reading only retained events may no longer
+	// see it. The offline full restate ('gc events reemit-execution') is the
+	// reemit path — it drives Projection.Events, which ignores this marker and
+	// re-states every step, so it re-materializes any aged-out definition.
 	StepDefinedEmittedMetadataKey = "gc.step_defined_emitted"
 	StepIDMetadataKey             = "gc.step_id"
 	StepRefMetadataKey            = "gc.step_ref"

--- a/internal/beadmeta/keys.go
+++ b/internal/beadmeta/keys.go
@@ -244,14 +244,24 @@ const (
 	SpecForRefMetadataKey       = "gc.spec_for_ref"
 	StderrMetadataKey           = "gc.stderr"
 	StdoutMetadataKey           = "gc.stdout"
-	StepIDMetadataKey           = "gc.step_id"
-	StepRefMetadataKey          = "gc.step_ref"
-	StepTimeoutMetadataKey      = "gc.step_timeout"
-	SyntheticKindMetadataKey    = "gc.synthetic_kind"
-	SyntheticMetadataKey        = "gc.synthetic"
-	TemplateMetadataKey         = "gc.template"
-	TerminalMetadataKey         = "gc.terminal"
-	TriggerBeadIDMetadataKey    = "gc.trigger_bead_id"
+	// StepDefinedEmittedMetadataKey records, on a graph.v2 physical step bead,
+	// that its execution.step_defined fact has already been emitted. The
+	// level-triggered projector restates the full graph every control tick;
+	// this per-step marker is what makes that restatement idempotent, so a
+	// step_defined is emitted once and a steady tick restates nothing (ga-rd8le).
+	// A step still lacking the marker — freshly created, or one whose emit
+	// crashed before the marker landed — is emitted and marked on the next tick,
+	// so every creator and recovery path self-heals. Presence alone is
+	// significant; the stamped RFC3339 value is for observability only.
+	StepDefinedEmittedMetadataKey = "gc.step_defined_emitted"
+	StepIDMetadataKey             = "gc.step_id"
+	StepRefMetadataKey            = "gc.step_ref"
+	StepTimeoutMetadataKey        = "gc.step_timeout"
+	SyntheticKindMetadataKey      = "gc.synthetic_kind"
+	SyntheticMetadataKey          = "gc.synthetic"
+	TemplateMetadataKey           = "gc.template"
+	TerminalMetadataKey           = "gc.terminal"
+	TriggerBeadIDMetadataKey      = "gc.trigger_bead_id"
 	// InfraMigratedFromMetadataKey stamps a bead the storage-class migration
 	// copied into a binding with the name of the binding it came from, so a
 	// resumed attempt can tell a row it wrote from content the destination
@@ -541,6 +551,7 @@ var KnownMetadataKeys = []string{
 	SpecForRefMetadataKey,
 	StderrMetadataKey,
 	StdoutMetadataKey,
+	StepDefinedEmittedMetadataKey,
 	StepIDMetadataKey,
 	StepRefMetadataKey,
 	StepTimeoutMetadataKey,

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -1303,6 +1303,11 @@ func clearRetryEphemera(meta map[string]string) {
 		beadmeta.DurationMsMetadataKey,
 		beadmeta.TruncatedMetadataKey,
 		beadmeta.TerminalMetadataKey,
+		// A retry attempt clones the previous attempt's metadata, so it must not
+		// inherit the projector's per-step step_defined marker: a born-marked
+		// clone would be skipped by EmitCurrent and never get its own
+		// step_defined (ga-rd8le). Every clone path here strips it via this list.
+		beadmeta.StepDefinedEmittedMetadataKey,
 		beadmeta.FailedAttemptMetadataKey,
 		beadmeta.FanoutStateMetadataKey,
 		beadmeta.SpawnedCountMetadataKey,

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -9241,8 +9241,9 @@ func TestClearRetryEphemeraPreservesRoutingAndClearsFanoutState(t *testing.T) {
 // EmitCurrent forever and never get its own execution.step_defined — a
 // deterministic, non-self-healing loss on every retry iteration >= 2.
 //
-// RED on d39c76e61f: clearRetryEphemera there does not strip the marker, so both
-// the direct-strip and the retryAttemptBead-clone assertions fail.
+// RED on this PR's first commit, before the clone-marker strip:
+// clearRetryEphemera there does not strip the marker, so both the direct-strip
+// and the retryAttemptBead-clone assertions fail.
 func TestRetryClonedStepGetsItsOwnStepDefined(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -9234,6 +9234,49 @@ func TestClearRetryEphemeraPreservesRoutingAndClearsFanoutState(t *testing.T) {
 	}
 }
 
+// TestRetryClonedStepGetsItsOwnStepDefined pins CRITICAL 2 of the ga-rd8le
+// council review: a retry attempt clones the previous attempt's metadata, so it
+// must not inherit the projector's per-step step_defined marker
+// (StepDefinedEmittedMetadataKey). A born-marked clone would be skipped by
+// EmitCurrent forever and never get its own execution.step_defined — a
+// deterministic, non-self-healing loss on every retry iteration >= 2.
+//
+// RED on d39c76e61f: clearRetryEphemera there does not strip the marker, so both
+// the direct-strip and the retryAttemptBead-clone assertions fail.
+func TestRetryClonedStepGetsItsOwnStepDefined(t *testing.T) {
+	t.Parallel()
+
+	const marker = beadmeta.StepDefinedEmittedMetadataKey
+
+	// The shared strip function every clone path calls must drop the marker.
+	meta := map[string]string{
+		marker:                         "2026-09-11T00:00:00Z",
+		beadmeta.RootBeadIDMetadataKey: "gcg-root",
+		beadmeta.StepIDMetadataKey:     "build",
+	}
+	clearRetryEphemera(meta)
+	if _, ok := meta[marker]; ok {
+		t.Fatal("clearRetryEphemera must strip the step_defined marker so a clone is not born-marked")
+	}
+
+	// End to end: a cloned retry attempt must be born unmarked, so a later
+	// EmitCurrent projects DefinedEmitted=false and emits its own step_defined.
+	prev := beads.Bead{
+		ID:    "gcg-attempt-1",
+		Title: "build",
+		Type:  "task",
+		Metadata: map[string]string{
+			marker:                         "2026-09-11T00:00:00Z",
+			beadmeta.RootBeadIDMetadataKey: "gcg-root",
+			beadmeta.StepIDMetadataKey:     "build",
+		},
+	}
+	clone := retryAttemptBead(prev, "gcg-logical", "step.ref.2", 2, (*config.City)(nil))
+	if _, ok := clone.Metadata[marker]; ok {
+		t.Fatal("retry attempt clone inherited the step_defined marker; EmitCurrent would skip it forever")
+	}
+}
+
 func TestRewriteRalphAttemptRefRespectsAttemptBoundaries(t *testing.T) {
 	t.Parallel()
 

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -476,6 +476,20 @@ type Recorder interface {
 	Record(e Event)
 }
 
+// AckRecorder is an optional Recorder extension whose RecordAck reports whether
+// the event was durably appended. Record is best-effort and void — a
+// FileRecorder silently drops the event on a cross-process lock timeout or a
+// write failure (e.g. ENOSPC), and Discard drops every event — so a caller that
+// must not take a durable action on the strength of an emit that may have been
+// lost type-asserts to this and treats a recorder that does not implement it
+// (Discard, exec scripts) as "never acknowledged". A nil error means the event
+// reached the log and is therefore readable back by any List/Watch consumer; a
+// non-nil error means it was dropped.
+type AckRecorder interface {
+	Recorder
+	RecordAck(e Event) error
+}
+
 // Provider is the full interface for event backends. It embeds Recorder
 // for writing and adds reading, querying, and watching. Implementations
 // include FileRecorder (built-in JSONL file) and exec (user-supplied

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -485,6 +485,9 @@ type Recorder interface {
 // (Discard, exec scripts) as "never acknowledged". A nil error means the event
 // reached the log and is therefore readable back by any List/Watch consumer; a
 // non-nil error means it was dropped.
+//
+// The append is not fsynced, so the acknowledgement covers reachability, not
+// stable storage: an OS crash can still lose an acknowledged event.
 type AckRecorder interface {
 	Recorder
 	RecordAck(e Event) error

--- a/internal/events/fake.go
+++ b/internal/events/fake.go
@@ -46,6 +46,21 @@ func (f *Fake) Record(e Event) {
 	f.notify = make(chan struct{})
 }
 
+// RecordAck records like Record and reports the append outcome, so a Fake
+// satisfies [AckRecorder]. A healthy Fake acknowledges every append with a nil
+// error; a broken Fake ([NewFailFake]) reports a drop without recording, so a
+// test can exercise the confirm-before-durable-action path both ways.
+func (f *Fake) RecordAck(e Event) error {
+	f.mu.Lock()
+	broken := f.broken
+	f.mu.Unlock()
+	if broken {
+		return fmt.Errorf("events provider unavailable")
+	}
+	f.Record(e)
+	return nil
+}
+
 // List returns events matching the filter from the in-memory store.
 func (f *Fake) List(filter Filter) ([]Event, error) {
 	f.mu.Lock()

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -251,6 +251,9 @@ func (r *FileRecorder) Record(e Event) {
 // write failure such as ENOSPC, or a closed recorder. It is the acknowledged
 // form Record swallows, for the rare caller that must not take a durable action
 // on the strength of an append that may have been lost (see events.AckRecorder).
+//
+// The write is not fsynced, so a nil error does not promise stable storage: an
+// OS crash can lose an acknowledged append.
 func (r *FileRecorder) RecordAck(e Event) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -226,6 +226,11 @@ func NewFileRecorder(path string, stderr io.Writer, opts ...FileRecorderOption) 
 	return r, nil
 }
 
+// errRecorderClosed reports a Record/RecordAck against a closed recorder. Record
+// swallows it to preserve its historical silent-on-closed behavior; RecordAck
+// surfaces it so a caller relying on durability learns the append never landed.
+var errRecorderClosed = errors.New("recorder is closed")
+
 // Record appends an event to the log. It auto-fills Seq and Ts (if zero).
 // Errors are written to stderr — never returned.
 //
@@ -234,11 +239,24 @@ func NewFileRecorder(path string, stderr io.Writer, opts ...FileRecorderOption) 
 // if the file has crossed the threshold since the last check. Auto
 // rotation is amortized — see WithRotationCheckRecords / Interval.
 func (r *FileRecorder) Record(e Event) {
+	if err := r.RecordAck(e); err != nil && !errors.Is(err, errRecorderClosed) {
+		fmt.Fprintf(r.stderr, "events: %v\n", err) //nolint:errcheck // best-effort stderr
+	}
+}
+
+// RecordAck appends an event exactly as Record does and additionally reports
+// whether it was durably appended: a nil error means the JSONL line reached the
+// active log (and is therefore readable back by any List/Watch consumer), while
+// a non-nil error means the event was dropped — a cross-process lock timeout, a
+// write failure such as ENOSPC, or a closed recorder. It is the acknowledged
+// form Record swallows, for the rare caller that must not take a durable action
+// on the strength of an append that may have been lost (see events.AckRecorder).
+func (r *FileRecorder) RecordAck(e Event) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.closed {
-		return
+		return errRecorderClosed
 	}
 
 	r.maybeAutoRotateLocked()
@@ -249,8 +267,7 @@ func (r *FileRecorder) Record(e Event) {
 	// lock instead of blocking forever and piling up processes.
 	fd := int(r.file.Fd())
 	if err := lockRecorderFile(fd, r.path); err != nil {
-		fmt.Fprintf(r.stderr, "events: lock: %v\n", err) //nolint:errcheck // best-effort stderr
-		return
+		return fmt.Errorf("lock: %w", err)
 	}
 	defer func() {
 		if err := syscall.Flock(fd, syscall.LOCK_UN); err != nil {
@@ -259,8 +276,9 @@ func (r *FileRecorder) Record(e Event) {
 	}()
 
 	if err := r.writeRecordLocked(&e); err != nil {
-		fmt.Fprintf(r.stderr, "events: %v\n", err) //nolint:errcheck // best-effort stderr
+		return err
 	}
+	return nil
 }
 
 // AppendBatch strictly appends a complete event batch under one mutex and one

--- a/internal/executionevent/projector.go
+++ b/internal/executionevent/projector.go
@@ -81,12 +81,21 @@ type Projection struct {
 // idempotent instead (ga-rd8le): a step already carrying
 // StepDefinedEmittedMetadataKey is skipped, and an unmarked step is emitted and
 // then marked, so a steady tick restates nothing while every creator and
-// recovery path still self-heals without threading created IDs. The emit
-// precedes the mark on purpose — a crash between them re-emits a tolerated
-// duplicate snapshot fact next tick rather than dropping the definition, and a
-// mark that fails to persist simply re-emits next tick. The offline full
-// restate ('gc events reemit-execution') calls Events instead, which ignores
-// the marker and re-states every step deliberately.
+// recovery path still self-heals without threading created IDs.
+//
+// The step is marked ONLY once its step_defined is acknowledged durable — the
+// same discipline applyConvergenceStamp uses for completion facts, where a
+// dropped append must never stamp a permanent fact loss. events.Recorder.Record
+// is best-effort and can silently drop the event (a FileRecorder lock timeout or
+// write error, or events.Discard returned on a recorder-open failure), so
+// marking after a dropped emit would skip the step FOREVER — the exact
+// permanent-miss the level-triggered restatement exists to prevent. An emit that
+// is not acknowledged (a drop, or a recorder that cannot promise durability at
+// all, such as events.Discard) leaves the step unmarked and re-emitted next tick
+// — a duplicate step_defined is a tolerated repeatable snapshot fact; a
+// permanent miss is not. The offline full restate ('gc events reemit-execution')
+// calls Events instead, which ignores the marker and re-states every step
+// deliberately.
 func EmitCurrent(recorder events.Recorder, graphStore beads.GraphStore, convoyStore beads.WorkStore, rootID, actor string) error {
 	if recorder == nil {
 		return nil
@@ -102,15 +111,40 @@ func EmitCurrent(recorder events.Recorder, graphStore beads.GraphStore, convoySt
 		if step.DefinedEmitted {
 			continue
 		}
-		recorder.Record(step.definedEvent(actor))
+		if !recordStepDefinedConfirmed(recorder, step.definedEvent(actor)) {
+			// The emit was dropped or the recorder cannot acknowledge durability
+			// (events.Discard). Leave the step unmarked so the next healthy tick
+			// re-emits it: a best-effort append that may have been lost must never
+			// durably mark the step, or a dropped emit becomes a permanent miss.
+			continue
+		}
 		if graphStore.Store != nil {
-			// Best-effort durable mark. A failure leaves the step unmarked, so
-			// the next tick re-emits it — the same at-least-once tolerance the
-			// snapshot facts already carry.
+			// The fact is durable; record that the step was emitted. A failed mark
+			// leaves the step unmarked, so the next tick re-emits it — the same
+			// at-least-once tolerance the snapshot facts already carry.
 			_ = graphStore.SetMetadata(step.BeadID, beadmeta.StepDefinedEmittedMetadataKey, time.Now().UTC().Format(time.RFC3339))
 		}
 	}
 	return nil
+}
+
+// recordStepDefinedConfirmed records a step's step_defined fact and reports
+// whether the append is durable enough to mark the step as emitted. It records
+// through events.AckRecorder when the recorder offers it — a nil ack means the
+// fact reached the log and is readable back by any consumer, the synchronous
+// equivalent of the journal read-back applyConvergenceStamp relies on, without
+// paying a per-tick journal read on this hot control-dispatch path (the ga-ftgyl
+// burn). A recorder that cannot acknowledge durability — events.Discard returned
+// on a recorder-open failure, or any bare Recorder — is recorded best-effort but
+// is NEVER treated as confirmed, so the step stays unmarked and re-emits next
+// tick rather than being marked on the strength of an emit that may have been
+// dropped.
+func recordStepDefinedConfirmed(recorder events.Recorder, event events.Event) bool {
+	if ack, ok := recorder.(events.AckRecorder); ok {
+		return ack.RecordAck(event) == nil
+	}
+	recorder.Record(event)
+	return false
 }
 
 // Events converts the projection to repeatable snapshot facts — the FULL

--- a/internal/executionevent/projector.go
+++ b/internal/executionevent/projector.go
@@ -55,6 +55,12 @@ type StepDefinition struct {
 	ExecutionRunID   string
 	StepID           string
 	DependsOnStepIDs *[]string
+	// DefinedEmitted reports that this step's step_defined fact has already
+	// been recorded durably (its bead carries StepDefinedEmittedMetadataKey).
+	// EmitCurrent skips re-emitting a marked step so a steady tick restates
+	// nothing; the full-restate Events form ignores it. It is projection state,
+	// not part of the emitted fact.
+	DefinedEmitted bool
 }
 
 // Projection is the deterministic current-store execution projection for one
@@ -67,6 +73,20 @@ type Projection struct {
 
 // EmitCurrent projects and records the current execution snapshot for rootID.
 // A nil recorder disables emission without reading either store.
+//
+// The projection is level-triggered — the whole graph is re-read every call —
+// so a definition missed on a crashed or failed pass self-heals on the next
+// one. Work associations and source anchors are bounded by convoy membership,
+// not by the step graph, and are restated in full each call. step_defined is
+// idempotent instead (ga-rd8le): a step already carrying
+// StepDefinedEmittedMetadataKey is skipped, and an unmarked step is emitted and
+// then marked, so a steady tick restates nothing while every creator and
+// recovery path still self-heals without threading created IDs. The emit
+// precedes the mark on purpose — a crash between them re-emits a tolerated
+// duplicate snapshot fact next tick rather than dropping the definition, and a
+// mark that fails to persist simply re-emits next tick. The offline full
+// restate ('gc events reemit-execution') calls Events instead, which ignores
+// the marker and re-states every step deliberately.
 func EmitCurrent(recorder events.Recorder, graphStore beads.GraphStore, convoyStore beads.WorkStore, rootID, actor string) error {
 	if recorder == nil {
 		return nil
@@ -75,18 +95,51 @@ func EmitCurrent(recorder events.Recorder, graphStore beads.GraphStore, convoySt
 	if err != nil {
 		return err
 	}
-	for _, event := range projection.Events(actor) {
+	for _, event := range projection.workAndAnchorEvents(actor) {
 		recorder.Record(event)
+	}
+	for _, step := range projection.Steps {
+		if step.DefinedEmitted {
+			continue
+		}
+		recorder.Record(step.definedEvent(actor))
+		if graphStore.Store != nil {
+			// Best-effort durable mark. A failure leaves the step unmarked, so
+			// the next tick re-emits it — the same at-least-once tolerance the
+			// snapshot facts already carry.
+			_ = graphStore.SetMetadata(step.BeadID, beadmeta.StepDefinedEmittedMetadataKey, time.Now().UTC().Format(time.RFC3339))
+		}
 	}
 	return nil
 }
 
-// Events converts the projection to repeatable snapshot facts. Work
-// associations precede source anchors and step definitions, preserving each
-// slice's deterministic order. Topology is copied so later graph reads cannot
-// mutate emitted facts.
+// Events converts the projection to repeatable snapshot facts — the FULL
+// restatement, emitting every work association, source anchor, and step
+// definition regardless of any per-step emitted marker. Work associations
+// precede source anchors and step definitions, preserving each slice's
+// deterministic order. Topology is copied so later graph reads cannot mutate
+// emitted facts. This is the offline reemit form; the online tick uses
+// EmitCurrent, which emits each step_defined once against its durable marker.
 func (p Projection) Events(actor string) []events.Event {
 	result := make([]events.Event, 0, len(p.WorkAssociations)+len(p.RunAnchors)+len(p.Steps))
+	result = p.appendWorkAndAnchorEvents(result, actor)
+	for _, step := range p.Steps {
+		result = append(result, step.definedEvent(actor))
+	}
+	return result
+}
+
+// workAndAnchorEvents renders the work-association and source-anchor facts, in
+// that order. These are bounded by convoy membership rather than the step
+// graph, so both the online tick and the offline full restate emit them whole.
+func (p Projection) workAndAnchorEvents(actor string) []events.Event {
+	return p.appendWorkAndAnchorEvents(make([]events.Event, 0, len(p.WorkAssociations)+len(p.RunAnchors)), actor)
+}
+
+// appendWorkAndAnchorEvents appends the work-association then source-anchor
+// facts to result, letting Events pre-size one slice for the whole restatement
+// while the online tick allocates only for the bounded work/anchor facts.
+func (p Projection) appendWorkAndAnchorEvents(result []events.Event, actor string) []events.Event {
 	for _, association := range p.WorkAssociations {
 		result = append(result, events.Event{
 			Type:    events.ExecutionWorkAssociated,
@@ -103,17 +156,20 @@ func (p Projection) Events(actor string) []events.Event {
 			RunID:   anchor.ExecutionRunID,
 		})
 	}
-	for _, step := range p.Steps {
-		result = append(result, events.Event{
-			Type:             events.ExecutionStepDefined,
-			Actor:            actor,
-			Subject:          step.BeadID,
-			RunID:            step.ExecutionRunID,
-			StepID:           step.StepID,
-			DependsOnStepIDs: cloneTopology(step.DependsOnStepIDs),
-		})
-	}
 	return result
+}
+
+// definedEvent renders this step's execution.step_defined snapshot fact.
+// Topology is copied so a later graph read cannot mutate an emitted fact.
+func (s StepDefinition) definedEvent(actor string) events.Event {
+	return events.Event{
+		Type:             events.ExecutionStepDefined,
+		Actor:            actor,
+		Subject:          s.BeadID,
+		RunID:            s.ExecutionRunID,
+		StepID:           s.StepID,
+		DependsOnStepIDs: cloneTopology(s.DependsOnStepIDs),
+	}
 }
 
 // ProjectCurrent projects current execution facts for rootID. The graph store
@@ -290,6 +346,7 @@ func currentStepRows(store beads.GraphStore, rootID string) ([]stepRow, error) {
 				ExecutionRunID:   rootID,
 				StepID:           stepID,
 				DependsOnStepIDs: canonicalTopology(row.Metadata[beadmeta.NativeStepDependenciesMetadataKey], stepID),
+				DefinedEmitted:   strings.TrimSpace(row.Metadata[beadmeta.StepDefinedEmittedMetadataKey]) != "",
 			},
 			bead: row,
 		})

--- a/internal/executionevent/projector_test.go
+++ b/internal/executionevent/projector_test.go
@@ -478,9 +478,10 @@ func TestEmitCurrentEmitsStepDefinedOncePerStep(t *testing.T) {
 // the mark lands only once the emit is acknowledged durable; an unacknowledged
 // tick leaves the step unmarked and it re-emits on the next healthy tick.
 //
-// RED on d39c76e61f: that revision marks unconditionally once graphStore.Store
-// is non-nil, regardless of the recorder, so the first assertion (still unmarked
-// after a Discard tick) fails there.
+// RED on this PR's first commit, before the confirm-before-mark change: that
+// revision marks unconditionally once graphStore.Store is non-nil, regardless
+// of the recorder, so the first assertion (still unmarked after a Discard tick)
+// fails there.
 func TestEmitCurrentDoesNotMarkOnDroppedOrDiscardEmit(t *testing.T) {
 	graph := beads.NewMemStore()
 	root := mustCreateProjectionRoot(t, graph, "")

--- a/internal/executionevent/projector_test.go
+++ b/internal/executionevent/projector_test.go
@@ -411,6 +411,72 @@ func TestEmitCurrentNilRecorderIsNoOp(t *testing.T) {
 	}
 }
 
+// TestEmitCurrentEmitsStepDefinedOncePerStep pins the idempotent-restatement
+// contract (ga-rd8le): EmitCurrent keeps re-projecting the full graph every
+// tick, but step_defined is emitted exactly once per step against a durable
+// per-step marker. A steady tick therefore restates nothing, while a step that
+// is still unmarked — one just created, or one whose emit crashed before the
+// marker landed — is re-emitted on the next tick, no matter which creator made
+// it. That is convergence-via-restatement without threading created IDs.
+func TestEmitCurrentEmitsStepDefinedOncePerStep(t *testing.T) {
+	graph := beads.NewMemStore()
+	root := mustCreateProjectionRoot(t, graph, "")
+	stepA := mustCreateProjectionStep(t, graph, "gcg-step-a", root.ID, "build", "[]")
+	stepB := mustCreateProjectionStep(t, graph, "gcg-step-b", root.ID, "test", `["build"]`)
+	recorder := events.NewFake()
+
+	// First tick emits step_defined for both unmarked steps and marks them.
+	if err := EmitCurrent(recorder, beads.GraphStore{Store: graph}, beads.WorkStore{}, root.ID, "control-dispatch"); err != nil {
+		t.Fatalf("EmitCurrent first tick: %v", err)
+	}
+	if got := countStepDefined(recorder.Events, root.ID); got != 2 {
+		t.Fatalf("first tick step_defined = %d, want 2", got)
+	}
+	for _, step := range []beads.Bead{stepA, stepB} {
+		reloaded, err := graph.Get(step.ID)
+		if err != nil {
+			t.Fatalf("reload step %s: %v", step.ID, err)
+		}
+		if reloaded.Metadata[beadmeta.StepDefinedEmittedMetadataKey] == "" {
+			t.Fatalf("step %s was emitted but not durably marked", step.ID)
+		}
+	}
+
+	// Second tick re-projects the same graph and must emit nothing: both steps
+	// are now durably marked. On base (no marker) this re-emits the full graph.
+	recorder.Events = nil
+	if err := EmitCurrent(recorder, beads.GraphStore{Store: graph}, beads.WorkStore{}, root.ID, "control-dispatch"); err != nil {
+		t.Fatalf("EmitCurrent second tick: %v", err)
+	}
+	if got := countStepDefined(recorder.Events, root.ID); got != 0 {
+		t.Fatalf("second tick step_defined = %d, want 0 (idempotent restatement)", got)
+	}
+
+	// A step created after the first pass is unmarked and self-heals: only it
+	// is emitted on the next tick, regardless of the steps already marked.
+	stepC := mustCreateProjectionStep(t, graph, "gcg-step-c", root.ID, "ship", `["test"]`)
+	recorder.Events = nil
+	if err := EmitCurrent(recorder, beads.GraphStore{Store: graph}, beads.WorkStore{}, root.ID, "control-dispatch"); err != nil {
+		t.Fatalf("EmitCurrent third tick: %v", err)
+	}
+	if got := countStepDefined(recorder.Events, root.ID); got != 1 {
+		t.Fatalf("third tick step_defined = %d, want 1 (only the new step)", got)
+	}
+	if recorder.Events[0].Subject != stepC.ID {
+		t.Fatalf("third tick emitted %q, want the new step %q", recorder.Events[0].Subject, stepC.ID)
+	}
+}
+
+func countStepDefined(recorded []events.Event, rootID string) int {
+	count := 0
+	for _, event := range recorded {
+		if event.Type == events.ExecutionStepDefined && event.RunID == rootID {
+			count++
+		}
+	}
+	return count
+}
+
 func mustCreateProjectionRoot(t *testing.T, store beads.Store, convoyID string) beads.Bead {
 	t.Helper()
 	metadata := map[string]string{

--- a/internal/executionevent/projector_test.go
+++ b/internal/executionevent/projector_test.go
@@ -467,6 +467,68 @@ func TestEmitCurrentEmitsStepDefinedOncePerStep(t *testing.T) {
 	}
 }
 
+// TestEmitCurrentDoesNotMarkOnDroppedOrDiscardEmit pins CRITICAL 1 of the
+// ga-rd8le council review: EmitCurrent must never durably mark a step
+// (StepDefinedEmittedMetadataKey) after a best-effort emit that may have been
+// dropped, or the step is skipped forever — a permanent miss.
+// events.Recorder.Record is void: a FileRecorder drops the event on a lock
+// timeout or a write error (ENOSPC), and events.Discard (which openCityRecorderAt
+// returns on a recorder-open failure) drops every event. Marking after such an
+// emit destroys the self-healing the level-triggered restatement provided, so
+// the mark lands only once the emit is acknowledged durable; an unacknowledged
+// tick leaves the step unmarked and it re-emits on the next healthy tick.
+//
+// RED on d39c76e61f: that revision marks unconditionally once graphStore.Store
+// is non-nil, regardless of the recorder, so the first assertion (still unmarked
+// after a Discard tick) fails there.
+func TestEmitCurrentDoesNotMarkOnDroppedOrDiscardEmit(t *testing.T) {
+	graph := beads.NewMemStore()
+	root := mustCreateProjectionRoot(t, graph, "")
+	step := mustCreateProjectionStep(t, graph, "gcg-step-a", root.ID, "build", "[]")
+	graphStore := beads.GraphStore{Store: graph}
+
+	assertUnmarked := func(when string) {
+		t.Helper()
+		reloaded, err := graph.Get(step.ID)
+		if err != nil {
+			t.Fatalf("reload step %s (%s): %v", step.ID, when, err)
+		}
+		if reloaded.Metadata[beadmeta.StepDefinedEmittedMetadataKey] != "" {
+			t.Fatalf("step marked emitted after %s: a dropped/void emit must never mark", when)
+		}
+	}
+
+	// events.Discard cannot acknowledge durability, so the void emit must not mark.
+	if err := EmitCurrent(events.Discard, graphStore, beads.WorkStore{}, root.ID, "control-dispatch"); err != nil {
+		t.Fatalf("EmitCurrent (discard): %v", err)
+	}
+	assertUnmarked("a Discard tick")
+
+	// A recorder whose append fails (the FileRecorder lock-timeout / ENOSPC drop
+	// shape) reports the drop, so the step must still stay unmarked.
+	if err := EmitCurrent(events.NewFailFake(), graphStore, beads.WorkStore{}, root.ID, "control-dispatch"); err != nil {
+		t.Fatalf("EmitCurrent (failing recorder): %v", err)
+	}
+	assertUnmarked("a failed-append tick")
+
+	// A healthy recorder acknowledges the append, so the still-unmarked step is
+	// re-emitted AND marked this tick — the definition was never permanently lost.
+	healthy := events.NewFake()
+	if err := EmitCurrent(healthy, graphStore, beads.WorkStore{}, root.ID, "control-dispatch"); err != nil {
+		t.Fatalf("EmitCurrent (healthy): %v", err)
+	}
+	if got := countStepDefined(healthy.Events, root.ID); got != 1 {
+		t.Fatalf("healthy tick step_defined = %d, want 1 (re-emit after the dropped ticks)", got)
+	}
+	reloaded, err := graph.Get(step.ID)
+	if err != nil {
+		t.Fatalf("reload step %s: %v", step.ID, err)
+	}
+	if reloaded.Metadata[beadmeta.StepDefinedEmittedMetadataKey] == "" {
+		t.Fatalf("step not marked after a healthy acknowledged emit")
+	}
+}
+
 func countStepDefined(recorded []events.Event, rootID string) int {
 	count := 0
 	for _, event := range recorded {


### PR DESCRIPTION
## Summary

The control-dispatcher re-emits `execution.step_defined` for a run's **entire** step graph on **every** control tick (`EmitCurrent` at `cmd/gc/cmd_convoy_dispatch.go`, driven by the serve loop). Observed at **~757/min sustained** (199,738 of 200,000 recent events were this one call), filling `events.jsonl` and drowning real progress. (ga-rd8le)

## Why not edge-triggered

An earlier edge-triggered rewrite (emit only newly-created steps) was rejected: it **violates the codebase's convergence-via-restatement reliability model** — `EmitCurrent` re-states the full projection every tick precisely so a definition missed on a failed/crashed creator pass self-heals next tick. Edge-triggered dropped definitions on 4+ recovery paths (fanout-resume, attach-duplicate, ralph clone-retry, retry-eval) with no self-heal.

## Approach: level-triggered + durable per-step marker

Keep the full-projection restatement (self-healing preserved for every creator/recovery path, no `CreatedIDs` threading), but make emission idempotent via a durable per-step marker (`beadmeta.StepDefinedEmittedMetadataKey`). `EmitCurrent` emits `step_defined` for an **unmarked** step and marks it; **marked** steps are skipped. An unmarked step (created on any pass, including a failed one) re-emits on the next tick — self-healing intact — while marked steps stop the storm.

### Two correctness criticals fixed (both caught by adversarial review)

1. **Never mark after a possibly-dropped emit.** `Recorder.Record` is best-effort/void (drops on flock timeout / ENOSPC; `events.Discard` swallows everything). Marking after a dropped emit = permanent loss. Fixed with a new `events.AckRecorder{ RecordAck(Event) error }`: `FileRecorder.RecordAck` surfaces the durable-write outcome, and `EmitCurrent` marks a step **only** on a nil ack. A recorder that can't acknowledge durability (`events.Discard`, any bare `Recorder`) emits best-effort but is **never** marked, so it re-emits next tick. This mirrors the file's own `applyConvergenceStamp` discipline while avoiding a per-tick journal read on the hot path.
2. **Clones must not inherit the marker.** ralph clone-retry + retry-eval clone the step's metadata; `clearRetryEphemera` now strips `StepDefinedEmittedMetadataKey` so attempt-N+1 steps aren't born-marked. Audit confirmed fanout/attach/drain build step beads from recipe **templates** (never marked), so this is the complete fix.

## Tests

RED-then-GREEN: `TestEmitCurrentDoesNotMarkOnDroppedOrDiscardEmit` (dropped/Discard emit leaves the step unmarked → re-emits next healthy tick) and `TestRetryClonedStepGetsItsOwnStepDefined`. Reviewed sound by a Fable council.

## Known minor follow-ups (non-blocking, noted for review)
- `FileRecorder.RecordAck` returns nil after `Write` (page cache, no `fsync`) — a whole-machine crash before writeback can leave a marked-but-unlogged step; matches the journal's existing durability posture (`AppendBatch` never fsyncs), and `gc events reemit-execution` (ignores the marker, full restate) is the recovery.
- Worth adding a direct `internal/events` test pinning `RecordAck` fidelity (closed→err, healthy→nil+readable) so a future relaxation can't silently reintroduce critical #1.
- The `fake` events provider acks non-durable in-memory appends (explicit test double).

🤖 Generated with [Claude Code](https://claude.com/claude-code)