### PR TITLE
Retain fresh pending-create pool sessions through demand recomputation

### DIFF
--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gastownhall/gascity/internal/agentutil"
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/worktree"
@@ -434,6 +435,13 @@ func computePoolDesiredStatesAt(
 		}
 	}
 	protectedNewRequests, inFlightNewRequests := poolNewDemandRequests(cfg, sessionInfos, resumeSessionBeadIDs, decisionTime)
+	sessionInfoByID := make(map[string]sessionpkg.Info, len(sessionInfos))
+	for _, info := range sessionInfos {
+		if info.ID == "" {
+			continue
+		}
+		sessionInfoByID[info.ID] = info
+	}
 	// A wake-known request has assigned work but no surviving concrete session
 	// identity. Freshly completed unassigned pool sessions are valid concrete
 	// capacity for that request. Bind them before calculating residual protected
@@ -489,10 +497,16 @@ func computePoolDesiredStatesAt(
 		if _, ok := aliasHeldTemplates[template]; ok {
 			continue
 		}
-		effectiveDemand := max(scaleCount, len(protected))
+		inFlight := inFlightNewRequests[template]
+		inFlightFloor := 0
+		for _, req := range inFlight {
+			if info, ok := sessionInfoByID[req.SessionBeadID]; ok && poolSessionWithinPendingCreateLease(info, cfg, decisionTime) {
+				inFlightFloor++
+			}
+		}
+		effectiveDemand := max(scaleCount, len(protected), inFlightFloor)
 		newCount := capNewDemandCount(limits, usage, agent, effectiveDemand)
 		recordNewDemandCapTrace(trace, template, agent, limits, usage, effectiveDemand, newCount)
-		inFlight := inFlightNewRequests[template]
 		protectedCount := minInt(len(protected), newCount)
 		inFlightCount := minInt(len(inFlight), newCount-protectedCount)
 		reusedCount := protectedCount + inFlightCount
@@ -781,6 +795,40 @@ func poolSessionEligibleForProtectedDemand(info sessionpkg.Info, decisionTime ti
 		strings.TrimSpace(info.WaitHold) == "" &&
 		!metadataTimeInFuture(info.HeldUntil, decisionTime) &&
 		!metadataTimeInFuture(info.QuarantinedUntil, decisionTime)
+}
+
+// poolSessionWithinPendingCreateLease reports whether an in-flight
+// pending-create pool session is still within its own lease window and should
+// therefore establish a demand floor of its own, mirroring the protected-
+// session floor above. decisionTime is injected the same way as
+// poolSessionWithinPostCreateProtection so every decision in a tick shares one
+// clock observation; a zero decisionTime fails closed for the same reason.
+//
+// The lease arithmetic itself is not reimplemented here: it delegates to
+// pendingCreateLeaseExpiredForRollbackInfo (session_reconciler.go), the exact
+// predicate the reconciler's own rollback path uses, so a bead genuinely stuck
+// past its lease is never propped up by this floor — it still rolls back on
+// schedule. That function only reasons about beads in a rollback-eligible
+// state (start-pending/creating/asleep, via pendingCreateRollbackState) and
+// returns false (not expired) for any other state as a no-op default, so the
+// state gate is re-checked here first: a pending_create_claim left set on an
+// already-stopped or failed-create session is not a live in-flight attempt
+// and must not establish a floor, regardless of how recently it was created.
+func poolSessionWithinPendingCreateLease(info sessionpkg.Info, cfg *config.City, decisionTime time.Time) bool {
+	if decisionTime.IsZero() {
+		return false
+	}
+	if !info.PendingCreateClaim {
+		return false
+	}
+	if !pendingCreateRollbackState(info.MetadataState) {
+		return false
+	}
+	var startupTimeout time.Duration
+	if cfg != nil {
+		startupTimeout = cfg.Session.StartupTimeoutDuration()
+	}
+	return !pendingCreateLeaseExpiredForRollbackInfo(info, &clock.Fake{Time: decisionTime}, startupTimeout)
 }
 
 // poolSessionConsumesNewDemandInfo reports whether a pool session already

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -2459,6 +2459,57 @@ func TestComputePoolDesiredStates_InFlightNewSessionsOnlySubtractCoveredDemand(t
 	}
 }
 
+// TestComputePoolDesiredStates_InFlightPendingCreateEstablishesDemandFloor
+// reproduces the claim-handoff race from ga-nf5xlp: a pending-create session
+// is born, and on the very next tick scale_check cleanly recomputes to zero
+// before that session finishes creating. Without a demand floor for
+// in-flight sessions (mirroring the protected-session floor #4789 added),
+// the session gets zero slots, falls out of desired state, and is rolled
+// back ~10 minutes later having never started — even though it is still
+// well within its own pending-create lease window.
+func TestComputePoolDesiredStates_InFlightPendingCreateEstablishesDemandFloor(t *testing.T) {
+	now := time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC)
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	sessions := []beads.Bead{
+		pendingPoolSessionBeadAt("sess-1", now.Add(-30*time.Second)),
+	}
+
+	result := ComputePoolDesiredStatesAt(cfg, nil, sessionInfosFromBeads(sessions), map[string]int{"claude": 0}, now)
+
+	counts := PoolDesiredCounts(result)
+	if counts["claude"] != 1 {
+		t.Fatalf("poolDesired[claude] = %d, want 1: a fresh pending-create session must survive a scale_check drop to zero on the next tick while still within its own lease window", counts["claude"])
+	}
+	if len(result) != 1 || len(result[0].Requests) != 1 || result[0].Requests[0].SessionBeadID != "sess-1" {
+		t.Fatalf("result = %#v, want sess-1 retained as the sole in-flight demand-floor request", result)
+	}
+}
+
+// TestComputePoolDesiredStates_InFlightPendingCreateDemandFloorExpiresWithLease
+// guards the other side of the same fix: a pending-create session that has
+// aged past its own lease window (pendingCreateLeaseExpiredForRollbackInfo)
+// must NOT be propped up by the new floor. It is genuinely stuck and should
+// still fall to zero desired demand so the existing rollback path can reap
+// it.
+func TestComputePoolDesiredStates_InFlightPendingCreateDemandFloorExpiresWithLease(t *testing.T) {
+	now := time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC)
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	sessions := []beads.Bead{
+		pendingPoolSessionBeadAt("sess-1", now.Add(-11*time.Minute)),
+	}
+
+	result := ComputePoolDesiredStatesAt(cfg, nil, sessionInfosFromBeads(sessions), map[string]int{"claude": 0}, now)
+
+	counts := PoolDesiredCounts(result)
+	if counts["claude"] != 0 {
+		t.Fatalf("poolDesired[claude] = %d, want 0: a pending-create session past its own lease window must still roll back to zero demand, not be propped up indefinitely", counts["claude"])
+	}
+}
+
 func TestComputePoolDesiredStates_InFlightResumeBeadsDoNotConsumeNewDemand(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},

--- a/release-gates/pool-in-flight-demand-floor-gate.md
+++ b/release-gates/pool-in-flight-demand-floor-gate.md
@@ -1,0 +1,102 @@
+# Release gate: retain in-flight pending-create pool demand (`ga-jj113k`)
+
+- Overall verdict: **PASS with attributed raw test failures**
+- Evaluated: 2026-09-11 UTC
+- Deploy mode: `remote`; push remote: `origin`
+- Reviewed deploy source: `2228831215f5c00e6b9ab10a695608307656c1cd`
+- Source branch: `builder/ga-nf5xlp.1` (provenance only)
+- Base evaluated: `origin/main@411413b1055d660a1d8cb7beac98d5f5f4cd7216`
+- Existing source PR: none
+
+`docs/PROJECT_MANIFEST.md` is not present at the reviewed commit or on
+`origin/main`, so this checklist uses the release criteria embedded in
+`mol-deployer-gate`, the Deployer instructions, and
+`engdocs/contributors/release-gate-criteria-conventions.md`. The pre-flight
+found no PR carrying the reviewed commit, so there was no already-merged or
+closed-PR disposition to reconcile.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-f3ltde` records `verdict: pass` against exact reviewed commit `2228831215f5c00e6b9ab10a695608307656c1cd`, with no review carryover or SHA substitution. The SHA resolves to that commit in this repository. |
+| 2 | Acceptance criteria met | **PASS** | Fresh pending-create sessions now contribute a demand floor only while their existing lease is live. The helper delegates lease arithmetic to `pendingCreateLeaseExpiredForRollbackInfo`; an expired attempt still falls to zero. `capNewDemandCount` remains after the floor calculation, protected sessions still consume capped demand before in-flight sessions, both new regression tests pass, and unrelated HQ work-query issue `gm-u7ehpl` is untouched. |
+| 3 | Tests pass | **PASS with attributed raw failures** | The documented full local CI union scheduled all 40 jobs and completed **37 jobs PASS / 3 jobs with raw failures / 0 omitted**. Its top-level result lines contain **49,914 PASS / 4 raw FAIL / 210 SKIP**. Both diff-owned tests ran twice and passed every time, with 0 diff-owned FAIL and 0 diff-owned SKIP. All four raw failures are non-diff-owned and satisfy criterion 3a below. |
+| 3a | Non-diff-owned failures attributed | **PASS** | Three failures are exact instances of the predating shared-schema tracker `ga-esyijp`; `TestE2E_SuspendResume_City` is the exact proven condition tracked by predating tracker `ga-dc9utn`. Each occurrence was appended to and read back from its tracker. All four attributions satisfy the required not-diff-owned, predating-tracker, mechanism-proof, and no-path-overlap clauses. |
+| 3b | Policy/lint lane | **PASS** | `make test-ci-policy`, `go vet ./...`, `LINT_CHANGED_REF=origin/main make fmt-check-changed`, and `git diff --check origin/main...HEAD` all exited 0. `core.hooksPath` is `.githooks`. |
+| 3c | CI-config lane run | **PASS / n/a** | The diff changes no workflow, CI job, matrix, timeout, required-check list, Makefile, or runner policy. `ci_lane_run: n/a (no CI-config change)`. |
+| 4 | No high-severity review findings open | **PASS** | The exact-head reviewer verdict records no style, security, specification, or high-severity finding. |
+| 5 | Final branch clean | **PASS** | The worktree remained clean at the exact reviewed SHA after the full suite and additive checks. This checklist is the deployer's only new file and will be committed on the isolated deploy branch. |
+| 6 | Branch diverges cleanly from main | **PASS** | After a fresh fetch, `git merge-tree --write-tree origin/main 2228831215f5c00e6b9ab10a695608307656c1cd` exited 0 and produced tree `dfa022c5e72311fdc7d68ecab3dbdc32c1cf031a`. The base has 5 exclusive commits and the candidate has 2; no bounded self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | The two candidate commits change only `cmd/gc/pool_desired_state.go` and its test for one pool-demand calculation. `assert_deploy_ancestry_scope` passed for `ga-jj113k`, `ga-f3ltde`, and `ga-nf5xlp.1`; no unrelated ancestry or `.claude/**` path is present. |
+
+## Build and acceptance evidence
+
+- `go build ./...`: **PASS**.
+- Fresh affected-package run, `go test ./cmd/gc/... -count=1 -v`: **PASS**, 9,956 top-level PASS / 0 FAIL / 100 SKIP.
+- `TestComputePoolDesiredStates_InFlightPendingCreateEstablishesDemandFloor`: **PASS** in both the process and integration-package full-suite lanes, and in the fresh affected-package run.
+- `TestComputePoolDesiredStates_InFlightPendingCreateDemandFloorExpiresWithLease`: **PASS** in both the process and integration-package full-suite lanes, and in the fresh affected-package run.
+- `TestTutorial01`: **PASS** in the required `cmd/gc` process lane with `GC_FAST_UNIT=0`; its skip in the separate integration-package lane is therefore not a coverage gap.
+- Source inspection confirms the new floor is calculated before `capNewDemandCount`, and the unchanged `protectedCount` calculation still precedes `inFlightCount`.
+- Source inspection confirms the floor helper requires a pending-create claim, a rollback-eligible state, and a nonzero decision time before delegating to the reconciler's existing lease-expiry predicate.
+- `git diff --check origin/main...HEAD`: **PASS**.
+- The diff does not touch or claim to resolve `gm-u7ehpl`.
+
+## Criterion 3 evidence
+
+The container-backed environment was established before the full-suite run:
+
+- `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`
+- `TESTCONTAINERS_RYUK_DISABLED=true`
+- Rootless Podman was reachable through the socket.
+- `docker.io/dolthub/dolt-sql-server:1.32.4` was refreshed and resolved to `sha256:b0400696666ab7f4743e15d28d9e934efebde99794a967fe14b3a3a13bfa0b3d`.
+- Repository-pinned `docker.io/dolthub/dolt:2.1.7` was present at `sha256:eba699ca1821847c2e8070475f8e504b476834ee425db4036f89c956cceaf472`.
+
+Test record:
+
+- `test_cmd`: `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true GO_TEST_TIMEOUT=30m LOCAL_TEST_JOBS=4 GOFLAGS=-v make test-local-full-parallel`
+- `test_cmd_scope`: `full-suite`
+- `test_counts`: **37 jobs PASS / 3 jobs with raw failures / 0 omitted**; **49,914 top-level PASS / 4 raw FAIL / 210 SKIP**
+- `diff_tests_executed`: `TestComputePoolDesiredStates_InFlightPendingCreateEstablishesDemandFloor=PASS` and `TestComputePoolDesiredStates_InFlightPendingCreateDemandFloorExpiresWithLease=PASS`, each in two independent full-suite lanes; 0 diff-owned FAIL and 0 diff-owned SKIP
+- `skip_justification`: all 210 skips are from unchanged suite code and cover platform, permission, optional-provider/live-infrastructure, helper-process, opt-in integration, or intentional shard-selection guards. The required `TestTutorial01` process lane ran and passed. Neither diff-owned test skipped.
+- `waiver_ref`: none
+- `ci_lane_run`: n/a (no CI-config change)
+- `shard_logs`: `/var/tmp/gc-local-tests.IojiMV`
+- `runner_log`: `/var/tmp/ga-jj113k-full-suite-20260911.log`
+- `runner_log_sha256`: `806d192a534da47d844f8e6c52e82dcb100420c458c74748f82569dd88305598`
+
+### Raw failure attribution
+
+- `failure_attribution: TestCleanInstallTutorialPath, TestGCLiveContract_BeadsAndEvents, TestGraphWorkflowFailureRunsCleanup -> ga-esyijp | mechanism proof — attributed`
+  - Clause 1: the candidate changes neither these integration tests nor Beads schema/init handling; it changes only pool desired-state arithmetic and its test.
+  - Clause 2: open `gate-tracker` bead `ga-esyijp` was created on 2026-08-29, before this run. All three sightings were appended and verified.
+  - Clause 3: each test failed before its intended assertion because the external `bd init` refused to migrate a shared server: 35 pending migrations (`v31 -> v66`), 64 (`v2 -> v66`), and 4 (`v62 -> v66`), respectively. Pool-demand calculation cannot alter the separately installed `bd` binary or shared database schema.
+  - Clause 4: the failing test paths are under `test/integration`; the candidate paths are `cmd/gc/pool_desired_state.go` and `cmd/gc/pool_desired_state_test.go`, with no path overlap.
+  - Raw logs: `integration-rest-full-2-of-8.log` (`sha256:7184c50b816af1fa66dbf9353bb96c26f51e4ac70301631e2ae2965105c5a27d`), `integration-rest-full-5-of-8.log` (`sha256:5ca7bcebb6fc627a14ba0f206750da463589a92dc4e741dbe8872b499db2952a`), and `integration-rest-full-7-of-8.log` (`sha256:2ffb332f086c941a84c859eb815ee137858e57e9d6031cdf10a20e469d07cc41`).
+
+- `failure_attribution: TestE2E_SuspendResume_City -> ga-dc9utn (fix ga-pmafyc) | proven mechanism — attributed`
+  - Clause 1: the candidate changes neither `test/integration/e2e_lifecycle_test.go` nor the reconciler's suspend/resume retirement path.
+  - Clause 2: open `gate-tracker` bead `ga-dc9utn` was created on 2026-09-09, before this run. The sighting was appended and verified.
+  - Clause 3: the run reproduced the tracker's canonical 94.55-second missing `citysus.report` signature. The tracker proves that suspension produces an empty desired state and the reconciler retires and clears the named session before resume. Pending-create pool-demand arithmetic cannot affect that configured named-session retirement mechanism.
+  - Clause 4: the failing integration-test path and proven `buildDesiredStateWithSessionBeads`/session-reconciler path do not overlap either candidate path.
+  - Raw log: `integration-rest-full-2-of-8.log` (`sha256:7184c50b816af1fa66dbf9353bb96c26f51e4ac70301631e2ae2965105c5a27d`).
+
+All four attributions use landed mechanism evidence, so the inconclusive
+reachability/load guard is not invoked. The first candidate run is preserved;
+it was not retried into green.
+
+## Policy and static evidence
+
+- `make test-ci-policy`: **PASS** (runner-policy, suite-coverage, `scripts/cipolicy`, `scripts/prwatchdog`, and static-scope contract tests).
+- `go vet ./...`: **PASS**.
+- `LINT_CHANGED_REF=origin/main make fmt-check-changed`: **PASS**.
+- `git diff --check origin/main...HEAD`: **PASS**.
+- `core.hooksPath`: `.githooks`.
+- Policy log: `/var/tmp/ga-jj113k-policy.log` (`sha256:7061eaa3e6662bba7ca8951b491bc4caf6cce2eeabd9fcf46fb0dd96b1fb20db`).
+- Affected-package log: `/var/tmp/ga-jj113k-affected.log` (`sha256:234f0ead54e5ffa4295d7f7c79ac5e074c292cb3a7dd697097b5e79dc2a64928`).
+
+## Disposition
+
+Gate PASS. Cut `deploy/ga-jj113k-gate` from the exact reviewed source, commit
+this checklist there, push the isolated branch, and open a pull request. Merge
+authority remains with mayor/mpr; the deployer does not merge.


### PR DESCRIPTION
## What this changes

A pool session that has been claimed for creation now remains desired when the next scale check drops to zero before startup finishes. Previously, that in-flight session could disappear from desired state and be rolled back later without ever starting.

The protection lasts only for the session's existing pending-create lease. An expired or terminal create attempt still falls out of desired state and follows the normal rollback path.

## Why it is built this way

The demand calculation counts only lease-valid in-flight sessions and delegates expiry to the reconciler's existing predicate, so there is one timeout definition. Existing agent, rig, and workspace caps still apply after the floor is calculated, and protected runnable sessions retain priority when capacity is constrained.

## Review notes

- The production change is confined to `cmd/gc/pool_desired_state.go`.
- The regression coverage checks both sides of the boundary: a fresh attempt establishes the floor, while an attempt older than its lease does not.
- Work-query routing and storage visibility are unchanged.

## Test plan

- [x] `go test ./cmd/gc/... -count=1 -v`
- [x] `go build ./...` and `go vet ./...`
- [x] `make test-ci-policy`
- [x] Full local CI union with rootless Podman; raw-failure attribution is recorded in the release gate
- [x] Release gate: [`release-gates/pool-in-flight-demand-floor-gate.md`](release-gates/pool-in-flight-demand-floor-gate.md)
