### PR TITLE
fix(dolt): gc dolt sync / pull run one server-side DOLT_FETCH / DOLT_PULL at a time and KILL the server-side call when the client bound expires; health warns on piled-up fetch sessions

### DIFF
--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -152,6 +152,11 @@ touch <cityPath>/.beads/dolt/<database>/.no-sync
 `gc dolt sync` and `gc dolt pull` honor the same marker, so one file covers
 every remote path.
 
+Both commands also run at most one server-side `DOLT_FETCH` / `DOLT_PULL` per
+database at a time and `KILL` the server-side call when their client bound
+expires; see the dolt pack's `docs/remote-sync-single-flight.md` for the rule,
+the `gc dolt health` WARN line, and the env bounds.
+
 Choose `.no-sync` over `--skip-fetch` when a database must never reach a
 remote. `--skip-fetch` defers the push and waits for the remote to become
 usable later; `.no-sync` states that it never will.

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -622,7 +622,11 @@ bound_expired() {
 REMOTE_OP_GATE_MARK='gc-remote-op-lock-held'
 REMOTE_OP_LOST_MARK='gc-remote-op-lost'
 REMOTE_OP_NOT_OWNER_MARK='gc-remote-op-not-owner'
-REMOTE_OP_RUN_NONCE="$$-$(date +%s)"
+# REMOTE_OP_RUN_NONCE is set by the scripts that take locks (sync, pull) once
+# per run, after sourcing this file: `REMOTE_OP_RUN_NONCE="$$-$(date +%s)"`.
+# Not computed here: health sources this file too and must not spend a `date`
+# call at source time (its tests script the date sequence).
+REMOTE_OP_RUN_NONCE="${REMOTE_OP_RUN_NONCE:-}"
 
 # remote_op_lock_name DB — the user-level lock name for DB, `gc_remote_op:<db>`
 # with the name lowercased: Dolt resolves `app` and `APP` to one database, and
@@ -637,7 +641,7 @@ remote_op_lock_name() {
 # `gc_remote_op_run:<db>:<pid>-<epoch>` (db lowercased like the database lock;
 # the nonce carries no caller data).
 remote_op_run_lock_name() {
-  printf 'gc_remote_op_run:%s:%s' "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" "$REMOTE_OP_RUN_NONCE"
+  printf 'gc_remote_op_run:%s:%s' "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" "${REMOTE_OP_RUN_NONCE:?remote_op_run_lock_name: REMOTE_OP_RUN_NONCE is unset (the script must set it once per run)}"
 }
 
 # remote_op_gate_sql DB — the gate statement for DB (DB already validated by

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -380,7 +380,11 @@ remote_op_sessions_sql() {
 # remote_op_sessions_sql; stdout: one `Id Time` line per session attributed to
 # DB (case-insensitively) or to no database, every session when DB is empty.
 # Every row is checked for shape BEFORE the filter, so a malformed row for
-# another database still refuses the whole answer. Returns 1 when the first line is not
+# another database still refuses the whole answer; the db column must be
+# exactly ONE CSV field — unquoted without a comma or a quote, or quoted with
+# doubled inner quotes — so a row with an extra column (`42,60,app,extra`) or
+# a stray quote is refused rather than read as "another database" (codex r7).
+# Returns 1 when the first line is not
 # the `Id,Time,db` header (an empty stdout, a banner or an error text is NOT a
 # processlist answer), 2 when a non-blank row does not START with an unquoted
 # all-digit Id and Time (`12,34,…`): a NULL, a truncated line, a wrapper's
@@ -402,7 +406,10 @@ remote_op_sessions_parse() {
       if ($0 !~ /^[0-9]+,[0-9]+,/) { bad = 1; exit 2 }
       have = $0
       sub(/^[0-9]+,[0-9]+,/, "", have)
-      gsub(/^"|"$/, "", have)
+      if (have ~ /^"([^"]|"")*"$/) {
+        have = substr(have, 2, length(have) - 2)
+        gsub(/""/, "\"", have)
+      } else if (have !~ /^[^",]*$/) { bad = 1; exit 2 }
       if (want != "" && have != "" && tolower(have) != want) next
       print $1, $2
     }
@@ -427,7 +434,7 @@ remote_op_sessions() {
   _rs_rows=$(printf '%s\n' "$_rs_csv" | remote_op_sessions_parse "$_rs_db") || {
     _rs_prc=$?
     if [ "$_rs_prc" -eq 2 ]; then
-      printf 'malformed processlist row (Id or Time not all-digit) — refusing the whole answer\n' >>"$_rs_errf"
+      printf 'malformed processlist row (Id or Time not all-digit, or the db column not one CSV field) — refusing the whole answer\n' >>"$_rs_errf"
     else
       printf 'not a processlist answer (no Id,Time,db header)\n' >>"$_rs_errf"
     fi

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -338,9 +338,10 @@ dolt_sql_csv() {
 # leading whitespace, block or line comments, any whitespace between CALL and
 # the procedure name and before the paren. DOLT_PUSH, DOLT_FETCHX and the text
 # inside a string literal do not match. Backslashes are doubled for the SQL
-# string literal. Verified on Dolt 2.1.10 (evidence 04b: 7 variants hit, 5
-# decoys miss).
-REMOTE_OP_INFO_REGEXP='^\\s*((/\\*([^*]|\\*[^/])*\\*/|--[^\\n]*\\n)\\s*)*CALL\\s+DOLT_(FETCH|PULL)\\s*\\('
+# string literal. The block-comment form `/\*([^*]|\*+[^*/])*\*+/` accepts
+# `/***/`, `/* **/` and `/* a * b */`. Verified on Dolt 2.1.10 (evidence 04b
+# and 04c-G: 7 + 9 variants hit, 5 + 4 decoys miss).
+REMOTE_OP_INFO_REGEXP='^\\s*((/\\*([^*]|\\*+[^*/])*\\*+/|--[^\\n]*\\n)\\s*)*CALL\\s+DOLT_(FETCH|PULL)\\s*\\('
 
 remote_op_sessions_sql() {
   _ros_q="SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE UPPER(Info) REGEXP '$REMOTE_OP_INFO_REGEXP'"
@@ -504,87 +505,34 @@ bound_expired() {
   esac
 }
 
-# --- Per-database runner lock (gp-f2yq) ---------------------------------------
+# --- Server-side single-flight gate (gp-f2yq) --------------------------------
 #
-# The processlist check and the CALL are two round trips. Two runners on this
-# host (the patrol and an operator's `gc dolt sync`, or sync and pull) can both
-# read "nothing in flight" and both issue a fetch. remote_op_lock_* serialize
-# runners per server + database with a mkdir lock (atomic on every POSIX
-# filesystem; no flock dependency), held from before the check until the
-# operation and its cleanup are done. A holder that died leaves a lock whose
-# pid is gone; the next runner reclaims it. Root: GC_DOLT_REMOTE_OP_LOCK_ROOT
-# (default ${TMPDIR:-/tmp}/gc-dolt-remote-op), one `<host>-<port>-<db>.lock`
-# directory per database, `pid` inside.
+# The processlist check and the CALL are two round trips, so two runners (on
+# this host or another) can both read "nothing in flight". The operand that
+# neither can move is the server's own session lock: remote_op_gate_sql is a
+# statement placed in the SAME session and batch as the CALL, taking a
+# user-level lock named for the database with timeout 0. GET_LOCK is
+# session-scoped: the server releases it only when that session ends — the
+# CALL finished and the client disconnected, or KILL. A client whose bound
+# expired leaves its server session holding the lock, so the next runner's
+# gate fails until the session is KILLed or finishes: exactly the
+# single-flight the processlist line reports. When the lock is held, the IF's
+# else branch raises an error (JSON_EXTRACT on a non-JSON text) and the CLI
+# stops the batch at the failing statement, so the CALL is never sent.
+# Verified on Dolt 2.1.10 (evidence 04c): a second session's batch ends with
+# `Error 3141 … Invalid JSON text … "gc-remote-op-lock-held"` and its
+# following statement never runs; IS_USED_LOCK names the holder; after KILL
+# the gate passes again; an 80-character lock name is accepted.
+REMOTE_OP_GATE_MARK='gc-remote-op-lock-held'
 
-remote_op_lock_root() {
-  printf '%s' "${GC_DOLT_REMOTE_OP_LOCK_ROOT:-${TMPDIR:-/tmp}/gc-dolt-remote-op}"
+# remote_op_gate_sql DB — the gate statement for DB (DB already validated by
+# the caller before it is interpolated).
+remote_op_gate_sql() {
+  printf "SELECT IF(GET_LOCK('gc_remote_op:%s', 0) = 1, 1, JSON_EXTRACT('%s', '\$')) AS gate" "$1" "$REMOTE_OP_GATE_MARK"
 }
 
-remote_op_lock_dir() {
-  _rl_host=$(printf '%s' "${GC_DOLT_HOST:-127.0.0.1}" | tr '[:upper:]' '[:lower:]')
-  _rl_key=$(printf '%s-%s-%s' "$_rl_host" "${GC_DOLT_PORT:-}" "$1" | tr -c 'A-Za-z0-9_.-' '-')
-  printf '%s/%s.lock' "$(remote_op_lock_root)" "$_rl_key"
-}
-
-# remote_op_lock_acquire DB — take DB's runner lock. Returns 0 holding it (path
-# in REMOTE_OP_LOCK_HELD); 1 when a live runner holds it (its pid, or
-# "unknown", in REMOTE_OP_LOCK_HOLDER); 2 when the lock root cannot be created
-# or the pid cannot be recorded. A lock without a pid file is given one second
-# (the holder is between its mkdir and its pid write) and then treated as
-# stale; a stale lock is reclaimed once.
-# shellcheck disable=SC2034  # REMOTE_OP_LOCK_HOLDER is read by the sync/pull callers
-remote_op_lock_acquire() {
-  _la_dir=$(remote_op_lock_dir "$1")
-  _la_root=$(remote_op_lock_root)
-  if [ ! -d "$_la_root" ]; then
-    _la_umask=$(umask)
-    umask 077
-    mkdir -p "$_la_root" 2>/dev/null || { umask "$_la_umask"; return 2; }
-    umask "$_la_umask"
-  fi
-  REMOTE_OP_LOCK_HOLDER=""
-  _la_waited=0
-  _la_reclaimed=0
-  while :; do
-    if mkdir "$_la_dir" 2>/dev/null; then
-      if ! printf '%s\n' "$$" > "$_la_dir/pid" 2>/dev/null; then
-        rmdir "$_la_dir" 2>/dev/null
-        return 2
-      fi
-      REMOTE_OP_LOCK_HELD="$_la_dir"
-      return 0
-    fi
-    _la_pid=$(cat "$_la_dir/pid" 2>/dev/null || true)
-    case "$_la_pid" in
-      ''|*[!0-9]*)
-        if [ "$_la_waited" -eq 0 ]; then
-          _la_waited=1
-          sleep 1
-          continue
-        fi
-        ;;
-      *)
-        if kill -0 "$_la_pid" 2>/dev/null; then
-          REMOTE_OP_LOCK_HOLDER="$_la_pid"
-          return 1
-        fi
-        ;;
-    esac
-    if [ "$_la_reclaimed" -ne 0 ]; then
-      REMOTE_OP_LOCK_HOLDER="${_la_pid:-unknown}"
-      return 1
-    fi
-    _la_reclaimed=1
-    rm -f "$_la_dir/pid" 2>/dev/null
-    rmdir "$_la_dir" 2>/dev/null
-  done
-}
-
-# remote_op_lock_release — drop the lock remote_op_lock_acquire took (no-op
-# when none is held).
-remote_op_lock_release() {
-  [ -n "${REMOTE_OP_LOCK_HELD:-}" ] || return 0
-  rm -f "$REMOTE_OP_LOCK_HELD/pid" 2>/dev/null
-  rmdir "$REMOTE_OP_LOCK_HELD" 2>/dev/null
-  REMOTE_OP_LOCK_HELD=""
+# remote_op_gate_refused STDERR_FILE — true when the captured dolt stderr says
+# the gate refused: another session holds this database's lock.
+remote_op_gate_refused() {
+  grep -q "$REMOTE_OP_GATE_MARK" "$1" 2>/dev/null
 }

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -333,8 +333,17 @@ dolt_sql_csv() {
 # unattributed fetch (issued without --use-db: an older gc dolt sync, or an
 # operator) may be this database's, so it counts, fail closed. Without DB:
 # every such session on the server (the health probe).
+# REMOTE_OP_INFO_REGEXP — the SQL REGEXP (ICU, applied to UPPER(Info)) that
+# recognizes a running CALL DOLT_FETCH / CALL DOLT_PULL however it was typed:
+# leading whitespace, block or line comments, any whitespace between CALL and
+# the procedure name and before the paren. DOLT_PUSH, DOLT_FETCHX and the text
+# inside a string literal do not match. Backslashes are doubled for the SQL
+# string literal. Verified on Dolt 2.1.10 (evidence 04b: 7 variants hit, 5
+# decoys miss).
+REMOTE_OP_INFO_REGEXP='^\\s*((/\\*([^*]|\\*[^/])*\\*/|--[^\\n]*\\n)\\s*)*CALL\\s+DOLT_(FETCH|PULL)\\s*\\('
+
 remote_op_sessions_sql() {
-  _ros_q="SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE (UPPER(Info) LIKE 'CALL DOLT_FETCH%' OR UPPER(Info) LIKE 'CALL DOLT_PULL%')"
+  _ros_q="SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE UPPER(Info) REGEXP '$REMOTE_OP_INFO_REGEXP'"
   if [ -n "${1:-}" ]; then
     _ros_q="$_ros_q AND (db = '$1' OR db = '' OR db IS NULL)"
   fi
@@ -343,9 +352,11 @@ remote_op_sessions_sql() {
 
 # remote_op_sessions_parse — stdin: the CSV answer to remote_op_sessions_sql;
 # stdout: one `Id Time` line per session. Returns 1 when the first line is not
-# the `Id,Time,db` header: an empty stdout, a banner or an error text is NOT a
-# processlist answer and must never be read as "nothing in flight". Rows whose
-# Id and Time are not both all-digit are dropped.
+# the `Id,Time,db` header (an empty stdout, a banner or an error text is NOT a
+# processlist answer), 2 when a non-blank row does not carry an all-digit Id
+# and Time (a NULL, a truncated line, a wrapper's noise). Neither may ever be
+# read as "nothing in flight": a malformed row is a session whose state is
+# unknown, so the whole answer is refused, fail closed.
 remote_op_sessions_parse() {
   awk -F, '
     NR == 1 {
@@ -354,12 +365,14 @@ remote_op_sessions_parse() {
       if (tolower(hdr) != "id,time,db") exit 1
       next
     }
+    /^[[:space:]]*$/ { next }
     {
       gsub(/"|\r/, "", $1)
       gsub(/"|\r/, "", $2)
-      if ($1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/) print $1, $2
+      if ($1 !~ /^[0-9]+$/ || $2 !~ /^[0-9]+$/) { bad = 1; exit 2 }
+      print $1, $2
     }
-    END { if (NR == 0) exit 1 }
+    END { if (NR == 0) exit 1; if (bad) exit 2 }
   '
 }
 
@@ -377,7 +390,12 @@ remote_op_sessions() {
   _rs_csv=$(dolt_sql_csv "$_rs_tmo" "" "$(remote_op_sessions_sql "$_rs_db")" 2>>"$_rs_errf") || _rs_rc=$?
   [ "$_rs_rc" -eq 0 ] || return "$_rs_rc"
   _rs_rows=$(printf '%s\n' "$_rs_csv" | remote_op_sessions_parse) || {
-    printf 'not a processlist answer (no Id,Time,db header)\n' >>"$_rs_errf"
+    _rs_prc=$?
+    if [ "$_rs_prc" -eq 2 ]; then
+      printf 'malformed processlist row (Id or Time not all-digit) — refusing the whole answer\n' >>"$_rs_errf"
+    else
+      printf 'not a processlist answer (no Id,Time,db header)\n' >>"$_rs_errf"
+    fi
     return 1
   }
   printf '%s\n' "$_rs_rows"
@@ -472,4 +490,101 @@ remote_op_replay_stderr() {
   while IFS= read -r _rr_line || [ -n "$_rr_line" ]; do
     printf '  %s: %s\n' "$1" "$_rr_line" >&2
   done < "$2"
+}
+
+# bound_expired RC — true when a run_bounded exit code means the wall-clock
+# bound expired: 124 (GNU timeout, or the python fallback) or 137 (GNU timeout
+# escalated to SIGKILL after --kill-after because the client ignored TERM).
+# Either way the client is dead and the server-side call is not: both are the
+# cleanup case, never the ordinary-error case.
+bound_expired() {
+  case "$1" in
+    124|137) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# --- Per-database runner lock (gp-f2yq) ---------------------------------------
+#
+# The processlist check and the CALL are two round trips. Two runners on this
+# host (the patrol and an operator's `gc dolt sync`, or sync and pull) can both
+# read "nothing in flight" and both issue a fetch. remote_op_lock_* serialize
+# runners per server + database with a mkdir lock (atomic on every POSIX
+# filesystem; no flock dependency), held from before the check until the
+# operation and its cleanup are done. A holder that died leaves a lock whose
+# pid is gone; the next runner reclaims it. Root: GC_DOLT_REMOTE_OP_LOCK_ROOT
+# (default ${TMPDIR:-/tmp}/gc-dolt-remote-op), one `<host>-<port>-<db>.lock`
+# directory per database, `pid` inside.
+
+remote_op_lock_root() {
+  printf '%s' "${GC_DOLT_REMOTE_OP_LOCK_ROOT:-${TMPDIR:-/tmp}/gc-dolt-remote-op}"
+}
+
+remote_op_lock_dir() {
+  _rl_host=$(printf '%s' "${GC_DOLT_HOST:-127.0.0.1}" | tr '[:upper:]' '[:lower:]')
+  _rl_key=$(printf '%s-%s-%s' "$_rl_host" "${GC_DOLT_PORT:-}" "$1" | tr -c 'A-Za-z0-9_.-' '-')
+  printf '%s/%s.lock' "$(remote_op_lock_root)" "$_rl_key"
+}
+
+# remote_op_lock_acquire DB — take DB's runner lock. Returns 0 holding it (path
+# in REMOTE_OP_LOCK_HELD); 1 when a live runner holds it (its pid, or
+# "unknown", in REMOTE_OP_LOCK_HOLDER); 2 when the lock root cannot be created
+# or the pid cannot be recorded. A lock without a pid file is given one second
+# (the holder is between its mkdir and its pid write) and then treated as
+# stale; a stale lock is reclaimed once.
+# shellcheck disable=SC2034  # REMOTE_OP_LOCK_HOLDER is read by the sync/pull callers
+remote_op_lock_acquire() {
+  _la_dir=$(remote_op_lock_dir "$1")
+  _la_root=$(remote_op_lock_root)
+  if [ ! -d "$_la_root" ]; then
+    _la_umask=$(umask)
+    umask 077
+    mkdir -p "$_la_root" 2>/dev/null || { umask "$_la_umask"; return 2; }
+    umask "$_la_umask"
+  fi
+  REMOTE_OP_LOCK_HOLDER=""
+  _la_waited=0
+  _la_reclaimed=0
+  while :; do
+    if mkdir "$_la_dir" 2>/dev/null; then
+      if ! printf '%s\n' "$$" > "$_la_dir/pid" 2>/dev/null; then
+        rmdir "$_la_dir" 2>/dev/null
+        return 2
+      fi
+      REMOTE_OP_LOCK_HELD="$_la_dir"
+      return 0
+    fi
+    _la_pid=$(cat "$_la_dir/pid" 2>/dev/null || true)
+    case "$_la_pid" in
+      ''|*[!0-9]*)
+        if [ "$_la_waited" -eq 0 ]; then
+          _la_waited=1
+          sleep 1
+          continue
+        fi
+        ;;
+      *)
+        if kill -0 "$_la_pid" 2>/dev/null; then
+          REMOTE_OP_LOCK_HOLDER="$_la_pid"
+          return 1
+        fi
+        ;;
+    esac
+    if [ "$_la_reclaimed" -ne 0 ]; then
+      REMOTE_OP_LOCK_HOLDER="${_la_pid:-unknown}"
+      return 1
+    fi
+    _la_reclaimed=1
+    rm -f "$_la_dir/pid" 2>/dev/null
+    rmdir "$_la_dir" 2>/dev/null
+  done
+}
+
+# remote_op_lock_release — drop the lock remote_op_lock_acquire took (no-op
+# when none is held).
+remote_op_lock_release() {
+  [ -n "${REMOTE_OP_LOCK_HELD:-}" ] || return 0
+  rm -f "$REMOTE_OP_LOCK_HELD/pid" 2>/dev/null
+  rmdir "$REMOTE_OP_LOCK_HELD" 2>/dev/null
+  REMOTE_OP_LOCK_HELD=""
 }

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -331,22 +331,28 @@ dolt_sql_csv() {
 # validated by the caller before it is interpolated): the sessions attributed
 # to that database PLUS the sessions attributed to no database at all — an
 # unattributed fetch (issued without --use-db: an older gc dolt sync, or an
-# operator) may be this database's, so it counts, fail closed. Without DB:
+# operator) may be this database's, so it counts, fail closed. Database names
+# compare case-insensitively (Dolt resolves `app` and `APP` to one database;
+# the processlist shows whichever spelling the client used). Without DB:
 # every such session on the server (the health probe).
 # REMOTE_OP_INFO_REGEXP — the SQL REGEXP (ICU, applied to UPPER(Info)) that
 # recognizes a running CALL DOLT_FETCH / CALL DOLT_PULL however it was typed:
-# leading whitespace, block or line comments, any whitespace between CALL and
-# the procedure name and before the paren. DOLT_PUSH, DOLT_FETCHX and the text
-# inside a string literal do not match. Backslashes are doubled for the SQL
-# string literal. The block-comment form `/\*([^*]|\*+[^*/])*\*+/` accepts
-# `/***/`, `/* **/` and `/* a * b */`. Verified on Dolt 2.1.10 (evidence 04b
-# and 04c-G: 7 + 9 variants hit, 5 + 4 decoys miss).
-REMOTE_OP_INFO_REGEXP='^\\s*((/\\*([^*]|\\*+[^*/])*\\*+/|--[^\\n]*\\n)\\s*)*CALL\\s+DOLT_(FETCH|PULL)\\s*\\('
+# whitespace or comments (block `/* … */` including `/***/`, line `-- …`)
+# before CALL, between CALL and the procedure, and before the paren; the
+# procedure name bare, backticked, or qualified by one database name
+# (`CALL app.DOLT_FETCH(`, `CALL \`dolt_fetch\`(` — both valid Dolt syntax).
+# DOLT_PUSH, DOLT_FETCHX, CALLDOLT_FETCH and the text inside a string literal
+# or a comment do not match. Backslashes are doubled for the SQL string
+# literal. Verified on Dolt 2.1.10 (evidence 04b, 04c-G, 04d: 9 spellings hit,
+# 6 decoys miss).
+_ws='(\\s|/\\*([^*]|\\*+[^*/])*\\*+/|--[^\\n]*\\n)'
+REMOTE_OP_INFO_REGEXP='^'"$_ws"'*CALL'"$_ws"'+(`?[A-Z0-9_]+`?'"$_ws"'*\\.'"$_ws"'*)?`?DOLT_(FETCH|PULL)`?'"$_ws"'*\\('
+unset _ws
 
 remote_op_sessions_sql() {
   _ros_q="SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE UPPER(Info) REGEXP '$REMOTE_OP_INFO_REGEXP'"
   if [ -n "${1:-}" ]; then
-    _ros_q="$_ros_q AND (db = '$1' OR db = '' OR db IS NULL)"
+    _ros_q="$_ros_q AND (LOWER(db) = LOWER('$1') OR db = '' OR db IS NULL)"
   fi
   printf '%s ORDER BY Time DESC, Id ASC' "$_ros_q"
 }
@@ -354,10 +360,12 @@ remote_op_sessions_sql() {
 # remote_op_sessions_parse — stdin: the CSV answer to remote_op_sessions_sql;
 # stdout: one `Id Time` line per session. Returns 1 when the first line is not
 # the `Id,Time,db` header (an empty stdout, a banner or an error text is NOT a
-# processlist answer), 2 when a non-blank row does not carry an all-digit Id
-# and Time (a NULL, a truncated line, a wrapper's noise). Neither may ever be
-# read as "nothing in flight": a malformed row is a session whose state is
-# unknown, so the whole answer is refused, fail closed.
+# processlist answer), 2 when a non-blank row does not START with an unquoted
+# all-digit Id and Time (`12,34,…`): a NULL, a truncated line, a wrapper's
+# noise, or a quoted field (`"12,34",60,app`) that field-splitting would read
+# as two numbers. Neither may ever be read as "nothing in flight": a
+# malformed row is a session whose state is unknown, so the whole answer is
+# refused, fail closed.
 remote_op_sessions_parse() {
   awk -F, '
     NR == 1 {
@@ -368,9 +376,8 @@ remote_op_sessions_parse() {
     }
     /^[[:space:]]*$/ { next }
     {
-      gsub(/"|\r/, "", $1)
-      gsub(/"|\r/, "", $2)
-      if ($1 !~ /^[0-9]+$/ || $2 !~ /^[0-9]+$/) { bad = 1; exit 2 }
+      sub(/\r$/, "")
+      if ($0 !~ /^[0-9]+,[0-9]+,/) { bad = 1; exit 2 }
       print $1, $2
     }
     END { if (NR == 0) exit 1; if (bad) exit 2 }
@@ -421,13 +428,17 @@ remote_op_session_id() {
 # expired, and PROVE it ended. SESSION_ID is the connection id the statement
 # printed about itself before the procedure started: the session is ours by
 # construction. An empty SESSION_ID (the client died before the server
-# answered) falls back to every in-flight remote operation attributed to DB:
-# the single-flight check found none before ours started, so each one is ours
-# or a concurrent runner's that raced the same window, and none may survive.
-# The verdict is the processlist read AFTER the KILL, never KILL's own exit
-# code: a session still listed is reported as NOT killed and returns 1. LABEL
-# names the operation in the lines ("fetch" / "pull"); every line goes to
-# stderr next to the timeout line it resolves.
+# answered) kills NOTHING: absence from the earlier processlist read does not
+# prove that a session listed now is ours (an operator's unattributed pull
+# for another database can appear in the same window), so the in-flight
+# sessions attributed to DB are reported for the operator and 1 is returned;
+# a session of ours that does exist holds the database's lock, so every later
+# run is refused by the server gate until it ends or is KILLed by hand, and
+# gc dolt health names it. The verdict for a known id is the processlist read
+# AFTER the KILL, never KILL's own exit code: a session still listed is
+# reported as NOT killed and returns 1. LABEL names the operation in the
+# lines ("fetch" / "pull"); every line goes to stderr next to the timeout
+# line it resolves.
 kill_remote_op_session() {
   _kr_label="$1"
   _kr_db="$2"
@@ -448,12 +459,14 @@ kill_remote_op_session() {
       rm -f "$_kr_errf"
       return 1
     }
-    _kr_ids=$(printf '%s\n' "$_kr_rows" | awk '{ print $1 }')
-    if [ -z "$_kr_ids" ]; then
-      rm -f "$_kr_errf"
+    _kr_listed=$(printf '%s\n' "$_kr_rows" | awk '{ printf "%s%s", sep, $1; sep = " " }')
+    rm -f "$_kr_errf"
+    if [ -z "$_kr_listed" ]; then
       echo "  $_kr_db: server-side $_kr_label already ended (nothing in flight to kill)" >&2
       return 0
     fi
+    echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and ownership of the in-flight session(s) attributed to $_kr_db (Id $_kr_listed) cannot be proven — left for the operator (KILL <Id>); gc dolt health names them" >&2
+    return 1
   fi
   for _kr_one in $_kr_ids; do
     _kr_krc=0
@@ -525,10 +538,19 @@ bound_expired() {
 # the gate passes again; an 80-character lock name is accepted.
 REMOTE_OP_GATE_MARK='gc-remote-op-lock-held'
 
+# remote_op_lock_name DB — the user-level lock name for DB, `gc_remote_op:<db>`
+# with the name lowercased: Dolt resolves `app` and `APP` to one database, and
+# a named lock is a literal key, so two spellings must map to one lock. The
+# gate lowercases on the server (LOWER) and this helper does the same for the
+# lines the scripts print.
+remote_op_lock_name() {
+  printf 'gc_remote_op:%s' "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+}
+
 # remote_op_gate_sql DB — the gate statement for DB (DB already validated by
 # the caller before it is interpolated).
 remote_op_gate_sql() {
-  printf "SELECT IF(GET_LOCK('gc_remote_op:%s', 0) = 1, 1, JSON_EXTRACT('%s', '\$')) AS gate" "$1" "$REMOTE_OP_GATE_MARK"
+  printf "SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('%s')), 0) = 1, 1, JSON_EXTRACT('%s', '\$')) AS gate" "$1" "$REMOTE_OP_GATE_MARK"
 }
 
 # remote_op_gate_refused STDERR_FILE — true when the captured dolt stderr says

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -281,3 +281,195 @@ PY
     return 124
   fi
 }
+
+# --- Server-side remote operations (gp-f2yq) ---------------------------------
+#
+# A `CALL DOLT_FETCH` / `CALL DOLT_PULL` issued through the dolt CLI runs
+# INSIDE the sql-server. When the client's wall-clock bound expires only the
+# client dies; the server-side procedure keeps running, and a patrol that
+# re-issues the call every cooldown stacks one more on top each run (boomtown
+# 2026-09-11: 169 of 178 sql-server connections in DOLT_FETCH, one per
+# 15-minute run for two days, dolt at 180% CPU, that store's sync dead for
+# weeks). sync, pull and health share the helpers below so all three agree on
+# what "a remote operation is in flight" means and how one is ended.
+#
+# Contract (verified on Dolt 2.1.10):
+#   - information_schema.processlist lists every server-side session with
+#     Id, Time (seconds the current statement has run), DB and Info (the
+#     statement text). A session whose client died stays listed.
+#   - The DB column is the connection's database as set by the CLI's
+#     --use-db; a `USE` statement inside the query does NOT set it.
+#   - The CLI prints each statement's result before running the next, so a
+#     `SELECT CONNECTION_ID()` issued just before the procedure lands on
+#     stdout before the fetch starts and survives the client's death.
+#   - `KILL <id>` exits 0 with no text whether or not <id> exists, so the
+#     proof that a session ended is the processlist read AFTER the KILL.
+
+# dolt_sql_csv TIMEOUT_SECS USE_DB QUERY — run QUERY against the managed
+# server through the dolt CLI under a wall-clock bound, CSV result. USE_DB,
+# when non-empty, is passed as --use-db so the server attributes the session
+# to that database (the processlist DB column). The password reaches dolt via
+# DOLT_CLI_PASSWORD, never as an argv flag.
+dolt_sql_csv() {
+  _dsc_tmo="$1"
+  _dsc_db="$2"
+  _dsc_q="$3"
+  export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
+  if [ -n "$_dsc_db" ]; then
+    run_bounded "$_dsc_tmo" dolt --host "${GC_DOLT_HOST:-127.0.0.1}" --port "$GC_DOLT_PORT" \
+      --user "${GC_DOLT_USER:-root}" --no-tls --use-db "$_dsc_db" \
+      sql --result-format csv -q "$_dsc_q"
+  else
+    run_bounded "$_dsc_tmo" dolt --host "${GC_DOLT_HOST:-127.0.0.1}" --port "$GC_DOLT_PORT" \
+      --user "${GC_DOLT_USER:-root}" --no-tls \
+      sql --result-format csv -q "$_dsc_q"
+  fi
+}
+
+# remote_op_sessions_sql [DB] — the SQL that lists the live sessions running
+# CALL DOLT_FETCH or CALL DOLT_PULL as `Id,Time,db` rows. With DB (already
+# validated by the caller before it is interpolated): the sessions attributed
+# to that database PLUS the sessions attributed to no database at all — an
+# unattributed fetch (issued without --use-db: an older gc dolt sync, or an
+# operator) may be this database's, so it counts, fail closed. Without DB:
+# every such session on the server (the health probe).
+remote_op_sessions_sql() {
+  _ros_q="SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE (UPPER(Info) LIKE 'CALL DOLT_FETCH%' OR UPPER(Info) LIKE 'CALL DOLT_PULL%')"
+  if [ -n "${1:-}" ]; then
+    _ros_q="$_ros_q AND (db = '$1' OR db = '' OR db IS NULL)"
+  fi
+  printf '%s ORDER BY Time DESC, Id ASC' "$_ros_q"
+}
+
+# remote_op_sessions_parse — stdin: the CSV answer to remote_op_sessions_sql;
+# stdout: one `Id Time` line per session. Returns 1 when the first line is not
+# the `Id,Time,db` header: an empty stdout, a banner or an error text is NOT a
+# processlist answer and must never be read as "nothing in flight". Rows whose
+# Id and Time are not both all-digit are dropped.
+remote_op_sessions_parse() {
+  awk -F, '
+    NR == 1 {
+      hdr = $0
+      gsub(/"|\r/, "", hdr)
+      if (tolower(hdr) != "id,time,db") exit 1
+      next
+    }
+    {
+      gsub(/"|\r/, "", $1)
+      gsub(/"|\r/, "", $2)
+      if ($1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/) print $1, $2
+    }
+    END { if (NR == 0) exit 1 }
+  '
+}
+
+# remote_op_sessions DB TIMEOUT_SECS STDERR_FILE — list the in-flight remote
+# operations (remote_op_sessions_sql DB; DB may be empty for server-wide) as
+# `Id Time` lines on stdout. Returns 0 on a processlist answer (possibly with
+# no rows); otherwise the query's exit code (124 = the bound expired), or 1
+# when the answer was not a processlist, with the reason appended to
+# STDERR_FILE for the caller to replay. Fail closed on every non-zero return.
+remote_op_sessions() {
+  _rs_db="$1"
+  _rs_tmo="$2"
+  _rs_errf="$3"
+  _rs_rc=0
+  _rs_csv=$(dolt_sql_csv "$_rs_tmo" "" "$(remote_op_sessions_sql "$_rs_db")" 2>>"$_rs_errf") || _rs_rc=$?
+  [ "$_rs_rc" -eq 0 ] || return "$_rs_rc"
+  _rs_rows=$(printf '%s\n' "$_rs_csv" | remote_op_sessions_parse) || {
+    printf 'not a processlist answer (no Id,Time,db header)\n' >>"$_rs_errf"
+    return 1
+  }
+  printf '%s\n' "$_rs_rows"
+}
+
+# remote_op_sessions_oldest — stdin: `Id Time` lines; stdout: the line with
+# the largest Time (the oldest session); nothing on empty input.
+remote_op_sessions_oldest() {
+  awk 'NF == 2 && ($2 + 0) >= (m + 0) { m = $2; l = $0 } END { if (l != "") print l }'
+}
+
+# remote_op_session_id FILE — the connection id that a `SELECT CONNECTION_ID()
+# AS id` printed into FILE (the all-digit line right after the `id` header);
+# nothing when the client died before the server answered.
+remote_op_session_id() {
+  [ -f "$1" ] || return 0
+  awk '{ gsub(/\r/, "") } prev == "id" && $0 ~ /^[0-9]+$/ { print; exit } { prev = $0 }' "$1"
+}
+
+# kill_remote_op_session LABEL DB SESSION_ID [TIMEOUT_SECS] — end the
+# server-side DOLT_FETCH / DOLT_PULL this client abandoned when its bound
+# expired, and PROVE it ended. SESSION_ID is the connection id the statement
+# printed about itself before the procedure started: the session is ours by
+# construction. An empty SESSION_ID (the client died before the server
+# answered) falls back to every in-flight remote operation attributed to DB:
+# the single-flight check found none before ours started, so each one is ours
+# or a concurrent runner's that raced the same window, and none may survive.
+# The verdict is the processlist read AFTER the KILL, never KILL's own exit
+# code: a session still listed is reported as NOT killed and returns 1. LABEL
+# names the operation in the lines ("fetch" / "pull"); every line goes to
+# stderr next to the timeout line it resolves.
+kill_remote_op_session() {
+  _kr_label="$1"
+  _kr_db="$2"
+  _kr_id="$3"
+  _kr_tmo="${4:-120}"
+  case "$_kr_id" in
+    ''|*[!0-9]*) _kr_ids="" ;;
+    *) _kr_ids="$_kr_id" ;;
+  esac
+  _kr_errf=$(mktemp) || {
+    echo "  $_kr_db: server-side $_kr_label NOT killed: cannot create temp file for processlist diagnostics" >&2
+    return 1
+  }
+  if [ -z "$_kr_ids" ]; then
+    _kr_rows=$(remote_op_sessions "$_kr_db" "$_kr_tmo" "$_kr_errf") || {
+      echo "  $_kr_db: server-side $_kr_label NOT killed: session id unknown and the processlist query failed" >&2
+      remote_op_replay_stderr "$_kr_db" "$_kr_errf"
+      rm -f "$_kr_errf"
+      return 1
+    }
+    _kr_ids=$(printf '%s\n' "$_kr_rows" | awk '{ print $1 }')
+    if [ -z "$_kr_ids" ]; then
+      rm -f "$_kr_errf"
+      echo "  $_kr_db: server-side $_kr_label already ended (nothing in flight to kill)" >&2
+      return 0
+    fi
+  fi
+  for _kr_one in $_kr_ids; do
+    _kr_krc=0
+    _kr_kerr=$(dolt_sql_csv "$_kr_tmo" "" "KILL $_kr_one" 2>&1 >/dev/null) || _kr_krc=$?
+    [ "$_kr_krc" -eq 0 ] || echo "  $_kr_db: KILL $_kr_one failed (exit $_kr_krc): $_kr_kerr" >&2
+  done
+  _kr_left=$(remote_op_sessions "$_kr_db" "$_kr_tmo" "$_kr_errf") || {
+    echo "  $_kr_db: server-side $_kr_label kill NOT confirmed: the processlist query failed after KILL" >&2
+    remote_op_replay_stderr "$_kr_db" "$_kr_errf"
+    rm -f "$_kr_errf"
+    return 1
+  }
+  rm -f "$_kr_errf"
+  _kr_left_ids=" $(printf '%s\n' "$_kr_left" | awk '{ printf "%s ", $1 }')"
+  _kr_rc=0
+  for _kr_one in $_kr_ids; do
+    case "$_kr_left_ids" in
+      *" $_kr_one "*)
+        echo "  $_kr_db: server-side $_kr_label NOT killed (session $_kr_one still in flight after KILL)" >&2
+        _kr_rc=1
+        ;;
+      *)
+        echo "  $_kr_db: server-side $_kr_label killed (session $_kr_one no longer in flight)" >&2
+        ;;
+    esac
+  done
+  return "$_kr_rc"
+}
+
+# remote_op_replay_stderr DB FILE — replay a captured dolt stderr, one line
+# per line prefixed with the db name (scannable multi-db output); a final line
+# without a trailing newline is flushed too. Nothing on an empty capture.
+remote_op_replay_stderr() {
+  [ -s "$2" ] || return 0
+  while IFS= read -r _rr_line || [ -n "$_rr_line" ]; do
+    printf '  %s: %s\n' "$1" "$_rr_line" >&2
+  done < "$2"
+}

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -630,8 +630,9 @@ bound_expired() {
 #     runs on a session that did not pass the check (04k2 a: the true path).
 #   - the run nonce is 64 random bits from /dev/urandom (16 hex), never the
 #     pid or the clock: two hosts starting a runner in the same second with
-#     the same pid must not share a run lock (codex r13). Without
-#     /dev/urandom the nonce falls back to pid-epoch.
+#     the same pid must not share a run lock (codex r13). Without random
+#     bytes there is NO nonce and the script refuses to run before any CALL
+#     (codex r14: a silent pid-epoch fallback reopened the collision).
 REMOTE_OP_GATE_MARK='gc-remote-op-lock-held'
 REMOTE_OP_LOST_MARK='gc-remote-op-lost'
 REMOTE_OP_NOT_OWNER_MARK='gc-remote-op-not-owner'
@@ -642,12 +643,17 @@ REMOTE_OP_NOT_OWNER_MARK='gc-remote-op-not-owner'
 REMOTE_OP_RUN_NONCE="${REMOTE_OP_RUN_NONCE:-}"
 
 # remote_op_new_run_nonce — a fresh run nonce: 16 hex digits from
-# /dev/urandom, or pid-epoch when the device is unavailable.
+# /dev/urandom. Returns 1 with a line on stderr when no such bytes could be
+# read (no device, no od): the caller must stop before any CALL — a nonce
+# that could repeat is worse than no run.
 remote_op_new_run_nonce() {
   _rn=$(od -An -N8 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')
   case "$_rn" in
     ????????????????) printf '%s' "$_rn" ;;
-    *) printf '%s-%s' "$$" "$(date +%s)" ;;
+    *)
+      printf 'dolt runtime: cannot read 8 random bytes from /dev/urandom for the run nonce (od output: %s)\n' "$_rn" >&2
+      return 1
+      ;;
   esac
 }
 

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -326,15 +326,22 @@ dolt_sql_csv() {
   fi
 }
 
-# remote_op_sessions_sql [DB] — the SQL that lists the live sessions running
-# CALL DOLT_FETCH or CALL DOLT_PULL as `Id,Time,db` rows. With DB (already
-# validated by the caller before it is interpolated): the sessions attributed
-# to that database PLUS the sessions attributed to no database at all — an
-# unattributed fetch (issued without --use-db: an older gc dolt sync, or an
-# operator) may be this database's, so it counts, fail closed. Database names
-# compare case-insensitively (Dolt resolves `app` and `APP` to one database;
-# the processlist shows whichever spelling the client used). Without DB:
-# every such session on the server (the health probe).
+# remote_op_sessions_sql — the SQL that lists the live sessions running
+# DOLT_FETCH or DOLT_PULL as `Id,Time,db` rows, server-wide. The text is
+# CONSTANT: it carries no database name and nothing else from the caller, so
+# no database an operator can create can make the query match its own text
+# (`dolt_fetch` and `team-dolt_pull-prod` are valid names; the previous shape
+# interpolated LOWER('<db>') and would have listed itself on every run of such
+# a store — codex r6, evidence 04g), and two probes running at once cannot
+# count each other. The per-database filter is applied on the ANSWER by
+# remote_op_sessions_parse: the sessions attributed to that database PLUS the
+# sessions attributed to no database at all — an unattributed fetch (issued
+# without --use-db: an older gc dolt sync, or an operator) may be this
+# database's, so it counts, fail closed. Database names compare
+# case-insensitively (Dolt resolves `app` and `APP` to one database; the
+# processlist shows whichever spelling the client used; the pack's own names
+# are ASCII by valid_database_name). Without a DB filter: every such session
+# on the server (the health probe).
 # REMOTE_OP_INFO_REGEXP — the SQL REGEXP (applied to UPPER(Info)) that decides
 # "a remote operation is in flight": ANY statement that names DOLT_FETCH or
 # DOLT_PULL as a whole identifier (a non-identifier character or the string's
@@ -350,18 +357,30 @@ dolt_sql_csv() {
 # and do not match themselves. Verified on Dolt 2.1.10 (evidence 04f): 15
 # spellings hit, 6 decoys miss, 2 mentions-in-text hit by design, no
 # self-match, and a live bare `CALL DOLT_FETCH` is listed and killable.
+# LIMIT, by decision (codex r6, evidence 04g): the processlist shows the
+# statement text a session SUBMITTED, so a fetch run indirectly — a
+# text-protocol prepared statement (`PREPARE s FROM 'CALL DOLT_FETCH()';
+# EXECUTE s` shows `EXECUTE s`), a user stored procedure that wraps the call
+# (`CALL fetch_wrapper()`), an event — is invisible to this predicate, to the
+# pre-check line and to the health count, and such a session holds no pack
+# lock. No text predicate can see it: the only wider ones (any `EXECUTE`, any
+# `CALL` not naming a DOLT_ procedure) either reintroduce a grammar the
+# reviewer can keep moving or make sync skip whenever bd is inside a
+# `CALL DOLT_COMMIT`. The pack's own runs never need it — they are serialized
+# by the server lock (remote_op_gate_sql) — and the herd's shape was direct
+# CALLs; an operator's indirect fetch is out of this guard's reach and
+# stays the operator's to KILL by hand.
 REMOTE_OP_INFO_REGEXP='(^|[^A-Z0-9_])DOLT_(FETCH|PULL)([^A-Z0-9_]|$)'
 
 remote_op_sessions_sql() {
-  _ros_q="SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE UPPER(Info) REGEXP '$REMOTE_OP_INFO_REGEXP'"
-  if [ -n "${1:-}" ]; then
-    _ros_q="$_ros_q AND (LOWER(db) = LOWER('$1') OR db = '' OR db IS NULL)"
-  fi
-  printf '%s ORDER BY Time DESC, Id ASC' "$_ros_q"
+  printf "SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE UPPER(Info) REGEXP '%s' ORDER BY Time DESC, Id ASC" "$REMOTE_OP_INFO_REGEXP"
 }
 
-# remote_op_sessions_parse — stdin: the CSV answer to remote_op_sessions_sql;
-# stdout: one `Id Time` line per session. Returns 1 when the first line is not
+# remote_op_sessions_parse [DB] — stdin: the CSV answer to
+# remote_op_sessions_sql; stdout: one `Id Time` line per session attributed to
+# DB (case-insensitively) or to no database, every session when DB is empty.
+# Every row is checked for shape BEFORE the filter, so a malformed row for
+# another database still refuses the whole answer. Returns 1 when the first line is not
 # the `Id,Time,db` header (an empty stdout, a banner or an error text is NOT a
 # processlist answer), 2 when a non-blank row does not START with an unquoted
 # all-digit Id and Time (`12,34,…`): a NULL, a truncated line, a wrapper's
@@ -370,7 +389,7 @@ remote_op_sessions_sql() {
 # malformed row is a session whose state is unknown, so the whole answer is
 # refused, fail closed.
 remote_op_sessions_parse() {
-  awk -F, '
+  awk -F, -v want="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" '
     NR == 1 {
       hdr = $0
       gsub(/"|\r/, "", hdr)
@@ -381,6 +400,10 @@ remote_op_sessions_parse() {
     {
       sub(/\r$/, "")
       if ($0 !~ /^[0-9]+,[0-9]+,/) { bad = 1; exit 2 }
+      have = $0
+      sub(/^[0-9]+,[0-9]+,/, "", have)
+      gsub(/^"|"$/, "", have)
+      if (want != "" && have != "" && tolower(have) != want) next
       print $1, $2
     }
     END { if (NR == 0) exit 1; if (bad) exit 2 }
@@ -388,7 +411,8 @@ remote_op_sessions_parse() {
 }
 
 # remote_op_sessions DB TIMEOUT_SECS STDERR_FILE — list the in-flight remote
-# operations (remote_op_sessions_sql DB; DB may be empty for server-wide) as
+# operations (the constant remote_op_sessions_sql, filtered to DB by
+# remote_op_sessions_parse; DB may be empty for server-wide) as
 # `Id Time` lines on stdout. Returns 0 on a processlist answer (possibly with
 # no rows); otherwise the query's exit code (124 = the bound expired), or 1
 # when the answer was not a processlist, with the reason appended to
@@ -398,9 +422,9 @@ remote_op_sessions() {
   _rs_tmo="$2"
   _rs_errf="$3"
   _rs_rc=0
-  _rs_csv=$(dolt_sql_csv "$_rs_tmo" "" "$(remote_op_sessions_sql "$_rs_db")" 2>>"$_rs_errf") || _rs_rc=$?
+  _rs_csv=$(dolt_sql_csv "$_rs_tmo" "" "$(remote_op_sessions_sql)" 2>>"$_rs_errf") || _rs_rc=$?
   [ "$_rs_rc" -eq 0 ] || return "$_rs_rc"
-  _rs_rows=$(printf '%s\n' "$_rs_csv" | remote_op_sessions_parse) || {
+  _rs_rows=$(printf '%s\n' "$_rs_csv" | remote_op_sessions_parse "$_rs_db") || {
     _rs_prc=$?
     if [ "$_rs_prc" -eq 2 ]; then
       printf 'malformed processlist row (Id or Time not all-digit) — refusing the whole answer\n' >>"$_rs_errf"

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -537,7 +537,7 @@ kill_remote_op_session() {
   if [ -z "$_kr_ids" ]; then
     _kr_listed=$(printf '%s\n' "$_kr_left" | awk '{ printf "%s%s", sep, $1; sep = " " }')
     if [ "$_kr_holder" != 0 ]; then
-      echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and session $_kr_holder holds this run's lock ($_kr_runlock) — the session that passed this run's gate, its answer lost with the client — left for the operator (KILL $_kr_holder); gc dolt health names it" >&2
+      echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and session $_kr_holder holds this run's lock ($_kr_runlock) — the session that passed this run's gate, its answer lost with the client; it runs no remote operation, so gc dolt health does not name it — left for the operator (KILL $_kr_holder)" >&2
       return 1
     fi
     if [ -z "$_kr_listed" ]; then

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -337,16 +337,19 @@ dolt_sql_csv() {
 # every such session on the server (the health probe).
 # REMOTE_OP_INFO_REGEXP — the SQL REGEXP (ICU, applied to UPPER(Info)) that
 # recognizes a running CALL DOLT_FETCH / CALL DOLT_PULL however it was typed:
-# whitespace or comments (block `/* … */` including `/***/`, line `-- …`)
-# before CALL, between CALL and the procedure, and before the paren; the
-# procedure name bare, backticked, or qualified by one database name
-# (`CALL app.DOLT_FETCH(`, `CALL \`dolt_fetch\`(` — both valid Dolt syntax).
+# whitespace or comments (block `/* … */` including `/***/`, line `-- …` and
+# `# …`) before CALL, between CALL and the procedure, and before the paren;
+# the procedure name bare, backticked, or qualified by one database name,
+# which may carry a hyphen (`CALL app.DOLT_FETCH(`, `CALL \`app-prod\`.DOLT_FETCH(`,
+# `CALL \`dolt_fetch\`(` — all valid Dolt syntax; valid_database_name allows
+# the hyphen).
 # DOLT_PUSH, DOLT_FETCHX, CALLDOLT_FETCH and the text inside a string literal
 # or a comment do not match. Backslashes are doubled for the SQL string
-# literal. Verified on Dolt 2.1.10 (evidence 04b, 04c-G, 04d: 9 spellings hit,
-# 6 decoys miss).
-_ws='(\\s|/\\*([^*]|\\*+[^*/])*\\*+/|--[^\\n]*\\n)'
-REMOTE_OP_INFO_REGEXP='^'"$_ws"'*CALL'"$_ws"'+(`?[A-Z0-9_]+`?'"$_ws"'*\\.'"$_ws"'*)?`?DOLT_(FETCH|PULL)`?'"$_ws"'*\\('
+# literal. The exact string composed below was run on Dolt 2.1.10 (evidence
+# 04e): 13 spellings hit, 7 decoys miss (a qualifier with a space is one of
+# them; valid_database_name forbids spaces).
+_ws='(\\s|/\\*([^*]|\\*+[^*/])*\\*+/|--[^\\n]*\\n|#[^\\n]*\\n)'
+REMOTE_OP_INFO_REGEXP='^'"$_ws"'*CALL'"$_ws"'+(`?[A-Z0-9_-]+`?'"$_ws"'*\\.'"$_ws"'*)?`?DOLT_(FETCH|PULL)`?'"$_ws"'*\\('
 unset _ws
 
 remote_op_sessions_sql() {

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -397,8 +397,11 @@ remote_op_sessions_parse() {
   awk -F, '
     NR == 1 {
       hdr = $0
-      gsub(/"|\r/, "", hdr)
-      if (tolower(hdr) != "id,time,db") exit 1
+      sub(/\r$/, "", hdr)
+      # Exactly the three header fields, each bare or quoted as a whole:
+      # stripping every quote first read `"Id,Time,db"` (ONE quoted field) or
+      # `Id",Time,db` as the header, i.e. as a processlist (codex r11).
+      if (tolower(hdr) !~ /^("id"|id),("time"|time),("db"|db)$/) exit 1
       next
     }
     /^[[:space:]]*$/ { next }

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -335,22 +335,22 @@ dolt_sql_csv() {
 # compare case-insensitively (Dolt resolves `app` and `APP` to one database;
 # the processlist shows whichever spelling the client used). Without DB:
 # every such session on the server (the health probe).
-# REMOTE_OP_INFO_REGEXP — the SQL REGEXP (ICU, applied to UPPER(Info)) that
-# recognizes a running CALL DOLT_FETCH / CALL DOLT_PULL however it was typed:
-# whitespace or comments (block `/* … */` including `/***/`, line `-- …` and
-# `# …`) before CALL, between CALL and the procedure, and before the paren;
-# the procedure name bare, backticked, or qualified by one database name,
-# which may carry a hyphen (`CALL app.DOLT_FETCH(`, `CALL \`app-prod\`.DOLT_FETCH(`,
-# `CALL \`dolt_fetch\`(` — all valid Dolt syntax; valid_database_name allows
-# the hyphen).
-# DOLT_PUSH, DOLT_FETCHX, CALLDOLT_FETCH and the text inside a string literal
-# or a comment do not match. Backslashes are doubled for the SQL string
-# literal. The exact string composed below was run on Dolt 2.1.10 (evidence
-# 04e): 13 spellings hit, 7 decoys miss (a qualifier with a space is one of
-# them; valid_database_name forbids spaces).
-_ws='(\\s|/\\*([^*]|\\*+[^*/])*\\*+/|--[^\\n]*\\n|#[^\\n]*\\n)'
-REMOTE_OP_INFO_REGEXP='^'"$_ws"'*CALL'"$_ws"'+(`?[A-Z0-9_-]+`?'"$_ws"'*\\.'"$_ws"'*)?`?DOLT_(FETCH|PULL)`?'"$_ws"'*\\('
-unset _ws
+# REMOTE_OP_INFO_REGEXP — the SQL REGEXP (applied to UPPER(Info)) that decides
+# "a remote operation is in flight": ANY statement that names DOLT_FETCH or
+# DOLT_PULL as a whole identifier (a non-identifier character or the string's
+# edge on both sides). Deliberately over-inclusive: the guard fails closed, so
+# a statement that merely mentions the procedure in a string literal or a
+# comment costs one skipped run while it executes, whereas a spelling this
+# predicate missed would let a second fetch start next to an operator's (the
+# herd's shape). Every way Dolt lets the call be written — bare `CALL
+# DOLT_FETCH`, `CALL\`dolt_fetch\`()`, comments or whitespace between tokens,
+# a backticked or qualified name — carries the identifier, and DOLT_PUSH,
+# DOLT_FETCHX, CALLDOLT_FETCH, dolt_fetch_log, my_dolt_fetch do not. The
+# pre-check and health queries carry `DOLT_(FETCH|PULL)` in their own text
+# and do not match themselves. Verified on Dolt 2.1.10 (evidence 04f): 15
+# spellings hit, 6 decoys miss, 2 mentions-in-text hit by design, no
+# self-match, and a live bare `CALL DOLT_FETCH` is listed and killable.
+REMOTE_OP_INFO_REGEXP='(^|[^A-Z0-9_])DOLT_(FETCH|PULL)([^A-Z0-9_]|$)'
 
 remote_op_sessions_sql() {
   _ros_q="SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE UPPER(Info) REGEXP '$REMOTE_OP_INFO_REGEXP'"

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -345,7 +345,7 @@ dolt_sql_csv() {
 # skipped run for a database while another's remote operation runs on the
 # same server (the pack's own runs are sequential within a run and serialized
 # across runs by the per-database server lock, so this bites only a
-# concurrent operator or an abandoned session, which health names). The db
+# concurrent operator or an abandoned session, which health counts). The db
 # column is still selected, validated as one CSV field, and not used.
 # REMOTE_OP_INFO_REGEXP — the SQL REGEXP (applied to UPPER(Info)) that decides
 # "a remote operation is in flight": ANY statement that names DOLT_FETCH or
@@ -486,8 +486,9 @@ remote_op_session_id() {
 # (a record from before the id came from the gate statement, a server that
 # restarted and reused the number) is reported NOT killed and named for the
 # operator — that session holds the database's lock, so every later run is
-# refused by the server gate until it ends or is KILLed by hand, and gc dolt
-# health names it. A holder answer that cannot be read refuses to confirm
+# refused by the server gate until it ends or is KILLed by hand (gc dolt
+# health counts remote-operation sessions and their age, never ids — codex
+# round-2 r4 — so the lines carry the id). A holder answer that cannot be read refuses to confirm
 # (1): an unknown holder is never "free". LABEL names the operation in the
 # lines ("fetch" / "pull"); every line goes to stderr next to the timeout
 # line it resolves.
@@ -541,7 +542,7 @@ kill_remote_op_session() {
   if [ -z "$_kr_ids" ]; then
     _kr_listed=$(printf '%s\n' "$_kr_left" | awk '{ printf "%s%s", sep, $1; sep = " " }')
     if [ "$_kr_holder" != 0 ]; then
-      echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and session $_kr_holder holds this run's lock ($_kr_runlock) — the session that passed this run's gate, its answer lost with the client; it runs no remote operation, so gc dolt health does not name it — left for the operator (KILL $_kr_holder)" >&2
+      echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and session $_kr_holder holds this run's lock ($_kr_runlock) — the session that passed this run's gate, its answer lost with the client; it runs no remote operation — left for the operator (KILL $_kr_holder)" >&2
       return 1
     fi
     if [ -z "$_kr_listed" ]; then
@@ -554,7 +555,7 @@ kill_remote_op_session() {
       echo "  $_kr_db: server-side $_kr_label cleanup NOT confirmed: this client never learned its session id (the gate's answer never arrived) and this run's lock ($_kr_runlock) reads free — the gate never reached the server, or is still pending and could take the lock after this read; nothing killed — a later run the gate refuses names the lock to KILL the holder of" >&2
       return 1
     fi
-    echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and ownership of the in-flight remote operation(s) on the server (Id $_kr_listed) cannot be proven — left for the operator (KILL <Id>); gc dolt health names them" >&2
+    echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and ownership of the in-flight remote operation(s) on the server (Id $_kr_listed) cannot be proven — left for the operator (KILL <Id>); gc dolt health counts them" >&2
     return 1
   fi
   _kr_left_ids=" $(printf '%s\n' "$_kr_left" | awk '{ printf "%s ", $1 }')"
@@ -580,10 +581,10 @@ kill_remote_op_session() {
         # gate and the CALL, and the KILL did not take — codex round-2 r1), or
         # another session may hold it (see the helper comment).
         if [ "$_kr_holder" = "$_kr_one" ]; then
-          echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one still holds this run's lock ($_kr_runlock) after the KILL — not listed as a remote operation (idle, or between the gate and the CALL), so gc dolt health does not name it — left for the operator (KILL $_kr_one)" >&2
+          echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one still holds this run's lock ($_kr_runlock) after the KILL — not listed as a remote operation (idle, or between the gate and the CALL) — left for the operator (KILL $_kr_one)" >&2
           _kr_rc=1
         elif [ "$_kr_holder" != 0 ]; then
-          echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one is gone but session $_kr_holder holds this run's lock ($_kr_runlock) — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number); gc dolt health names it only while it runs a remote operation — left for the operator (KILL $_kr_holder)" >&2
+          echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one is gone but session $_kr_holder holds this run's lock ($_kr_runlock) — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number) — left for the operator (KILL $_kr_holder)" >&2
           _kr_rc=1
         elif [ "$_kr_was_guarded" -eq 1 ]; then
           echo "  $_kr_db: server-side $_kr_label already ended (session $_kr_one is gone; nothing killed)" >&2

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -384,7 +384,11 @@ remote_op_sessions_sql() {
 # exactly ONE CSV field — unquoted without a comma or a quote, or quoted with
 # doubled inner quotes — so a row with an extra column (`42,60,app,extra`) or
 # a stray quote is refused rather than read as "another database" (codex r7).
-# Returns 1 when the first line is not
+# A revision-qualified attribution (`app/main`, `app/<commit>`: a client that
+# connected with --use-db app/main or ran USE app/main — Dolt's branch-qualified
+# database name, which no plain database can carry since Dolt reserves `/`)
+# is this database's: the `/revision` suffix is stripped before the compare
+# (codex r8, evidence 04h). Returns 1 when the first line is not
 # the `Id,Time,db` header (an empty stdout, a banner or an error text is NOT a
 # processlist answer), 2 when a non-blank row does not START with an unquoted
 # all-digit Id and Time (`12,34,…`): a NULL, a truncated line, a wrapper's
@@ -410,6 +414,7 @@ remote_op_sessions_parse() {
         have = substr(have, 2, length(have) - 2)
         gsub(/""/, "\"", have)
       } else if (have !~ /^[^",]*$/) { bad = 1; exit 2 }
+      sub(/\/.*$/, "", have)
       if (want != "" && have != "" && tolower(have) != want) next
       print $1, $2
     }
@@ -588,7 +593,17 @@ remote_op_gate_sql() {
 }
 
 # remote_op_gate_refused STDERR_FILE — true when the captured dolt stderr says
-# the gate refused: another session holds this database's lock.
+# the gate refused: another session holds this database's lock. The refusal is
+# Dolt's Error 3141 with the marker echoed as json_extract's argument, in
+# double quotes: `… Error 3141 (HY000): Invalid JSON text in argument 1 to
+# function json_extract: "gc-remote-op-lock-held"` (Dolt 2.1.10, evidence 04c).
+# The marker ALONE is not enough: the CLI echoes the failing statement in every
+# batch diagnostic (`error on line 1 for query …`), so an ordinary error on a
+# statement whose text carries the marker — the gate statement itself failing
+# for another reason, or a remote literally named gc-remote-op-lock-held — must
+# not read as "refused" and hide the real error (codex r8). A future Dolt that
+# words 3141 differently falls to the ordinary-error branch: the run still
+# skips with the error replayed and nothing is pushed — the safe side.
 remote_op_gate_refused() {
-  grep -q "$REMOTE_OP_GATE_MARK" "$1" 2>/dev/null
+  grep -Eq "Error 3141 .*\"$REMOTE_OP_GATE_MARK\"" "$1" 2>/dev/null
 }

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -510,10 +510,12 @@ kill_remote_op_session() {
   _kr_guarded=""
   for _kr_one in $_kr_ids; do
     _kr_krc=0
-    # One batch: the KILL runs only while <id> still holds THIS run's lock;
-    # otherwise the batch stops before it (a restarted server may have handed
-    # the number to someone else — see the gate comment above).
-    _kr_kerr=$(dolt_sql_csv "$_kr_tmo" "" "SELECT IF(IS_USED_LOCK('$_kr_runlock') = $_kr_one, 1, JSON_EXTRACT('$REMOTE_OP_NOT_OWNER_MARK', '\$')) AS own; KILL $_kr_one" 2>&1 >/dev/null) || _kr_krc=$?
+    # One batch: the KILL is prepared first (a session-local handle), then
+    # runs only while <id> still holds THIS run's lock; otherwise the batch
+    # stops at the guard (a restarted server may have handed the number to
+    # someone else), and a client that reconnected between the guard and the
+    # EXECUTE has no handle to execute — see the gate comment above.
+    _kr_kerr=$(dolt_sql_csv "$_kr_tmo" "" "PREPARE gc_kill FROM 'KILL $_kr_one'; SELECT IF(IS_USED_LOCK('$_kr_runlock') = $_kr_one, 1, JSON_EXTRACT('$REMOTE_OP_NOT_OWNER_MARK', '\$')) AS own; EXECUTE gc_kill; DEALLOCATE PREPARE gc_kill" 2>&1 >/dev/null) || _kr_krc=$?
     if [ "$_kr_krc" -ne 0 ]; then
       case "$_kr_kerr" in
         *"Error 3141 "*"\"$REMOTE_OP_NOT_OWNER_MARK\""*) _kr_guarded="$_kr_guarded $_kr_one " ;;
@@ -611,22 +613,43 @@ bound_expired() {
 #     reconnected between the gate and the CALL, and the fresh session took
 #     no lock — raises Error 3141 with "gc-remote-op-lost" BEFORE the
 #     procedure runs (04i b) and a session that holds it fetches (04i c);
-#   - the KILL is `SELECT IF(IS_USED_LOCK('<run lock>') = <id>, 1,
-#     JSON_EXTRACT('gc-remote-op-not-owner', '$')) AS own; KILL <id>` in ONE
-#     batch: the id printed by our statement proves ownership only within the
-#     server lifetime that issued it (a restarted server hands the same
-#     numbers out again), so the KILL runs only while that id still holds
-#     this run's lock; otherwise the batch stops before the KILL (04i e1, e3)
-#     and the processlist read after says whether the session is gone
-#     (already ended) or someone else's (NOT killed, left for the operator).
+#   - the KILL is ONE batch: `PREPARE gc_kill FROM 'KILL <id>'; SELECT
+#     IF(IS_USED_LOCK('<run lock>') = <id>, 1, JSON_EXTRACT(
+#     'gc-remote-op-not-owner', '$')) AS own; EXECUTE gc_kill; DEALLOCATE
+#     PREPARE gc_kill`. The id printed by our statement proves ownership only
+#     within the server lifetime that issued it (a restarted server hands the
+#     same numbers out again), so the KILL runs only while that id still
+#     holds this run's lock; otherwise the batch stops at the guard (04i e1,
+#     e3; 04k2 b) and the processlist read after says whether the session is
+#     gone (already ended) or someone else's (NOT killed, left for the
+#     operator). KILL takes only a literal (04k a–c), so the check cannot sit
+#     inside it; the prepared handle closes the window between the check and
+#     the KILL instead (codex r13): it is session-local, so a client that
+#     reconnected in between lands on a session with no handle and EXECUTE
+#     fails ("Unknown prepared statement handler", 04k d2) — the KILL never
+#     runs on a session that did not pass the check (04k2 a: the true path).
+#   - the run nonce is 64 random bits from /dev/urandom (16 hex), never the
+#     pid or the clock: two hosts starting a runner in the same second with
+#     the same pid must not share a run lock (codex r13). Without
+#     /dev/urandom the nonce falls back to pid-epoch.
 REMOTE_OP_GATE_MARK='gc-remote-op-lock-held'
 REMOTE_OP_LOST_MARK='gc-remote-op-lost'
 REMOTE_OP_NOT_OWNER_MARK='gc-remote-op-not-owner'
 # REMOTE_OP_RUN_NONCE is set by the scripts that take locks (sync, pull) once
-# per run, after sourcing this file: `REMOTE_OP_RUN_NONCE="$$-$(date +%s)"`.
+# per run, after sourcing this file: `REMOTE_OP_RUN_NONCE=$(remote_op_new_run_nonce)`.
 # Not computed here: health sources this file too and must not spend a `date`
 # call at source time (its tests script the date sequence).
 REMOTE_OP_RUN_NONCE="${REMOTE_OP_RUN_NONCE:-}"
+
+# remote_op_new_run_nonce — a fresh run nonce: 16 hex digits from
+# /dev/urandom, or pid-epoch when the device is unavailable.
+remote_op_new_run_nonce() {
+  _rn=$(od -An -N8 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')
+  case "$_rn" in
+    ????????????????) printf '%s' "$_rn" ;;
+    *) printf '%s-%s' "$$" "$(date +%s)" ;;
+  esac
+}
 
 # remote_op_lock_name DB — the user-level lock name for DB, `gc_remote_op:<db>`
 # with the name lowercased: Dolt resolves `app` and `APP` to one database, and

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -333,15 +333,19 @@ dolt_sql_csv() {
 # (`dolt_fetch` and `team-dolt_pull-prod` are valid names; the previous shape
 # interpolated LOWER('<db>') and would have listed itself on every run of such
 # a store — codex r6, evidence 04g), and two probes running at once cannot
-# count each other. The per-database filter is applied on the ANSWER by
-# remote_op_sessions_parse: the sessions attributed to that database PLUS the
-# sessions attributed to no database at all — an unattributed fetch (issued
-# without --use-db: an older gc dolt sync, or an operator) may be this
-# database's, so it counts, fail closed. Database names compare
-# case-insensitively (Dolt resolves `app` and `APP` to one database; the
-# processlist shows whichever spelling the client used; the pack's own names
-# are ASCII by valid_database_name). Without a DB filter: every such session
-# on the server (the health probe).
+# count each other. There is NO per-database filter: the processlist DB column
+# is the connection's --use-db, not the statement's target — a client on
+# `--use-db other` running `USE app; CALL DOLT_FETCH(...)` is attributed to
+# `other` (codex r9; a USE inside the batch does not change the column,
+# evidence 04h b) — so attribution proves nothing about which database a
+# fetch touches, and an operand the adversary can move is not one to filter
+# on. Every DOLT_FETCH / DOLT_PULL in flight anywhere on the server blocks
+# every database's fetch and pull for that run, fail closed; the cost is one
+# skipped run for a database while another's remote operation runs on the
+# same server (the pack's own runs are sequential within a run and serialized
+# across runs by the per-database server lock, so this bites only a
+# concurrent operator or an abandoned session, which health names). The db
+# column is still selected, validated as one CSV field, and not used.
 # REMOTE_OP_INFO_REGEXP — the SQL REGEXP (applied to UPPER(Info)) that decides
 # "a remote operation is in flight": ANY statement that names DOLT_FETCH or
 # DOLT_PULL as a whole identifier (a non-identifier character or the string's
@@ -376,19 +380,12 @@ remote_op_sessions_sql() {
   printf "SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE UPPER(Info) REGEXP '%s' ORDER BY Time DESC, Id ASC" "$REMOTE_OP_INFO_REGEXP"
 }
 
-# remote_op_sessions_parse [DB] — stdin: the CSV answer to
-# remote_op_sessions_sql; stdout: one `Id Time` line per session attributed to
-# DB (case-insensitively) or to no database, every session when DB is empty.
-# Every row is checked for shape BEFORE the filter, so a malformed row for
-# another database still refuses the whole answer; the db column must be
+# remote_op_sessions_parse — stdin: the CSV answer to remote_op_sessions_sql;
+# stdout: one `Id Time` line per session — every session, no filter (above).
+# Every row is checked for shape: Id and Time all-digit, and the db column
 # exactly ONE CSV field — unquoted without a comma or a quote, or quoted with
 # doubled inner quotes — so a row with an extra column (`42,60,app,extra`) or
-# a stray quote is refused rather than read as "another database" (codex r7).
-# A revision-qualified attribution (`app/main`, `app/<commit>`: a client that
-# connected with --use-db app/main or ran USE app/main — Dolt's branch-qualified
-# database name, which no plain database can carry since Dolt reserves `/`)
-# is this database's: the `/revision` suffix is stripped before the compare
-# (codex r8, evidence 04h). Returns 1 when the first line is not
+# a stray quote refuses the whole answer (codex r7). Returns 1 when the first line is not
 # the `Id,Time,db` header (an empty stdout, a banner or an error text is NOT a
 # processlist answer), 2 when a non-blank row does not START with an unquoted
 # all-digit Id and Time (`12,34,…`): a NULL, a truncated line, a wrapper's
@@ -397,7 +394,7 @@ remote_op_sessions_sql() {
 # malformed row is a session whose state is unknown, so the whole answer is
 # refused, fail closed.
 remote_op_sessions_parse() {
-  awk -F, -v want="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" '
+  awk -F, '
     NR == 1 {
       hdr = $0
       gsub(/"|\r/, "", hdr)
@@ -414,8 +411,6 @@ remote_op_sessions_parse() {
         have = substr(have, 2, length(have) - 2)
         gsub(/""/, "\"", have)
       } else if (have !~ /^[^",]*$/) { bad = 1; exit 2 }
-      sub(/\/.*$/, "", have)
-      if (want != "" && have != "" && tolower(have) != want) next
       print $1, $2
     }
     END { if (NR == 0) exit 1; if (bad) exit 2 }
@@ -423,8 +418,9 @@ remote_op_sessions_parse() {
 }
 
 # remote_op_sessions DB TIMEOUT_SECS STDERR_FILE — list the in-flight remote
-# operations (the constant remote_op_sessions_sql, filtered to DB by
-# remote_op_sessions_parse; DB may be empty for server-wide) as
+# operations (the constant remote_op_sessions_sql; DB is kept for the callers'
+# symmetry and NOT used — every in-flight remote operation on the server is
+# listed, see remote_op_sessions_sql) as
 # `Id Time` lines on stdout. Returns 0 on a processlist answer (possibly with
 # no rows); otherwise the query's exit code (124 = the bound expired), or 1
 # when the answer was not a processlist, with the reason appended to
@@ -436,7 +432,7 @@ remote_op_sessions() {
   _rs_rc=0
   _rs_csv=$(dolt_sql_csv "$_rs_tmo" "" "$(remote_op_sessions_sql)" 2>>"$_rs_errf") || _rs_rc=$?
   [ "$_rs_rc" -eq 0 ] || return "$_rs_rc"
-  _rs_rows=$(printf '%s\n' "$_rs_csv" | remote_op_sessions_parse "$_rs_db") || {
+  _rs_rows=$(printf '%s\n' "$_rs_csv" | remote_op_sessions_parse) || {
     _rs_prc=$?
     if [ "$_rs_prc" -eq 2 ]; then
       printf 'malformed processlist row (Id or Time not all-digit, or the db column not one CSV field) — refusing the whole answer\n' >>"$_rs_errf"
@@ -468,9 +464,9 @@ remote_op_session_id() {
 # printed about itself before the procedure started: the session is ours by
 # construction. An empty SESSION_ID (the client died before the server
 # answered) kills NOTHING: absence from the earlier processlist read does not
-# prove that a session listed now is ours (an operator's unattributed pull
-# for another database can appear in the same window), so the in-flight
-# sessions attributed to DB are reported for the operator and 1 is returned;
+# prove that a session listed now is ours (an operator's pull can appear in
+# the same window), so the in-flight remote operations on the server are
+# reported for the operator and 1 is returned;
 # a session of ours that does exist holds the database's lock, so every later
 # run is refused by the server gate until it ends or is KILLed by hand, and
 # gc dolt health names it. The verdict for a known id is the processlist read
@@ -504,7 +500,7 @@ kill_remote_op_session() {
       echo "  $_kr_db: server-side $_kr_label already ended (nothing in flight to kill)" >&2
       return 0
     fi
-    echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and ownership of the in-flight session(s) attributed to $_kr_db (Id $_kr_listed) cannot be proven — left for the operator (KILL <Id>); gc dolt health names them" >&2
+    echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and ownership of the in-flight remote operation(s) on the server (Id $_kr_listed) cannot be proven — left for the operator (KILL <Id>); gc dolt health names them" >&2
     return 1
   fi
   for _kr_one in $_kr_ids; do

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -468,11 +468,15 @@ remote_op_session_id() {
 # expired, and PROVE it ended. SESSION_ID is the connection id the gate
 # statement printed about itself in the SAME statement that took this
 # database's lock and this run's lock: the session is ours, and the lock
-# holder, by construction. An empty SESSION_ID (the client died before the
-# server answered the gate) kills NOTHING: absence from the earlier
-# processlist read does not prove that a session listed now is ours (an
-# operator's pull can appear in the same window), so the in-flight remote
-# operations on the server are reported for the operator and 1 is returned.
+# holder, by construction. An empty SESSION_ID (the gate's answer never
+# reached the client) kills NOTHING and never confirms the cleanup (1):
+# absence from the earlier processlist read does not prove that a session
+# listed now is ours (an operator's pull can appear in the same window), so
+# in-flight remote operations are reported for the operator; and with the id
+# inside the gate, no id no longer proves the gate never ran — a gate still
+# pending on the server takes this run's lock after any "free" read (codex
+# round-2 r3), and a session lock cannot fence it (it lives only as long as
+# the helper's own session).
 # The verdict for a known id is the processlist read AFTER the KILL, never
 # KILL's own exit code: a session still listed is reported as NOT killed and
 # returns 1. Then, on every path, who holds THIS run's lock is read
@@ -541,8 +545,14 @@ kill_remote_op_session() {
       return 1
     fi
     if [ -z "$_kr_listed" ]; then
-      echo "  $_kr_db: server-side $_kr_label already ended (nothing in flight to kill)" >&2
-      return 0
+      # Nothing listed and the lock reads free — but the gate's answer never
+      # arrived, and with the id inside the gate that no longer proves the
+      # gate never ran: a gate still pending on the server takes this run's
+      # lock AFTER this read (codex round-2 r3). Nothing here can fence it
+      # (a session lock lives only as long as the helper's own session), so
+      # the cleanup is never confirmed without an id.
+      echo "  $_kr_db: server-side $_kr_label cleanup NOT confirmed: this client never learned its session id (the gate's answer never arrived) and this run's lock ($_kr_runlock) reads free — the gate never reached the server, or is still pending and could take the lock after this read; nothing killed — a later run the gate refuses names the lock to KILL the holder of" >&2
+      return 1
     fi
     echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and ownership of the in-flight remote operation(s) on the server (Id $_kr_listed) cannot be proven — left for the operator (KILL <Id>); gc dolt health names them" >&2
     return 1
@@ -573,7 +583,7 @@ kill_remote_op_session() {
           echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one still holds this run's lock ($_kr_runlock) after the KILL — not listed as a remote operation (idle, or between the gate and the CALL), so gc dolt health does not name it — left for the operator (KILL $_kr_one)" >&2
           _kr_rc=1
         elif [ "$_kr_holder" != 0 ]; then
-          echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one is gone but session $_kr_holder holds this run's lock ($_kr_runlock) — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number) — left for the operator (KILL $_kr_holder); gc dolt health names it" >&2
+          echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one is gone but session $_kr_holder holds this run's lock ($_kr_runlock) — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number); gc dolt health names it only while it runs a remote operation — left for the operator (KILL $_kr_holder)" >&2
           _kr_rc=1
         elif [ "$_kr_was_guarded" -eq 1 ]; then
           echo "  $_kr_db: server-side $_kr_label already ended (session $_kr_one is gone; nothing killed)" >&2

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -564,7 +564,15 @@ kill_remote_op_session() {
         _kr_rc=1
         ;;
       *)
-        if [ "$_kr_holder" != 0 ]; then
+        # Not listed as a remote operation. That is "gone" only when this
+        # run's lock is free: the recorded id may still hold it while running
+        # no DOLT_FETCH/DOLT_PULL statement (the bound expired between the
+        # gate and the CALL, and the KILL did not take — codex round-2 r1), or
+        # another session may hold it (see the helper comment).
+        if [ "$_kr_holder" = "$_kr_one" ]; then
+          echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one still holds this run's lock ($_kr_runlock) after the KILL — not listed as a remote operation (idle, or between the gate and the CALL), so gc dolt health does not name it — left for the operator (KILL $_kr_one)" >&2
+          _kr_rc=1
+        elif [ "$_kr_holder" != 0 ]; then
           echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one is gone but session $_kr_holder holds this run's lock ($_kr_runlock) — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number) — left for the operator (KILL $_kr_holder); gc dolt health names it" >&2
           _kr_rc=1
         elif [ "$_kr_was_guarded" -eq 1 ]; then

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -299,9 +299,10 @@ PY
 #     statement text). A session whose client died stays listed.
 #   - The DB column is the connection's database as set by the CLI's
 #     --use-db; a `USE` statement inside the query does NOT set it.
-#   - The CLI prints each statement's result before running the next, so a
-#     `SELECT CONNECTION_ID()` issued just before the procedure lands on
-#     stdout before the fetch starts and survives the client's death.
+#   - The CLI prints each statement's result before running the next, so the
+#     gate statement's answer — the session's own CONNECTION_ID(), printed by
+#     the statement that took the locks — lands on stdout before the fetch
+#     starts and survives the client's death.
 #   - `KILL <id>` exits 0 with no text whether or not <id> exists, so the
 #     proof that a session ended is the processlist read AFTER the KILL.
 
@@ -453,9 +454,10 @@ remote_op_sessions_oldest() {
   awk 'NF == 2 && ($2 + 0) >= (m + 0) { m = $2; l = $0 } END { if (l != "") print l }'
 }
 
-# remote_op_session_id FILE — the connection id that a `SELECT CONNECTION_ID()
-# AS id` printed into FILE (the all-digit line right after the `id` header);
-# nothing when the client died before the server answered.
+# remote_op_session_id FILE — the connection id that the gate statement
+# (remote_op_gate_sql, `… CONNECTION_ID() … AS id`) printed into FILE when it
+# took both locks (the all-digit line right after the `id` header); nothing
+# when the gate refused or the client died before the server answered.
 remote_op_session_id() {
   [ -f "$1" ] || return 0
   awk '{ gsub(/\r/, "") } prev == "id" && $0 ~ /^[0-9]+$/ { print; exit } { prev = $0 }' "$1"
@@ -463,18 +465,26 @@ remote_op_session_id() {
 
 # kill_remote_op_session LABEL DB SESSION_ID [TIMEOUT_SECS] — end the
 # server-side DOLT_FETCH / DOLT_PULL this client abandoned when its bound
-# expired, and PROVE it ended. SESSION_ID is the connection id the statement
-# printed about itself before the procedure started: the session is ours by
-# construction. An empty SESSION_ID (the client died before the server
-# answered) kills NOTHING: absence from the earlier processlist read does not
-# prove that a session listed now is ours (an operator's pull can appear in
-# the same window), so the in-flight remote operations on the server are
-# reported for the operator and 1 is returned;
-# a session of ours that does exist holds the database's lock, so every later
-# run is refused by the server gate until it ends or is KILLed by hand, and
-# gc dolt health names it. The verdict for a known id is the processlist read
-# AFTER the KILL, never KILL's own exit code: a session still listed is
-# reported as NOT killed and returns 1. LABEL names the operation in the
+# expired, and PROVE it ended. SESSION_ID is the connection id the gate
+# statement printed about itself in the SAME statement that took this
+# database's lock and this run's lock: the session is ours, and the lock
+# holder, by construction. An empty SESSION_ID (the client died before the
+# server answered the gate) kills NOTHING: absence from the earlier
+# processlist read does not prove that a session listed now is ours (an
+# operator's pull can appear in the same window), so the in-flight remote
+# operations on the server are reported for the operator and 1 is returned.
+# The verdict for a known id is the processlist read AFTER the KILL, never
+# KILL's own exit code: a session still listed is reported as NOT killed and
+# returns 1. Then, on every path, who holds THIS run's lock is read
+# (remote_op_run_lock_holder) and the helper never returns 0 while any
+# session holds it: a guarded id that is gone means the session ended on its
+# own ONLY when the lock is free; a live holder other than the recorded id
+# (a record from before the id came from the gate statement, a server that
+# restarted and reused the number) is reported NOT killed and named for the
+# operator — that session holds the database's lock, so every later run is
+# refused by the server gate until it ends or is KILLed by hand, and gc dolt
+# health names it. A holder answer that cannot be read refuses to confirm
+# (1): an unknown holder is never "free". LABEL names the operation in the
 # lines ("fetch" / "pull"); every line goes to stderr next to the timeout
 # line it resolves.
 kill_remote_op_session() {
@@ -490,22 +500,6 @@ kill_remote_op_session() {
     echo "  $_kr_db: server-side $_kr_label NOT killed: cannot create temp file for processlist diagnostics" >&2
     return 1
   }
-  if [ -z "$_kr_ids" ]; then
-    _kr_rows=$(remote_op_sessions "$_kr_db" "$_kr_tmo" "$_kr_errf") || {
-      echo "  $_kr_db: server-side $_kr_label NOT killed: session id unknown and the processlist query failed" >&2
-      remote_op_replay_stderr "$_kr_db" "$_kr_errf"
-      rm -f "$_kr_errf"
-      return 1
-    }
-    _kr_listed=$(printf '%s\n' "$_kr_rows" | awk '{ printf "%s%s", sep, $1; sep = " " }')
-    rm -f "$_kr_errf"
-    if [ -z "$_kr_listed" ]; then
-      echo "  $_kr_db: server-side $_kr_label already ended (nothing in flight to kill)" >&2
-      return 0
-    fi
-    echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and ownership of the in-flight remote operation(s) on the server (Id $_kr_listed) cannot be proven — left for the operator (KILL <Id>); gc dolt health names them" >&2
-    return 1
-  fi
   _kr_runlock=$(remote_op_run_lock_name "$_kr_db")
   _kr_guarded=""
   for _kr_one in $_kr_ids; do
@@ -524,37 +518,60 @@ kill_remote_op_session() {
     fi
   done
   _kr_left=$(remote_op_sessions "$_kr_db" "$_kr_tmo" "$_kr_errf") || {
-    echo "  $_kr_db: server-side $_kr_label kill NOT confirmed: the processlist query failed after KILL" >&2
+    if [ -z "$_kr_ids" ]; then
+      echo "  $_kr_db: server-side $_kr_label NOT killed: session id unknown and the processlist query failed" >&2
+    else
+      echo "  $_kr_db: server-side $_kr_label kill NOT confirmed: the processlist query failed after KILL" >&2
+    fi
+    remote_op_replay_stderr "$_kr_db" "$_kr_errf"
+    rm -f "$_kr_errf"
+    return 1
+  }
+  _kr_holder=$(remote_op_run_lock_holder "$_kr_db" "$_kr_tmo" "$_kr_errf") || {
+    echo "  $_kr_db: server-side $_kr_label kill NOT confirmed: the run-lock holder query failed ($_kr_runlock)" >&2
     remote_op_replay_stderr "$_kr_db" "$_kr_errf"
     rm -f "$_kr_errf"
     return 1
   }
   rm -f "$_kr_errf"
+  if [ -z "$_kr_ids" ]; then
+    _kr_listed=$(printf '%s\n' "$_kr_left" | awk '{ printf "%s%s", sep, $1; sep = " " }')
+    if [ "$_kr_holder" != 0 ]; then
+      echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and session $_kr_holder holds this run's lock ($_kr_runlock) — the session that passed this run's gate, its answer lost with the client — left for the operator (KILL $_kr_holder); gc dolt health names it" >&2
+      return 1
+    fi
+    if [ -z "$_kr_listed" ]; then
+      echo "  $_kr_db: server-side $_kr_label already ended (nothing in flight to kill)" >&2
+      return 0
+    fi
+    echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and ownership of the in-flight remote operation(s) on the server (Id $_kr_listed) cannot be proven — left for the operator (KILL <Id>); gc dolt health names them" >&2
+    return 1
+  fi
   _kr_left_ids=" $(printf '%s\n' "$_kr_left" | awk '{ printf "%s ", $1 }')"
   _kr_rc=0
   for _kr_one in $_kr_ids; do
     case "$_kr_guarded" in
+      *" $_kr_one "*) _kr_was_guarded=1 ;;
+      *) _kr_was_guarded=0 ;;
+    esac
+    case "$_kr_left_ids" in
       *" $_kr_one "*)
-        case "$_kr_left_ids" in
-          *" $_kr_one "*)
-            echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one does not hold this run's lock ($_kr_runlock) — the server restarted and reused the id, or it is another runner's — left for the operator (KILL <Id>)" >&2
-            _kr_rc=1
-            ;;
-          *)
-            echo "  $_kr_db: server-side $_kr_label already ended (session $_kr_one is gone; nothing killed)" >&2
-            ;;
-        esac
+        if [ "$_kr_was_guarded" -eq 1 ]; then
+          echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one does not hold this run's lock ($_kr_runlock) — the server restarted and reused the id, or it is another runner's — left for the operator (KILL <Id>)" >&2
+        else
+          echo "  $_kr_db: server-side $_kr_label NOT killed (session $_kr_one still in flight after KILL)" >&2
+        fi
+        _kr_rc=1
         ;;
       *)
-        case "$_kr_left_ids" in
-          *" $_kr_one "*)
-            echo "  $_kr_db: server-side $_kr_label NOT killed (session $_kr_one still in flight after KILL)" >&2
-            _kr_rc=1
-            ;;
-          *)
-            echo "  $_kr_db: server-side $_kr_label killed (session $_kr_one no longer in flight)" >&2
-            ;;
-        esac
+        if [ "$_kr_holder" != 0 ]; then
+          echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one is gone but session $_kr_holder holds this run's lock ($_kr_runlock) — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number) — left for the operator (KILL $_kr_holder); gc dolt health names it" >&2
+          _kr_rc=1
+        elif [ "$_kr_was_guarded" -eq 1 ]; then
+          echo "  $_kr_db: server-side $_kr_label already ended (session $_kr_one is gone; nothing killed)" >&2
+        else
+          echo "  $_kr_db: server-side $_kr_label killed (session $_kr_one no longer in flight)" >&2
+        fi
         ;;
     esac
   done
@@ -604,8 +621,11 @@ bound_expired() {
 #
 # Ownership is re-proven INSIDE the statements that matter (codex r12,
 # evidence 04i). The gate takes a second, per-run lock,
-# `gc_remote_op_run:<db>:<nonce>` (REMOTE_OP_RUN_NONCE = pid-epoch of this
-# script run), and:
+# `gc_remote_op_run:<db>:<nonce>` (REMOTE_OP_RUN_NONCE = 16 random hex digits
+# per script run), answers with the session's own CONNECTION_ID() in that
+# same statement when both locks are taken (the mayor's gate r1: the id the
+# bound's KILL targets is the lock holder by construction, never a session a
+# separate statement saw before a reconnect), and:
 #   - the CALL's first argument is `IF(IS_USED_LOCK('<run lock>') =
 #     CONNECTION_ID(), '<remote>', JSON_EXTRACT('gc-remote-op-lost', '$'))`:
 #     Dolt evaluates expressions in CALL arguments (04i a), so a session that
@@ -616,13 +636,17 @@ bound_expired() {
 #   - the KILL is ONE batch: `PREPARE gc_kill FROM 'KILL <id>'; SELECT
 #     IF(IS_USED_LOCK('<run lock>') = <id>, 1, JSON_EXTRACT(
 #     'gc-remote-op-not-owner', '$')) AS own; EXECUTE gc_kill; DEALLOCATE
-#     PREPARE gc_kill`. The id printed by our statement proves ownership only
+#     PREPARE gc_kill`. The id printed by our gate proves ownership only
 #     within the server lifetime that issued it (a restarted server hands the
 #     same numbers out again), so the KILL runs only while that id still
 #     holds this run's lock; otherwise the batch stops at the guard (04i e1,
 #     e3; 04k2 b) and the processlist read after says whether the session is
-#     gone (already ended) or someone else's (NOT killed, left for the
-#     operator). KILL takes only a literal (04k a–c), so the check cannot sit
+#     still listed (NOT killed, left for the operator) or gone — and gone is
+#     "already ended" only when a read of IS_USED_LOCK on this run's lock,
+#     after the KILL attempt, answers free: a live holder other than the
+#     recorded id is NOT killed and named for the operator (the mayor's gate
+#     r1; the helper never returns 0 while any session holds this run's
+#     lock). KILL takes only a literal (04k a–c), so the check cannot sit
 #     inside it; the prepared handle closes the window between the check and
 #     the KILL instead (codex r13): it is session-local, so a client that
 #     reconnected in between lands on a session with no handle and EXECUTE
@@ -675,9 +699,43 @@ remote_op_run_lock_name() {
 
 # remote_op_gate_sql DB — the gate statement for DB (DB already validated by
 # the caller before it is interpolated): the database lock AND this run's
-# lock, both session-scoped, or the marked error.
+# lock, both session-scoped, or the marked error. When both locks are taken
+# the statement answers with the session's OWN connection id (`id` column):
+# the id the bound's KILL targets and the locks are ONE statement, so the
+# recorded id is the lock holder by construction — a separate `SELECT
+# CONNECTION_ID()` before the gate recorded whatever session the pooled
+# client had at that moment, and a reconnect between the two statements left
+# the timeout path killing (and reporting gone) a session that never held the
+# locks while the reconnected one fetched on with both (the mayor's codex
+# gate r1 on aphexcx/gascity#16).
 remote_op_gate_sql() {
-  printf "SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('%s')), 0) = 1 AND GET_LOCK('%s', 0) = 1, 1, JSON_EXTRACT('%s', '\$')) AS gate" "$1" "$(remote_op_run_lock_name "$1")" "$REMOTE_OP_GATE_MARK"
+  printf "SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('%s')), 0) = 1 AND GET_LOCK('%s', 0) = 1, CONNECTION_ID(), JSON_EXTRACT('%s', '\$')) AS id" "$1" "$(remote_op_run_lock_name "$1")" "$REMOTE_OP_GATE_MARK"
+}
+
+# remote_op_run_lock_holder_sql DB — who holds this run's lock for DB: the
+# holder's connection id, or 0 when the lock is free (IS_USED_LOCK answers
+# NULL for a free lock, which the CSV prints as an empty field; 0 is never a
+# connection id, so the answer is always one all-digit row).
+remote_op_run_lock_holder_sql() {
+  printf "SELECT COALESCE(IS_USED_LOCK('%s'), 0) AS holder" "$(remote_op_run_lock_name "$1")"
+}
+
+# remote_op_run_lock_holder DB TIMEOUT_SECS STDERR_FILE — stdout: the
+# connection id holding this run's lock for DB, or 0 when it is free. Returns
+# the query's exit code, or 1 when the answer is not a holder answer (no
+# `holder` header, or not exactly one all-digit row after it), with the reason
+# appended to STDERR_FILE for the caller to replay. Fail closed on every
+# non-zero return: an unknown holder is never "free".
+remote_op_run_lock_holder() {
+  _rh_rc=0
+  _rh_csv=$(dolt_sql_csv "$2" "" "$(remote_op_run_lock_holder_sql "$1")" 2>>"$3") || _rh_rc=$?
+  [ "$_rh_rc" -eq 0 ] || return "$_rh_rc"
+  _rh_val=$(printf '%s\n' "$_rh_csv" | awk '{ gsub(/\r/, "") } NR == 1 && $0 == "holder" { ok = 1; next } NR == 2 && ok && $0 ~ /^[0-9]+$/ { v = $0; next } { bad = 1 } END { if (ok && !bad && v != "") print v }')
+  if [ -z "$_rh_val" ]; then
+    printf 'not a run-lock holder answer (expected a holder header and one all-digit row)\n' >>"$3"
+    return 1
+  fi
+  printf '%s\n' "$_rh_val"
 }
 
 # remote_op_owned_arg DB VALUE — VALUE as the CALL's argument, but only while

--- a/examples/bd/dolt/assets/scripts/runtime.sh
+++ b/examples/bd/dolt/assets/scripts/runtime.sh
@@ -506,10 +506,20 @@ kill_remote_op_session() {
     echo "  $_kr_db: server-side $_kr_label NOT killed: this client never learned its session id, and ownership of the in-flight remote operation(s) on the server (Id $_kr_listed) cannot be proven — left for the operator (KILL <Id>); gc dolt health names them" >&2
     return 1
   fi
+  _kr_runlock=$(remote_op_run_lock_name "$_kr_db")
+  _kr_guarded=""
   for _kr_one in $_kr_ids; do
     _kr_krc=0
-    _kr_kerr=$(dolt_sql_csv "$_kr_tmo" "" "KILL $_kr_one" 2>&1 >/dev/null) || _kr_krc=$?
-    [ "$_kr_krc" -eq 0 ] || echo "  $_kr_db: KILL $_kr_one failed (exit $_kr_krc): $_kr_kerr" >&2
+    # One batch: the KILL runs only while <id> still holds THIS run's lock;
+    # otherwise the batch stops before it (a restarted server may have handed
+    # the number to someone else — see the gate comment above).
+    _kr_kerr=$(dolt_sql_csv "$_kr_tmo" "" "SELECT IF(IS_USED_LOCK('$_kr_runlock') = $_kr_one, 1, JSON_EXTRACT('$REMOTE_OP_NOT_OWNER_MARK', '\$')) AS own; KILL $_kr_one" 2>&1 >/dev/null) || _kr_krc=$?
+    if [ "$_kr_krc" -ne 0 ]; then
+      case "$_kr_kerr" in
+        *"Error 3141 "*"\"$REMOTE_OP_NOT_OWNER_MARK\""*) _kr_guarded="$_kr_guarded $_kr_one " ;;
+        *) echo "  $_kr_db: KILL $_kr_one failed (exit $_kr_krc): $_kr_kerr" >&2 ;;
+      esac
+    fi
   done
   _kr_left=$(remote_op_sessions "$_kr_db" "$_kr_tmo" "$_kr_errf") || {
     echo "  $_kr_db: server-side $_kr_label kill NOT confirmed: the processlist query failed after KILL" >&2
@@ -521,13 +531,28 @@ kill_remote_op_session() {
   _kr_left_ids=" $(printf '%s\n' "$_kr_left" | awk '{ printf "%s ", $1 }')"
   _kr_rc=0
   for _kr_one in $_kr_ids; do
-    case "$_kr_left_ids" in
+    case "$_kr_guarded" in
       *" $_kr_one "*)
-        echo "  $_kr_db: server-side $_kr_label NOT killed (session $_kr_one still in flight after KILL)" >&2
-        _kr_rc=1
+        case "$_kr_left_ids" in
+          *" $_kr_one "*)
+            echo "  $_kr_db: server-side $_kr_label NOT killed: session $_kr_one does not hold this run's lock ($_kr_runlock) — the server restarted and reused the id, or it is another runner's — left for the operator (KILL <Id>)" >&2
+            _kr_rc=1
+            ;;
+          *)
+            echo "  $_kr_db: server-side $_kr_label already ended (session $_kr_one is gone; nothing killed)" >&2
+            ;;
+        esac
         ;;
       *)
-        echo "  $_kr_db: server-side $_kr_label killed (session $_kr_one no longer in flight)" >&2
+        case "$_kr_left_ids" in
+          *" $_kr_one "*)
+            echo "  $_kr_db: server-side $_kr_label NOT killed (session $_kr_one still in flight after KILL)" >&2
+            _kr_rc=1
+            ;;
+          *)
+            echo "  $_kr_db: server-side $_kr_label killed (session $_kr_one no longer in flight)" >&2
+            ;;
+        esac
         ;;
     esac
   done
@@ -574,7 +599,30 @@ bound_expired() {
 # `Error 3141 … Invalid JSON text … "gc-remote-op-lock-held"` and its
 # following statement never runs; IS_USED_LOCK names the holder; after KILL
 # the gate passes again; an 80-character lock name is accepted.
+#
+# Ownership is re-proven INSIDE the statements that matter (codex r12,
+# evidence 04i). The gate takes a second, per-run lock,
+# `gc_remote_op_run:<db>:<nonce>` (REMOTE_OP_RUN_NONCE = pid-epoch of this
+# script run), and:
+#   - the CALL's first argument is `IF(IS_USED_LOCK('<run lock>') =
+#     CONNECTION_ID(), '<remote>', JSON_EXTRACT('gc-remote-op-lost', '$'))`:
+#     Dolt evaluates expressions in CALL arguments (04i a), so a session that
+#     no longer holds this run's lock — the dolt CLI's pooled client
+#     reconnected between the gate and the CALL, and the fresh session took
+#     no lock — raises Error 3141 with "gc-remote-op-lost" BEFORE the
+#     procedure runs (04i b) and a session that holds it fetches (04i c);
+#   - the KILL is `SELECT IF(IS_USED_LOCK('<run lock>') = <id>, 1,
+#     JSON_EXTRACT('gc-remote-op-not-owner', '$')) AS own; KILL <id>` in ONE
+#     batch: the id printed by our statement proves ownership only within the
+#     server lifetime that issued it (a restarted server hands the same
+#     numbers out again), so the KILL runs only while that id still holds
+#     this run's lock; otherwise the batch stops before the KILL (04i e1, e3)
+#     and the processlist read after says whether the session is gone
+#     (already ended) or someone else's (NOT killed, left for the operator).
 REMOTE_OP_GATE_MARK='gc-remote-op-lock-held'
+REMOTE_OP_LOST_MARK='gc-remote-op-lost'
+REMOTE_OP_NOT_OWNER_MARK='gc-remote-op-not-owner'
+REMOTE_OP_RUN_NONCE="$$-$(date +%s)"
 
 # remote_op_lock_name DB — the user-level lock name for DB, `gc_remote_op:<db>`
 # with the name lowercased: Dolt resolves `app` and `APP` to one database, and
@@ -585,10 +633,34 @@ remote_op_lock_name() {
   printf 'gc_remote_op:%s' "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
 }
 
+# remote_op_run_lock_name DB — this run's own lock for DB,
+# `gc_remote_op_run:<db>:<pid>-<epoch>` (db lowercased like the database lock;
+# the nonce carries no caller data).
+remote_op_run_lock_name() {
+  printf 'gc_remote_op_run:%s:%s' "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" "$REMOTE_OP_RUN_NONCE"
+}
+
 # remote_op_gate_sql DB — the gate statement for DB (DB already validated by
-# the caller before it is interpolated).
+# the caller before it is interpolated): the database lock AND this run's
+# lock, both session-scoped, or the marked error.
 remote_op_gate_sql() {
-  printf "SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('%s')), 0) = 1, 1, JSON_EXTRACT('%s', '\$')) AS gate" "$1" "$REMOTE_OP_GATE_MARK"
+  printf "SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('%s')), 0) = 1 AND GET_LOCK('%s', 0) = 1, 1, JSON_EXTRACT('%s', '\$')) AS gate" "$1" "$(remote_op_run_lock_name "$1")" "$REMOTE_OP_GATE_MARK"
+}
+
+# remote_op_owned_arg DB VALUE — VALUE as the CALL's argument, but only while
+# this session still holds this run's lock for DB: otherwise the marked error
+# is raised and the procedure never runs (VALUE already validated by the
+# caller before it is interpolated).
+remote_op_owned_arg() {
+  printf "IF(IS_USED_LOCK('%s') = CONNECTION_ID(), '%s', JSON_EXTRACT('%s', '\$'))" "$(remote_op_run_lock_name "$1")" "$2" "$REMOTE_OP_LOST_MARK"
+}
+
+# remote_op_gate_lost STDERR_FILE — true when the captured dolt stderr says the
+# CALL's own ownership check failed: this session no longer held this run's
+# lock when the CALL was sent (the client reconnected); the procedure did not
+# run and there is nothing to kill.
+remote_op_gate_lost() {
+  grep -Eq "Error 3141 .*\"$REMOTE_OP_LOST_MARK\"" "$1" 2>/dev/null
 }
 
 # remote_op_gate_refused STDERR_FILE — true when the captured dolt stderr says

--- a/examples/bd/dolt/commands/health/run.sh
+++ b/examples/bd/dolt/commands/health/run.sh
@@ -92,6 +92,9 @@ if [ "$max_fetch_sessions_valid" != true ]; then
     "$max_fetch_sessions" >&2
   exit 2
 fi
+# Canonical decimal: leading zeros dropped (validated non-zero, so never empty)
+# — `"warn_above": 02` would not be JSON.
+max_fetch_sessions=$(printf '%s' "$max_fetch_sessions" | sed 's/^0*//')
 
 # Determine host for probing.
 host="${GC_DOLT_HOST:-127.0.0.1}"

--- a/examples/bd/dolt/commands/health/run.sh
+++ b/examples/bd/dolt/commands/health/run.sh
@@ -313,8 +313,7 @@ fetch_sessions_probed=false
 fetch_sessions_count=0
 fetch_sessions_oldest_sec=0
 fetch_sessions_warn=false
-if [ "$server_reachable" = true ]; then
-  _fs_err=$(mktemp)
+if [ "$server_reachable" = true ] && _fs_err=$(mktemp 2>/dev/null); then
   if _fs_rows=$(remote_op_sessions "" 5 "$_fs_err"); then
     fetch_sessions_probed=true
     fetch_sessions_count=$(printf '%s\n' "$_fs_rows" | awk 'NF == 2 { n++ } END { print n + 0 }')

--- a/examples/bd/dolt/commands/health/run.sh
+++ b/examples/bd/dolt/commands/health/run.sh
@@ -3,10 +3,13 @@
 #
 # Checks server status and latency, per-database commit counts and open
 # beads, backup freshness, orphan databases, active compaction quarantine
-# markers, and zombie Dolt processes.
+# markers, zombie Dolt processes, and server-side DOLT_FETCH / DOLT_PULL
+# sessions piling up (gp-f2yq).
 #
 # Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_HOST, GC_DOLT_USER,
-#              GC_DOLT_PASSWORD, GC_DOLT_RIG_LIST_TIMEOUT_SECS
+#              GC_DOLT_PASSWORD, GC_DOLT_RIG_LIST_TIMEOUT_SECS,
+#              GC_DOLT_HEALTH_MAX_FETCH_SESSIONS (default: 2) — WARN when
+#              more than this many server-side fetch/pull sessions are in flight
 set -e
 
 : "${GC_DOLT_USER:=root}"
@@ -72,6 +75,23 @@ while [ $# -gt 0 ]; do
 done
 
 # Note: run_bounded / TIMEOUT_BIN are provided by assets/scripts/runtime.sh.
+
+# WARN threshold for server-side DOLT_FETCH / DOLT_PULL sessions in flight:
+# more than this many is a herd (a patrol stacking a fetch per run on top of
+# server-side calls its client bounds abandoned). Validated the way the sync
+# bounds are — empty / non-numeric / all-zero is rejected before any probe —
+# so a misconfigured threshold fails loud instead of silently never warning.
+max_fetch_sessions="${GC_DOLT_HEALTH_MAX_FETCH_SESSIONS-2}"
+case "$max_fetch_sessions" in
+  ''|*[!0-9]*) max_fetch_sessions_valid=false ;;
+  *[1-9]*)     max_fetch_sessions_valid=true ;;
+  *)           max_fetch_sessions_valid=false ;;
+esac
+if [ "$max_fetch_sessions_valid" != true ]; then
+  printf 'gc dolt health: invalid GC_DOLT_HEALTH_MAX_FETCH_SESSIONS=%s (must be a positive integer)\n' \
+    "$max_fetch_sessions" >&2
+  exit 2
+fi
 
 # Determine host for probing.
 host="${GC_DOLT_HOST:-127.0.0.1}"
@@ -275,6 +295,31 @@ if [ "$server_reachable" = true ]; then
 "
     done
   fi
+fi
+
+# Server-side DOLT_FETCH / DOLT_PULL sessions in flight (gp-f2yq). A CALL
+# DOLT_FETCH runs inside the sql-server and outlives a client whose bound
+# expired; before the sync/pull guards, a 15-minute patrol stacked one more
+# per run (boomtown 2026-09-11: 169 of 178 sessions, the oldest 2 days, dolt
+# at 180% CPU). One read-only, server-wide processlist probe under the same
+# 5s bound as the other probes: count and oldest age. A probe that fails, or
+# answers with anything but a processlist, is reported as probed=false with
+# count 0 — never as a fabricated "nothing in flight". WARN when the count is
+# MORE than the threshold; informational, never the exit code.
+fetch_sessions_probed=false
+fetch_sessions_count=0
+fetch_sessions_oldest_sec=0
+fetch_sessions_warn=false
+if [ "$server_reachable" = true ]; then
+  _fs_err=$(mktemp)
+  if _fs_rows=$(remote_op_sessions "" 5 "$_fs_err"); then
+    fetch_sessions_probed=true
+    fetch_sessions_count=$(printf '%s\n' "$_fs_rows" | awk 'NF == 2 { n++ } END { print n + 0 }')
+    _fs_oldest=$(printf '%s\n' "$_fs_rows" | remote_op_sessions_oldest)
+    [ -n "$_fs_oldest" ] && fetch_sessions_oldest_sec=${_fs_oldest#* }
+    [ "$fetch_sessions_count" -gt "$max_fetch_sessions" ] && fetch_sessions_warn=true
+  fi
+  rm -f "$_fs_err"
 fi
 
 # Check backup freshness.
@@ -603,6 +648,13 @@ JSONEOF
   cat <<JSONEOF
 
   ],
+  "fetch_sessions": {
+    "probed": $fetch_sessions_probed,
+    "count": $fetch_sessions_count,
+    "oldest_age_sec": $fetch_sessions_oldest_sec,
+    "warn_above": $max_fetch_sessions,
+    "warn": $fetch_sessions_warn
+  },
   "processes": {
     "zombie_count": $zombie_count,
     "zombie_pids": [$(echo "$zombie_pids" | tr -s ' ' ',' | sed 's/^,//;s/,$//')]
@@ -673,6 +725,11 @@ fi
 if [ "$zombie_count" -gt 0 ]; then
   echo ""
   echo "Zombie processes: $zombie_count (PIDs:$zombie_pids)"
+fi
+
+if [ "$fetch_sessions_warn" = true ]; then
+  echo ""
+  echo "WARN: $fetch_sessions_count server-side DOLT_FETCH/DOLT_PULL sessions in flight (oldest $(human_duration "$fetch_sessions_oldest_sec"), more than $max_fetch_sessions) — clients gone, procedures still running; gc dolt sync/pull now skip and KILL these, an older run's leftovers need a manual KILL"
 fi
 
 # Exit status (human mode only): 0 when the data plane is healthy

--- a/examples/bd/dolt/commands/health/schemas/result.schema.json
+++ b/examples/bd/dolt/commands/health/schemas/result.schema.json
@@ -102,6 +102,28 @@
         "additionalProperties": true
       }
     },
+    "fetch_sessions": {
+      "type": "object",
+      "required": ["probed", "count", "oldest_age_sec", "warn_above", "warn"],
+      "properties": {
+        "probed": {
+          "type": "boolean"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "oldest_age_sec": {
+          "type": "integer"
+        },
+        "warn_above": {
+          "type": "integer"
+        },
+        "warn": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
     "processes": {
       "type": "object",
       "required": ["zombie_count", "zombie_pids"],

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -249,18 +249,17 @@ pull_database_sql() {
     echo "  $name: pulled from $remote_url"
     return 0
   fi
-  if remote_op_gate_refused "$pull_err_tmp"; then
-    rm -f "$pull_err_tmp"
-    echo "  $name: pull already in flight — the server refused a second one (session lock $(remote_op_lock_name "$name") held) — skipped" >&2
-    return 1
-  fi
-
+  # The bound's verdict outranks anything the client printed.
   if bound_expired "$pull_rc"; then
     echo "  $name: pull timed out after ${pull_timeout}s (GC_DOLT_PULL_TIMEOUT_SECS; client exit $pull_rc)" >&2
     # The client is dead (124: the bound; 137: the bound's SIGKILL escalation);
     # the server-side pull is not. End it and prove it ended (the outcome is
     # reported on its own line).
     kill_remote_op_session pull "$name" "$pull_session_id" || true
+  elif remote_op_gate_refused "$pull_err_tmp"; then
+    rm -f "$pull_err_tmp"
+    echo "  $name: pull already in flight — the server refused a second one (session lock $(remote_op_lock_name "$name") held) — skipped" >&2
+    return 1
   else
     echo "  $name: ERROR: pull failed (exit $pull_rc)" >&2
   fi

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -241,16 +241,19 @@ pull_database_sql() {
     rm -f "$pull_err_tmp"
     return 1
   }
-  # The statement prints its OWN connection id before the procedure starts;
-  # --use-db attributes the session to this database. The id is the KILL
-  # operand when the bound expires.
   pull_rc=0
-  # Then the server-side gate (remote_op_gate_sql): the session takes this
-  # database's lock and this run's lock or the batch stops here, before the
-  # CALL; the CALL's own first argument re-proves that THIS session still holds
-  # the run lock (remote_op_owned_arg), so a reconnected client never pulls on
-  # a lockless session.
-  dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; $(remote_op_gate_sql "$name"); CALL DOLT_PULL($(remote_op_owned_arg "$name" "$remote_name"), 'main')" "$pull_timeout" "$name" \
+  # The server-side gate (remote_op_gate_sql) is the batch's first statement
+  # after USE: the session takes this database's lock and this run's lock and
+  # prints its OWN connection id in that same statement, or the batch stops
+  # here, before the CALL. The id and the locks are one statement, so the id
+  # the KILL targets when the bound expires is the lock holder by construction
+  # (a separate id statement before the gate could record a session that a
+  # pooled-client reconnect left lockless while the reconnected one pulled on
+  # — the mayor's gate r1); --use-db attributes the session to this database.
+  # The CALL's own first argument re-proves that THIS session still holds the
+  # run lock (remote_op_owned_arg), so a reconnected client never pulls on a
+  # lockless session.
+  dolt_sql "USE \`$name\`; $(remote_op_gate_sql "$name"); CALL DOLT_PULL($(remote_op_owned_arg "$name" "$remote_name"), 'main')" "$pull_timeout" "$name" \
     >"$pull_out_tmp" 2>"$pull_err_tmp" || pull_rc=$?
   pull_session_id=$(remote_op_session_id "$pull_out_tmp")
   rm -f "$pull_out_tmp"

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -26,8 +26,12 @@ set -e
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 # This run's lock nonce (see runtime.sh, "Server-side single-flight gate"):
-# one random value per script run, computed here and not at source time.
-REMOTE_OP_RUN_NONCE=$(remote_op_new_run_nonce)
+# one random value per script run, computed here and not at source time; no
+# random bytes = no run (before any database is touched).
+REMOTE_OP_RUN_NONCE=$(remote_op_new_run_nonce) || {
+  echo "gc dolt pull: no run nonce — refusing to run (see the line above)" >&2
+  exit 2
+}
 
 db_filter=""
 data_dir="$DOLT_DATA_DIR"

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -15,8 +15,10 @@
 # bound killed, so before issuing one the script asks the server whether a
 # DOLT_PULL / DOLT_FETCH is already in flight for the database (skipped when
 # one is), and when the bound expires it KILLs the server-side session the
-# pull printed about itself and proves it gone from the processlist. See the
-# "Server-side remote operations" helpers in assets/scripts/runtime.sh.
+# pull printed about itself and proves it gone from the processlist. Runners
+# on this host are serialized per database by a mkdir lock (root
+# GC_DOLT_REMOTE_OP_LOCK_ROOT, default ${TMPDIR:-/tmp}/gc-dolt-remote-op). See
+# the "Server-side remote operations" helpers in assets/scripts/runtime.sh.
 set -e
 
 : "${GC_DOLT_USER:=root}"
@@ -70,6 +72,9 @@ if [ "$pull_timeout_valid" != true ]; then
     "$pull_timeout" >&2
   exit 2
 fi
+# Canonical decimal: leading zeros dropped (validated non-zero, so never empty)
+# so the value prints and compares as the integer it is.
+pull_timeout=$(printf '%s' "$pull_timeout" | sed 's/^0*//')
 
 is_running() {
   managed_runtime_tcp_reachable "$GC_DOLT_PORT"
@@ -177,7 +182,28 @@ find_remote_sql() {
   printf '%s\n' "$chosen" | awk -F, '{print $1 "|" $2}'
 }
 
+# pull_database_sql <db> — pull_database_sql_locked under the per-database
+# runner lock (remote_op_lock_acquire, runtime.sh): two runners on this host
+# must not both read "nothing in flight" and both pull. A live holder = this
+# database skipped this run; a lock root that cannot be created = the same skip.
 pull_database_sql() {
+  _pl_name="$1"
+  _pl_lrc=0
+  remote_op_lock_acquire "$_pl_name" || _pl_lrc=$?
+  if [ "$_pl_lrc" -eq 1 ]; then
+    echo "  $_pl_name: another gc dolt sync/pull (pid ${REMOTE_OP_LOCK_HOLDER:-unknown}) holds this database's runner lock — skipped" >&2
+    return 1
+  elif [ "$_pl_lrc" -ne 0 ]; then
+    echo "  $_pl_name: ERROR: cannot create the runner lock under $(remote_op_lock_root) — skipped" >&2
+    return 1
+  fi
+  _pl_rc=0
+  pull_database_sql_locked "$_pl_name" || _pl_rc=$?
+  remote_op_lock_release
+  return "$_pl_rc"
+}
+
+pull_database_sql_locked() {
   name="$1"
   if ! valid_database_name "$name"; then
     echo "  $name: ERROR: invalid database name" >&2
@@ -242,10 +268,11 @@ pull_database_sql() {
     return 0
   fi
 
-  if [ "$pull_rc" -eq 124 ]; then
-    echo "  $name: pull timed out after ${pull_timeout}s (GC_DOLT_PULL_TIMEOUT_SECS)" >&2
-    # The client is dead; the server-side pull is not. End it and prove it
-    # ended (the outcome is reported on its own line).
+  if bound_expired "$pull_rc"; then
+    echo "  $name: pull timed out after ${pull_timeout}s (GC_DOLT_PULL_TIMEOUT_SECS; client exit $pull_rc)" >&2
+    # The client is dead (124: the bound; 137: the bound's SIGKILL escalation);
+    # the server-side pull is not. End it and prove it ended (the outcome is
+    # reported on its own line).
     kill_remote_op_session pull "$name" "$pull_session_id" || true
   else
     echo "  $name: ERROR: pull failed (exit $pull_rc)" >&2

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -7,6 +7,16 @@
 #
 # Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_USER, GC_DOLT_PASSWORD,
 # GC_DOLT_REMOTE_<DB> (select among multiple remotes), GC_DOLT_PULL_ALLOW_REMOTE_<DB>=1 (permit a non-file:// pull)
+#   GC_DOLT_PULL_TIMEOUT_SECS (default: 120) — wall-clock bound for the
+#   SQL-mode DOLT_PULL; increase for a slow link or a large first pull.
+#
+# One server-side pull per database at a time (gp-f2yq): a CALL DOLT_PULL
+# runs inside the sql-server (it fetches first) and outlives a client the
+# bound killed, so before issuing one the script asks the server whether a
+# DOLT_PULL / DOLT_FETCH is already in flight for the database (skipped when
+# one is), and when the bound expires it KILLs the server-side session the
+# pull printed about itself and proves it gone from the processlist. See the
+# "Server-side remote operations" helpers in assets/scripts/runtime.sh.
 set -e
 
 : "${GC_DOLT_USER:=root}"
@@ -30,6 +40,7 @@ while [ $# -gt 0 ]; do
       echo "Environment:"
       echo "  GC_DOLT_REMOTE_<DB>                Select which remote to pull from when a database has several"
       echo "  GC_DOLT_PULL_ALLOW_REMOTE_<DB>=1   Permit pulling from a non-file:// remote"
+      echo "  GC_DOLT_PULL_TIMEOUT_SECS  SQL-mode pull bound (default 120)"
       exit 0
       ;;
     *) echo "gc dolt pull: unknown flag: $1" >&2; exit 1 ;;
@@ -42,6 +53,23 @@ case "$(printf '%s' "$db_filter" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | t
   exit 1
   ;;
 esac
+
+# Wall-clock bound for the SQL-mode DOLT_PULL (seconds). Defaults to 120s (the
+# prior fixed ceiling). Validated the way the sync bounds are: an empty /
+# non-numeric / all-zero value is rejected before any database is touched —
+# GNU `timeout 0` disables the timeout, i.e. an unbounded pull, the exact
+# anti-hang outcome this bound exists to prevent.
+pull_timeout="${GC_DOLT_PULL_TIMEOUT_SECS-120}"
+case "$pull_timeout" in
+  ''|*[!0-9]*) pull_timeout_valid=false ;;
+  *[1-9]*)     pull_timeout_valid=true ;;
+  *)           pull_timeout_valid=false ;;
+esac
+if [ "$pull_timeout_valid" != true ]; then
+  printf 'gc dolt pull: invalid GC_DOLT_PULL_TIMEOUT_SECS=%s (must be a positive integer)\n' \
+    "$pull_timeout" >&2
+  exit 2
+fi
 
 is_running() {
   managed_runtime_tcp_reachable "$GC_DOLT_PORT"
@@ -131,12 +159,12 @@ select_remote() {
   printf '%s\n' "$sel_match"; return 0
 }
 
+# dolt_sql QUERY [TIMEOUT_SECS] [USE_DB] — run a SQL query against the live
+# server under a wall-clock bound (dolt_sql_csv, runtime.sh); 120s by default,
+# sized for metadata queries. The pull passes its own bound and its database
+# (--use-db, so the server attributes the session in its processlist).
 dolt_sql() {
-  query="$1"
-  host="${GC_DOLT_HOST:-127.0.0.1}"
-  export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
-  run_bounded 120 dolt --host "$host" --port "$GC_DOLT_PORT" --user "$GC_DOLT_USER" --no-tls \
-    sql --result-format csv -q "$query"
+  dolt_sql_csv "${2:-120}" "${3:-}" "$1"
 }
 
 find_remote_sql() {
@@ -172,12 +200,58 @@ pull_database_sql() {
     return 1
   fi
 
-  if dolt_sql "USE \`$name\`; CALL DOLT_PULL('$remote_name', 'main')" >/dev/null 2>&1; then
+  pull_err_tmp=$(mktemp) || {
+    echo "  $name: ERROR: cannot create temp file for pull diagnostics" >&2
+    return 1
+  }
+  # gp-f2yq: ONE server-side remote operation per database at a time. A CALL
+  # DOLT_PULL runs inside the sql-server and outlives a client the bound
+  # killed, so ask the server first and skip when a pull or fetch is already
+  # in flight for this database. Fail closed: a processlist query that fails,
+  # or answers with anything but a processlist, skips too.
+  inflight_rc=0
+  inflight=$(remote_op_sessions "$name" 120 "$pull_err_tmp") || inflight_rc=$?
+  if [ "$inflight_rc" -ne 0 ]; then
+    echo "  $name: ERROR: processlist query failed (exit $inflight_rc) — skipped" >&2
+    remote_op_replay_stderr "$name" "$pull_err_tmp"
+    rm -f "$pull_err_tmp"
+    return 1
+  fi
+  inflight_oldest=$(printf '%s\n' "$inflight" | remote_op_sessions_oldest)
+  if [ -n "$inflight_oldest" ]; then
+    rm -f "$pull_err_tmp"
+    echo "  $name: pull already in flight for ${inflight_oldest#* }s (session ${inflight_oldest%% *}) — skipped" >&2
+    return 1
+  fi
+  pull_out_tmp=$(mktemp) || {
+    echo "  $name: ERROR: cannot create temp file for the pull session id" >&2
+    rm -f "$pull_err_tmp"
+    return 1
+  }
+  # The statement prints its OWN connection id before the procedure starts;
+  # --use-db attributes the session to this database. The id is the KILL
+  # operand when the bound expires.
+  pull_rc=0
+  dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; CALL DOLT_PULL('$remote_name', 'main')" "$pull_timeout" "$name" \
+    >"$pull_out_tmp" 2>"$pull_err_tmp" || pull_rc=$?
+  pull_session_id=$(remote_op_session_id "$pull_out_tmp")
+  rm -f "$pull_out_tmp"
+  if [ "$pull_rc" -eq 0 ]; then
+    rm -f "$pull_err_tmp"
     echo "  $name: pulled from $remote_url"
     return 0
   fi
 
-  echo "  $name: ERROR: pull failed" >&2
+  if [ "$pull_rc" -eq 124 ]; then
+    echo "  $name: pull timed out after ${pull_timeout}s (GC_DOLT_PULL_TIMEOUT_SECS)" >&2
+    # The client is dead; the server-side pull is not. End it and prove it
+    # ended (the outcome is reported on its own line).
+    kill_remote_op_session pull "$name" "$pull_session_id" || true
+  else
+    echo "  $name: ERROR: pull failed (exit $pull_rc)" >&2
+  fi
+  remote_op_replay_stderr "$name" "$pull_err_tmp"
+  rm -f "$pull_err_tmp"
   return 1
 }
 

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -13,7 +13,7 @@
 # One server-side pull per database at a time (gp-f2yq): a CALL DOLT_PULL
 # runs inside the sql-server (it fetches first) and outlives a client the
 # bound killed, so before issuing one the script asks the server whether a
-# DOLT_PULL / DOLT_FETCH is already in flight for the database (skipped when
+# DOLT_PULL / DOLT_FETCH is already in flight on the server (skipped when
 # one is), and when the bound expires it KILLs the server-side session the
 # pull printed about itself and proves it gone from the processlist. The pull
 # statement also takes the server's session lock for the database (GET_LOCK,

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -26,8 +26,8 @@ set -e
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 # This run's lock nonce (see runtime.sh, "Server-side single-flight gate"):
-# one value per script run, computed here and not at source time.
-REMOTE_OP_RUN_NONCE="$$-$(date +%s)"
+# one random value per script run, computed here and not at source time.
+REMOTE_OP_RUN_NONCE=$(remote_op_new_run_nonce)
 
 db_filter=""
 data_dir="$DOLT_DATA_DIR"

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -25,6 +25,9 @@ set -e
 : "${GC_DOLT_USER:=root}"
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
+# This run's lock nonce (see runtime.sh, "Server-side single-flight gate"):
+# one value per script run, computed here and not at source time.
+REMOTE_OP_RUN_NONCE="$$-$(date +%s)"
 
 db_filter=""
 data_dir="$DOLT_DATA_DIR"

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -239,8 +239,11 @@ pull_database_sql() {
   # operand when the bound expires.
   pull_rc=0
   # Then the server-side gate (remote_op_gate_sql): the session takes this
-  # database's lock or the batch stops here, before the CALL.
-  dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; $(remote_op_gate_sql "$name"); CALL DOLT_PULL('$remote_name', 'main')" "$pull_timeout" "$name" \
+  # database's lock and this run's lock or the batch stops here, before the
+  # CALL; the CALL's own first argument re-proves that THIS session still holds
+  # the run lock (remote_op_owned_arg), so a reconnected client never pulls on
+  # a lockless session.
+  dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; $(remote_op_gate_sql "$name"); CALL DOLT_PULL($(remote_op_owned_arg "$name" "$remote_name"), 'main')" "$pull_timeout" "$name" \
     >"$pull_out_tmp" 2>"$pull_err_tmp" || pull_rc=$?
   pull_session_id=$(remote_op_session_id "$pull_out_tmp")
   rm -f "$pull_out_tmp"
@@ -259,6 +262,10 @@ pull_database_sql() {
   elif remote_op_gate_refused "$pull_err_tmp"; then
     rm -f "$pull_err_tmp"
     echo "  $name: pull already in flight — the server refused a second one (session lock $(remote_op_lock_name "$name") held) — skipped" >&2
+    return 1
+  elif remote_op_gate_lost "$pull_err_tmp"; then
+    rm -f "$pull_err_tmp"
+    echo "  $name: pull not sent — this session lost the run lock between the gate and the CALL (client reconnected) — skipped" >&2
     return 1
   else
     echo "  $name: ERROR: pull failed (exit $pull_rc)" >&2

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -15,10 +15,11 @@
 # bound killed, so before issuing one the script asks the server whether a
 # DOLT_PULL / DOLT_FETCH is already in flight for the database (skipped when
 # one is), and when the bound expires it KILLs the server-side session the
-# pull printed about itself and proves it gone from the processlist. Runners
-# on this host are serialized per database by a mkdir lock (root
-# GC_DOLT_REMOTE_OP_LOCK_ROOT, default ${TMPDIR:-/tmp}/gc-dolt-remote-op). See
-# the "Server-side remote operations" helpers in assets/scripts/runtime.sh.
+# pull printed about itself and proves it gone from the processlist. The pull
+# statement also takes the server's session lock for the database (GET_LOCK,
+# timeout 0) in the same batch, so two runners that both read "nothing in
+# flight" cannot both pull. See the "Server-side remote operations" helpers
+# in assets/scripts/runtime.sh.
 set -e
 
 : "${GC_DOLT_USER:=root}"
@@ -182,28 +183,7 @@ find_remote_sql() {
   printf '%s\n' "$chosen" | awk -F, '{print $1 "|" $2}'
 }
 
-# pull_database_sql <db> — pull_database_sql_locked under the per-database
-# runner lock (remote_op_lock_acquire, runtime.sh): two runners on this host
-# must not both read "nothing in flight" and both pull. A live holder = this
-# database skipped this run; a lock root that cannot be created = the same skip.
 pull_database_sql() {
-  _pl_name="$1"
-  _pl_lrc=0
-  remote_op_lock_acquire "$_pl_name" || _pl_lrc=$?
-  if [ "$_pl_lrc" -eq 1 ]; then
-    echo "  $_pl_name: another gc dolt sync/pull (pid ${REMOTE_OP_LOCK_HOLDER:-unknown}) holds this database's runner lock — skipped" >&2
-    return 1
-  elif [ "$_pl_lrc" -ne 0 ]; then
-    echo "  $_pl_name: ERROR: cannot create the runner lock under $(remote_op_lock_root) — skipped" >&2
-    return 1
-  fi
-  _pl_rc=0
-  pull_database_sql_locked "$_pl_name" || _pl_rc=$?
-  remote_op_lock_release
-  return "$_pl_rc"
-}
-
-pull_database_sql_locked() {
   name="$1"
   if ! valid_database_name "$name"; then
     echo "  $name: ERROR: invalid database name" >&2
@@ -258,7 +238,9 @@ pull_database_sql_locked() {
   # --use-db attributes the session to this database. The id is the KILL
   # operand when the bound expires.
   pull_rc=0
-  dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; CALL DOLT_PULL('$remote_name', 'main')" "$pull_timeout" "$name" \
+  # Then the server-side gate (remote_op_gate_sql): the session takes this
+  # database's lock or the batch stops here, before the CALL.
+  dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; $(remote_op_gate_sql "$name"); CALL DOLT_PULL('$remote_name', 'main')" "$pull_timeout" "$name" \
     >"$pull_out_tmp" 2>"$pull_err_tmp" || pull_rc=$?
   pull_session_id=$(remote_op_session_id "$pull_out_tmp")
   rm -f "$pull_out_tmp"
@@ -266,6 +248,11 @@ pull_database_sql_locked() {
     rm -f "$pull_err_tmp"
     echo "  $name: pulled from $remote_url"
     return 0
+  fi
+  if remote_op_gate_refused "$pull_err_tmp"; then
+    rm -f "$pull_err_tmp"
+    echo "  $name: pull already in flight — the server refused a second one (session lock gc_remote_op:$name held) — skipped" >&2
+    return 1
   fi
 
   if bound_expired "$pull_rc"; then

--- a/examples/bd/dolt/commands/pull/run.sh
+++ b/examples/bd/dolt/commands/pull/run.sh
@@ -251,7 +251,7 @@ pull_database_sql() {
   fi
   if remote_op_gate_refused "$pull_err_tmp"; then
     rm -f "$pull_err_tmp"
-    echo "  $name: pull already in flight — the server refused a second one (session lock gc_remote_op:$name held) — skipped" >&2
+    echo "  $name: pull already in flight — the server refused a second one (session lock $(remote_op_lock_name "$name") held) — skipped" >&2
     return 1
   fi
 

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -119,8 +119,12 @@ esac
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 # This run's lock nonce (see runtime.sh, "Server-side single-flight gate"):
-# one random value per script run, computed here and not at source time.
-REMOTE_OP_RUN_NONCE=$(remote_op_new_run_nonce)
+# one random value per script run, computed here and not at source time; no
+# random bytes = no run (before any database is touched).
+REMOTE_OP_RUN_NONCE=$(remote_op_new_run_nonce) || {
+  echo "gc dolt sync: no run nonce — refusing to run (see the line above)" >&2
+  exit 2
+}
 
 beads_bd="$GC_BEADS_BD_SCRIPT"
 data_dir="$DOLT_DATA_DIR"

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -119,8 +119,8 @@ esac
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 # This run's lock nonce (see runtime.sh, "Server-side single-flight gate"):
-# one value per script run, computed here and not at source time.
-REMOTE_OP_RUN_NONCE="$$-$(date +%s)"
+# one random value per script run, computed here and not at source time.
+REMOTE_OP_RUN_NONCE=$(remote_op_new_run_nonce)
 
 beads_bd="$GC_BEADS_BD_SCRIPT"
 data_dir="$DOLT_DATA_DIR"

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -541,7 +541,20 @@ sync_database_sql() {
       >"$fetch_out_tmp" 2>"$fetch_err_tmp" || fetch_rc=$?
     fetch_session_id=$(remote_op_session_id "$fetch_out_tmp")
     rm -f "$fetch_out_tmp"
-    if [ "$fetch_rc" -ne 0 ] && remote_op_gate_refused "$fetch_err_tmp"; then
+    # The bound's verdict outranks anything the client printed: a client the
+    # bound killed may have written a first-push signal ("no branches found"
+    # / "invalid ref spec") before stalling, and that text must never turn a
+    # dead client into a push.
+    if bound_expired "$fetch_rc"; then
+      rm -f "$fetch_err_tmp"
+      echo "  $name: fetch timed out after ${fetch_timeout}s (client exit $fetch_rc) — skipped (NOT pushed)" >&2
+      last_fail_reason="fetch timed out after ${fetch_timeout}s (client exit $fetch_rc)"
+      # The client is dead (124: the bound; 137: the bound's SIGKILL escalation);
+      # the server-side fetch is not. End it and prove it ended (the outcome is
+      # reported on its own line; either way, skipped).
+      kill_remote_op_session fetch "$name" "$fetch_session_id" || true
+      return 1
+    elif [ "$fetch_rc" -ne 0 ] && remote_op_gate_refused "$fetch_err_tmp"; then
       # Another session holds this database's lock: a fetch or pull that the
       # processlist read did not show yet (it raced this one), or one whose
       # client died and whose session still runs. The server refused ours
@@ -556,15 +569,6 @@ sync_database_sql() {
       # and is necessarily a fast-forward.
       ff_status="first-push"
       rm -f "$fetch_err_tmp"
-    elif bound_expired "$fetch_rc"; then
-      rm -f "$fetch_err_tmp"
-      echo "  $name: fetch timed out after ${fetch_timeout}s (client exit $fetch_rc) — skipped (NOT pushed)" >&2
-      last_fail_reason="fetch timed out after ${fetch_timeout}s (client exit $fetch_rc)"
-      # The client is dead (124: the bound; 137: the bound's SIGKILL escalation);
-      # the server-side fetch is not. End it and prove it ended (the outcome is
-      # reported on its own line; either way, skipped).
-      kill_remote_op_session fetch "$name" "$fetch_session_id" || true
-      return 1
     elif [ "$fetch_rc" -ne 0 ]; then
       echo "  $name: fetch failed (exit $fetch_rc) — skipped (NOT pushed)" >&2
       if [ -s "$fetch_err_tmp" ]; then

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -58,11 +58,12 @@
 # issuing one the script asks the server whether a DOLT_FETCH / DOLT_PULL is
 # already in flight for the database (skipped, NOT pushed, when one is), and
 # when the fetch bound expires it KILLs the server-side session the fetch
-# printed about itself and proves it gone from the processlist. Runners on
-# this host are serialized per database by a mkdir lock (root
-# GC_DOLT_REMOTE_OP_LOCK_ROOT, default ${TMPDIR:-/tmp}/gc-dolt-remote-op) so
-# two of them cannot both read "nothing in flight". See the "Server-side
-# remote operations" helpers in assets/scripts/runtime.sh.
+# printed about itself and proves it gone from the processlist. The fetch
+# statement also takes the server's session lock for the database (GET_LOCK,
+# timeout 0) in the same batch, so two runners that both read "nothing in
+# flight" cannot both fetch: the server refuses the second one before its
+# CALL is sent. See the "Server-side remote operations" helpers in
+# assets/scripts/runtime.sh.
 set -e
 
 dry_run=false
@@ -449,30 +450,7 @@ resolve_refspec_cli() {
   printf 'main\nmain\n'
 }
 
-# sync_database_sql <db> — sync_database_sql_locked under the per-database
-# runner lock (remote_op_lock_acquire, runtime.sh): two runners on this host
-# must not both read "nothing in flight" and both fetch. A live holder = this
-# database skipped, NOT pushed, this run; a lock root that cannot be created =
-# the same skip. The lock is held through the fetch, the classification, the
-# push and the kill-on-expiry.
 sync_database_sql() {
-  _sl_name="$1"
-  _sl_lrc=0
-  remote_op_lock_acquire "$_sl_name" || _sl_lrc=$?
-  if [ "$_sl_lrc" -eq 1 ]; then
-    echo "  $_sl_name: another gc dolt sync/pull (pid ${REMOTE_OP_LOCK_HOLDER:-unknown}) holds this database's runner lock — skipped (NOT pushed)" >&2
-    return 1
-  elif [ "$_sl_lrc" -ne 0 ]; then
-    echo "  $_sl_name: ERROR: cannot create the runner lock under $(remote_op_lock_root) — skipped (NOT pushed)" >&2
-    return 1
-  fi
-  _sl_rc=0
-  sync_database_sql_locked "$_sl_name" || _sl_rc=$?
-  remote_op_lock_release
-  return "$_sl_rc"
-}
-
-sync_database_sql_locked() {
   name="$1"
   if ! valid_database_name "$name"; then
     echo "  $name: ERROR: invalid database name" >&2
@@ -557,11 +535,21 @@ sync_database_sql_locked() {
     # the id is on disk before the fetch begins and survives the client's
     # death); --use-db attributes the session to this database. The id is the
     # KILL operand when the bound expires.
-    dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; CALL DOLT_FETCH('$remote_name', '$remote_branch')" "$fetch_timeout" "$name" \
+    # Then the server-side gate (remote_op_gate_sql): the session takes this
+    # database's lock or the batch stops here, before the CALL.
+    dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; $(remote_op_gate_sql "$name"); CALL DOLT_FETCH('$remote_name', '$remote_branch')" "$fetch_timeout" "$name" \
       >"$fetch_out_tmp" 2>"$fetch_err_tmp" || fetch_rc=$?
     fetch_session_id=$(remote_op_session_id "$fetch_out_tmp")
     rm -f "$fetch_out_tmp"
-    if [ "$fetch_rc" -ne 0 ] && { grep -q "no branches found in remote" "$fetch_err_tmp" 2>/dev/null || grep -q "invalid ref spec" "$fetch_err_tmp" 2>/dev/null; }; then
+    if [ "$fetch_rc" -ne 0 ] && remote_op_gate_refused "$fetch_err_tmp"; then
+      # Another session holds this database's lock: a fetch or pull that the
+      # processlist read did not show yet (it raced this one), or one whose
+      # client died and whose session still runs. The server refused ours
+      # before the CALL; nothing to kill.
+      rm -f "$fetch_err_tmp"
+      echo "  $name: fetch already in flight — the server refused a second one (session lock gc_remote_op:$name held) — skipped (NOT pushed)" >&2
+      return 1
+    elif [ "$fetch_rc" -ne 0 ] && { grep -q "no branches found in remote" "$fetch_err_tmp" 2>/dev/null || grep -q "invalid ref spec" "$fetch_err_tmp" 2>/dev/null; }; then
       # The remote has no such branch: an empty remote ("no branches found in
       # remote") or a brand-new branch on a populated remote ("invalid ref
       # spec" — both verified on Dolt 2.1.0). The first push creates the branch

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -56,7 +56,7 @@
 # One server-side fetch per database at a time (gp-f2yq): a CALL DOLT_FETCH
 # runs inside the sql-server and outlives a client the bound killed, so before
 # issuing one the script asks the server whether a DOLT_FETCH / DOLT_PULL is
-# already in flight for the database (skipped, NOT pushed, when one is), and
+# already in flight on the server (skipped, NOT pushed, when one is), and
 # when the fetch bound expires it KILLs the server-side session the fetch
 # printed about itself and proves it gone from the processlist. The fetch
 # statement also takes the server's session lock for the database (GET_LOCK,

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -537,17 +537,21 @@ sync_database_sql() {
       return 1
     }
     fetch_rc=0
-    # The statement prints its OWN connection id before the procedure starts
-    # (the CLI flushes each statement's result before running the next, so
-    # the id is on disk before the fetch begins and survives the client's
-    # death); --use-db attributes the session to this database. The id is the
-    # KILL operand when the bound expires.
-    # Then the server-side gate (remote_op_gate_sql): the session takes this
-    # database's lock and this run's lock or the batch stops here, before the
-    # CALL; and the CALL's own first argument re-proves that THIS session still
-    # holds the run lock (remote_op_owned_arg), so a client that reconnected in
-    # between never fetches on a lockless session.
-    dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; $(remote_op_gate_sql "$name"); CALL DOLT_FETCH($(remote_op_owned_arg "$name" "$remote_name"), '$remote_branch')" "$fetch_timeout" "$name" \
+    # The server-side gate (remote_op_gate_sql) is the batch's first statement
+    # after USE: the session takes this database's lock and this run's lock
+    # and prints its OWN connection id in that same statement, or the batch
+    # stops here, before the CALL. The id and the locks are one statement, so
+    # the id the KILL targets when the bound expires is the lock holder by
+    # construction (a separate id statement before the gate could record a
+    # session that a pooled-client reconnect left lockless while the
+    # reconnected one fetched on — the mayor's gate r1). The CLI flushes each
+    # statement's result before running the next, so the id is on disk before
+    # the fetch begins and survives the client's death; --use-db attributes the
+    # session to this database. The CALL's own first argument re-proves that
+    # THIS session still holds the run lock (remote_op_owned_arg), so a client
+    # that reconnected between the gate and the CALL never fetches on a
+    # lockless session.
+    dolt_sql "USE \`$name\`; $(remote_op_gate_sql "$name"); CALL DOLT_FETCH($(remote_op_owned_arg "$name" "$remote_name"), '$remote_branch')" "$fetch_timeout" "$name" \
       >"$fetch_out_tmp" 2>"$fetch_err_tmp" || fetch_rc=$?
     fetch_session_id=$(remote_op_session_id "$fetch_out_tmp")
     rm -f "$fetch_out_tmp"

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -547,7 +547,7 @@ sync_database_sql() {
       # client died and whose session still runs. The server refused ours
       # before the CALL; nothing to kill.
       rm -f "$fetch_err_tmp"
-      echo "  $name: fetch already in flight — the server refused a second one (session lock gc_remote_op:$name held) — skipped (NOT pushed)" >&2
+      echo "  $name: fetch already in flight — the server refused a second one (session lock $(remote_op_lock_name "$name") held) — skipped (NOT pushed)" >&2
       return 1
     elif [ "$fetch_rc" -ne 0 ] && { grep -q "no branches found in remote" "$fetch_err_tmp" 2>/dev/null || grep -q "invalid ref spec" "$fetch_err_tmp" 2>/dev/null; }; then
       # The remote has no such branch: an empty remote ("no branches found in

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -118,6 +118,9 @@ esac
 : "${GC_DOLT_USER:=root}"
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
+# This run's lock nonce (see runtime.sh, "Server-side single-flight gate"):
+# one value per script run, computed here and not at source time.
+REMOTE_OP_RUN_NONCE="$$-$(date +%s)"
 
 beads_bd="$GC_BEADS_BD_SCRIPT"
 data_dir="$DOLT_DATA_DIR"

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -536,8 +536,11 @@ sync_database_sql() {
     # death); --use-db attributes the session to this database. The id is the
     # KILL operand when the bound expires.
     # Then the server-side gate (remote_op_gate_sql): the session takes this
-    # database's lock or the batch stops here, before the CALL.
-    dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; $(remote_op_gate_sql "$name"); CALL DOLT_FETCH('$remote_name', '$remote_branch')" "$fetch_timeout" "$name" \
+    # database's lock and this run's lock or the batch stops here, before the
+    # CALL; and the CALL's own first argument re-proves that THIS session still
+    # holds the run lock (remote_op_owned_arg), so a client that reconnected in
+    # between never fetches on a lockless session.
+    dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; $(remote_op_gate_sql "$name"); CALL DOLT_FETCH($(remote_op_owned_arg "$name" "$remote_name"), '$remote_branch')" "$fetch_timeout" "$name" \
       >"$fetch_out_tmp" 2>"$fetch_err_tmp" || fetch_rc=$?
     fetch_session_id=$(remote_op_session_id "$fetch_out_tmp")
     rm -f "$fetch_out_tmp"
@@ -561,6 +564,14 @@ sync_database_sql() {
       # before the CALL; nothing to kill.
       rm -f "$fetch_err_tmp"
       echo "  $name: fetch already in flight — the server refused a second one (session lock $(remote_op_lock_name "$name") held) — skipped (NOT pushed)" >&2
+      return 1
+    elif [ "$fetch_rc" -ne 0 ] && remote_op_gate_lost "$fetch_err_tmp"; then
+      # The session that passed the gate is not the one that sent the CALL
+      # (the client reconnected in between): the CALL refused itself before
+      # the procedure ran. Nothing to kill; the lockless session ends with
+      # the client.
+      rm -f "$fetch_err_tmp"
+      echo "  $name: fetch not sent — this session lost the run lock between the gate and the CALL (client reconnected) — skipped (NOT pushed)" >&2
       return 1
     elif [ "$fetch_rc" -ne 0 ] && { grep -q "no branches found in remote" "$fetch_err_tmp" 2>/dev/null || grep -q "invalid ref spec" "$fetch_err_tmp" 2>/dev/null; }; then
       # The remote has no such branch: an empty remote ("no branches found in

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -58,8 +58,11 @@
 # issuing one the script asks the server whether a DOLT_FETCH / DOLT_PULL is
 # already in flight for the database (skipped, NOT pushed, when one is), and
 # when the fetch bound expires it KILLs the server-side session the fetch
-# printed about itself and proves it gone from the processlist. See the
-# "Server-side remote operations" helpers in assets/scripts/runtime.sh.
+# printed about itself and proves it gone from the processlist. Runners on
+# this host are serialized per database by a mkdir lock (root
+# GC_DOLT_REMOTE_OP_LOCK_ROOT, default ${TMPDIR:-/tmp}/gc-dolt-remote-op) so
+# two of them cannot both read "nothing in flight". See the "Server-side
+# remote operations" helpers in assets/scripts/runtime.sh.
 set -e
 
 dry_run=false
@@ -446,7 +449,30 @@ resolve_refspec_cli() {
   printf 'main\nmain\n'
 }
 
+# sync_database_sql <db> — sync_database_sql_locked under the per-database
+# runner lock (remote_op_lock_acquire, runtime.sh): two runners on this host
+# must not both read "nothing in flight" and both fetch. A live holder = this
+# database skipped, NOT pushed, this run; a lock root that cannot be created =
+# the same skip. The lock is held through the fetch, the classification, the
+# push and the kill-on-expiry.
 sync_database_sql() {
+  _sl_name="$1"
+  _sl_lrc=0
+  remote_op_lock_acquire "$_sl_name" || _sl_lrc=$?
+  if [ "$_sl_lrc" -eq 1 ]; then
+    echo "  $_sl_name: another gc dolt sync/pull (pid ${REMOTE_OP_LOCK_HOLDER:-unknown}) holds this database's runner lock — skipped (NOT pushed)" >&2
+    return 1
+  elif [ "$_sl_lrc" -ne 0 ]; then
+    echo "  $_sl_name: ERROR: cannot create the runner lock under $(remote_op_lock_root) — skipped (NOT pushed)" >&2
+    return 1
+  fi
+  _sl_rc=0
+  sync_database_sql_locked "$_sl_name" || _sl_rc=$?
+  remote_op_lock_release
+  return "$_sl_rc"
+}
+
+sync_database_sql_locked() {
   name="$1"
   if ! valid_database_name "$name"; then
     echo "  $name: ERROR: invalid database name" >&2
@@ -542,12 +568,13 @@ sync_database_sql() {
       # and is necessarily a fast-forward.
       ff_status="first-push"
       rm -f "$fetch_err_tmp"
-    elif [ "$fetch_rc" -eq 124 ]; then
+    elif bound_expired "$fetch_rc"; then
       rm -f "$fetch_err_tmp"
-      echo "  $name: fetch timed out after ${fetch_timeout}s — skipped (NOT pushed)" >&2
-      last_fail_reason="fetch timed out after ${fetch_timeout}s"
-      # The client is dead; the server-side fetch is not. End it and prove it
-      # ended (the outcome is reported on its own line; either way, skipped).
+      echo "  $name: fetch timed out after ${fetch_timeout}s (client exit $fetch_rc) — skipped (NOT pushed)" >&2
+      last_fail_reason="fetch timed out after ${fetch_timeout}s (client exit $fetch_rc)"
+      # The client is dead (124: the bound; 137: the bound's SIGKILL escalation);
+      # the server-side fetch is not. End it and prove it ended (the outcome is
+      # reported on its own line; either way, skipped).
       kill_remote_op_session fetch "$name" "$fetch_session_id" || true
       return 1
     elif [ "$fetch_rc" -ne 0 ]; then

--- a/examples/bd/dolt/commands/sync/run.sh
+++ b/examples/bd/dolt/commands/sync/run.sh
@@ -50,6 +50,16 @@
 #                     a fresh remote can exceed the prior fixed 120s ceiling).
 #                     Metadata queries (remote lookup, active branch) keep their
 #                     own 120s bound.
+#   GC_DOLT_SYNC_FETCH_TIMEOUT_SECS
+#     (default: 60)   — wall-clock bound for the SQL-mode pre-push fetch.
+#
+# One server-side fetch per database at a time (gp-f2yq): a CALL DOLT_FETCH
+# runs inside the sql-server and outlives a client the bound killed, so before
+# issuing one the script asks the server whether a DOLT_FETCH / DOLT_PULL is
+# already in flight for the database (skipped, NOT pushed, when one is), and
+# when the fetch bound expires it KILLs the server-side session the fetch
+# printed about itself and proves it gone from the processlist. See the
+# "Server-side remote operations" helpers in assets/scripts/runtime.sh.
 set -e
 
 dry_run=false
@@ -268,19 +278,17 @@ refspec_parts() {
   printf '%s\n%s\n' "$l" "$r"
 }
 
-# dolt_sql QUERY [TIMEOUT_SECS] — run a SQL query against the live server under a
-# wall-clock bound. The optional second arg overrides the bound; it defaults to
-# 120s, which is sized for SHORT METADATA QUERIES ONLY (remote lookup,
-# active_branch). This is a load-bearing contract: any data-transfer operation
-# (e.g. DOLT_PUSH) MUST pass its own larger bound, or it will silently re-hit
-# this 120s ceiling and be SIGKILLed mid-transfer.
+# dolt_sql QUERY [TIMEOUT_SECS] [USE_DB] — run a SQL query against the live
+# server under a wall-clock bound (dolt_sql_csv, runtime.sh). The optional
+# second arg overrides the bound; it defaults to 120s, which is sized for SHORT
+# METADATA QUERIES ONLY (remote lookup, active_branch). This is a load-bearing
+# contract: any data-transfer operation (e.g. DOLT_PUSH) MUST pass its own
+# larger bound, or it will silently re-hit this 120s ceiling and be SIGKILLed
+# mid-transfer. The optional third arg is passed as --use-db so the server
+# attributes the session to that database in its processlist (the fetch uses
+# it; a `USE` inside the query does not set that column).
 dolt_sql() {
-  query="$1"
-  tmo="${2:-120}"
-  host="${GC_DOLT_HOST:-127.0.0.1}"
-  export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
-  run_bounded "$tmo" dolt --host "$host" --port "$GC_DOLT_PORT" --user "$GC_DOLT_USER" --no-tls \
-    sql --result-format csv -q "$query"
+  dolt_sql_csv "${2:-120}" "${3:-}" "$1"
 }
 
 # classify_count <db> <revrange> — emit the dolt_log commit count for a revision
@@ -491,9 +499,42 @@ sync_database_sql() {
       last_fail_reason="cannot create temp file for fetch diagnostics"
       return 1
     }
+    # gp-f2yq: ONE server-side fetch per database at a time. A CALL DOLT_FETCH
+    # runs inside the sql-server and outlives a client the bound killed, so
+    # before issuing one, ask the server whether a fetch (or pull) is already
+    # in flight for this database and skip without fetching when one is. The
+    # check fails closed — a processlist query that fails, or answers with
+    # anything but a processlist, skips too — the same rule as the classify
+    # step below.
+    inflight_rc=0
+    inflight=$(remote_op_sessions "$name" 120 "$fetch_err_tmp") || inflight_rc=$?
+    if [ "$inflight_rc" -ne 0 ]; then
+      echo "  $name: ERROR: processlist query failed (exit $inflight_rc) — skipped (NOT pushed)" >&2
+      remote_op_replay_stderr "$name" "$fetch_err_tmp"
+      rm -f "$fetch_err_tmp"
+      return 1
+    fi
+    inflight_oldest=$(printf '%s\n' "$inflight" | remote_op_sessions_oldest)
+    if [ -n "$inflight_oldest" ]; then
+      rm -f "$fetch_err_tmp"
+      echo "  $name: fetch already in flight for ${inflight_oldest#* }s (session ${inflight_oldest%% *}) — skipped (NOT pushed)" >&2
+      return 1
+    fi
+    fetch_out_tmp=$(mktemp) || {
+      echo "  $name: ERROR: cannot create temp file for the fetch session id" >&2
+      rm -f "$fetch_err_tmp"
+      return 1
+    }
     fetch_rc=0
-    dolt_sql "USE \`$name\`; CALL DOLT_FETCH('$remote_name', '$remote_branch')" "$fetch_timeout" \
-      >/dev/null 2>"$fetch_err_tmp" || fetch_rc=$?
+    # The statement prints its OWN connection id before the procedure starts
+    # (the CLI flushes each statement's result before running the next, so
+    # the id is on disk before the fetch begins and survives the client's
+    # death); --use-db attributes the session to this database. The id is the
+    # KILL operand when the bound expires.
+    dolt_sql "USE \`$name\`; SELECT CONNECTION_ID() AS id; CALL DOLT_FETCH('$remote_name', '$remote_branch')" "$fetch_timeout" "$name" \
+      >"$fetch_out_tmp" 2>"$fetch_err_tmp" || fetch_rc=$?
+    fetch_session_id=$(remote_op_session_id "$fetch_out_tmp")
+    rm -f "$fetch_out_tmp"
     if [ "$fetch_rc" -ne 0 ] && { grep -q "no branches found in remote" "$fetch_err_tmp" 2>/dev/null || grep -q "invalid ref spec" "$fetch_err_tmp" 2>/dev/null; }; then
       # The remote has no such branch: an empty remote ("no branches found in
       # remote") or a brand-new branch on a populated remote ("invalid ref
@@ -505,6 +546,9 @@ sync_database_sql() {
       rm -f "$fetch_err_tmp"
       echo "  $name: fetch timed out after ${fetch_timeout}s — skipped (NOT pushed)" >&2
       last_fail_reason="fetch timed out after ${fetch_timeout}s"
+      # The client is dead; the server-side fetch is not. End it and prove it
+      # ended (the outcome is reported on its own line; either way, skipped).
+      kill_remote_op_session fetch "$name" "$fetch_session_id" || true
       return 1
     elif [ "$fetch_rc" -ne 0 ]; then
       echo "  $name: fetch failed (exit $fetch_rc) — skipped (NOT pushed)" >&2

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -23,7 +23,9 @@ keeps the lock until it finishes or is killed. The statement also prints its own
 connection id first and runs with `--use-db`, so when the client bound expires
 (exit 124, or 137 when GNU timeout had to escalate to SIGKILL) the script
 `KILL`s exactly that server-side session and proves it gone with a second
-processlist read (a session still listed is reported as NOT killed).
+processlist read (a session still listed is reported as NOT killed; a client
+that never learned its id kills nothing and names the sessions for the
+operator). Database names are compared and locked case-insensitively.
 `gc dolt health` adds one `WARN` line, and a `fetch_sessions` block in its
 JSON report, when more than `GC_DOLT_HEALTH_MAX_FETCH_SESSIONS` (default 2)
 such sessions are in flight server-wide; leftovers from runs older than this

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -16,7 +16,16 @@ processlist, or carries a row that is not `digits,digits,…`, also skips (fail
 closed). "In flight" means any server-side statement that names `DOLT_FETCH`
 or `DOLT_PULL` as an identifier, however the call was spelled; a statement
 that merely mentions the name in a literal or comment costs one skipped run
-while it executes, which is the safe side.
+while it executes, which is the safe side. The processlist query itself is
+constant text — no database name is interpolated into it — so a store named,
+say, `dolt_fetch` cannot make the query match its own text; the per-database
+filter is applied to the answer. One limit, by design: the processlist shows
+the statement text a session submitted, so a fetch run *indirectly* — through
+a text-protocol prepared statement (`EXECUTE s`), a user stored procedure that
+wraps the call, or an event — is invisible to the pre-check and to the health
+count, and holds no pack lock. The pack's own runs never need that visibility
+(they are serialized by the server lock below); an operator's indirect fetch is
+theirs to `KILL` by hand.
 The statement they do issue takes the server's own session lock for the
 database (`GET_LOCK('gc_remote_op:<db>', 0)`) in the same batch as the CALL:
 two runners that both read "nothing in flight" cannot both fetch, because the

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -35,16 +35,22 @@ for this run (`gc_remote_op_run:<db>:<16 random hex digits>`), and the CALL's ow
 argument re-checks that the session still holds it — Dolt evaluates expressions
 in CALL arguments — so a client that reconnected between the gate and the CALL
 fails before the procedure runs instead of fetching on a lockless session. The
-statement also prints its own connection id first and runs with `--use-db`, so
-when the client bound expires (exit 124, or 137 when GNU timeout had to escalate
-to SIGKILL) the script `KILL`s exactly that server-side session — in one batch
-that prepares the `KILL`, checks that the id still holds this run's lock, and
-only then executes the prepared handle, so a server that restarted and handed
-the number to someone else is never asked to kill them, and a client that
-reconnected between the check and the kill has no handle to execute — and proves
-it gone with a second processlist read (a session still listed is reported as
-NOT killed; a client that never learned its id kills nothing and names the
-sessions for the operator). Database names are locked case-insensitively.
+gate statement itself answers with the session's own connection id when it has
+taken both locks — one statement, so the recorded id is the lock holder by
+construction, never a session a separate statement saw before a reconnect — and
+the batch runs with `--use-db`, so when the client bound expires (exit 124, or
+137 when GNU timeout had to escalate to SIGKILL) the script `KILL`s exactly that
+server-side session — in one batch that prepares the `KILL`, checks that the id
+still holds this run's lock, and only then executes the prepared handle, so a
+server that restarted and handed the number to someone else is never asked to
+kill them, and a client that reconnected between the check and the kill has no
+handle to execute — and proves it gone with a second processlist read (a session
+still listed is reported as NOT killed; a client that never learned its id kills
+nothing and names the sessions for the operator). After the kill attempt the
+script also reads who holds this run's lock (`IS_USED_LOCK`) and never reports
+success while any session holds it: a live holder other than the recorded id is
+reported NOT killed and named for the operator. Database names are locked
+case-insensitively.
 `gc dolt health` adds one `WARN` line, and a `fetch_sessions` block in its
 JSON report, when more than `GC_DOLT_HEALTH_MAX_FETCH_SESSIONS` (default 2)
 such sessions are in flight server-wide; leftovers from runs older than this

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -13,8 +13,10 @@ when a `DOLT_FETCH` / `DOLT_PULL` session is already in flight for the database
 line naming the oldest session's age and id and skip — sync skips without
 pushing. A processlist read that fails, answers with anything that is not a
 processlist, or carries a row that is not `digits,digits,…`, also skips (fail
-closed). "In flight" is decided by a `REGEXP` on the statement text, so
-`call dolt_fetch(`, `CALL  DOLT_PULL(` and a call behind a comment all count.
+closed). "In flight" means any server-side statement that names `DOLT_FETCH`
+or `DOLT_PULL` as an identifier, however the call was spelled; a statement
+that merely mentions the name in a literal or comment costs one skipped run
+while it executes, which is the safe side.
 The statement they do issue takes the server's own session lock for the
 database (`GET_LOCK('gc_remote_op:<db>', 0)`) in the same batch as the CALL:
 two runners that both read "nothing in flight" cannot both fetch, because the

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -31,15 +31,17 @@ database (`GET_LOCK('gc_remote_op:<db>', 0)`) in the same batch as the CALL:
 two runners that both read "nothing in flight" cannot both fetch, because the
 server stops the second batch before its CALL, and a session whose client died
 keeps the lock until it finishes or is killed. The gate also takes a lock named
-for this run (`gc_remote_op_run:<db>:<pid>-<epoch>`), and the CALL's own first
+for this run (`gc_remote_op_run:<db>:<16 random hex digits>`), and the CALL's own first
 argument re-checks that the session still holds it — Dolt evaluates expressions
 in CALL arguments — so a client that reconnected between the gate and the CALL
 fails before the procedure runs instead of fetching on a lockless session. The
 statement also prints its own connection id first and runs with `--use-db`, so
 when the client bound expires (exit 124, or 137 when GNU timeout had to escalate
 to SIGKILL) the script `KILL`s exactly that server-side session — in one batch
-that first checks the id still holds this run's lock, so a server that restarted
-and handed the number to someone else is never asked to kill them — and proves
+that prepares the `KILL`, checks that the id still holds this run's lock, and
+only then executes the prepared handle, so a server that restarted and handed
+the number to someone else is never asked to kill them, and a client that
+reconnected between the check and the kill has no handle to execute — and proves
 it gone with a second processlist read (a session still listed is reported as
 NOT killed; a client that never learned its id kills nothing and names the
 sessions for the operator). Database names are locked case-insensitively.

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -30,13 +30,19 @@ The statement they do issue takes the server's own session lock for the
 database (`GET_LOCK('gc_remote_op:<db>', 0)`) in the same batch as the CALL:
 two runners that both read "nothing in flight" cannot both fetch, because the
 server stops the second batch before its CALL, and a session whose client died
-keeps the lock until it finishes or is killed. The statement also prints its own
-connection id first and runs with `--use-db`, so when the client bound expires
-(exit 124, or 137 when GNU timeout had to escalate to SIGKILL) the script
-`KILL`s exactly that server-side session and proves it gone with a second
-processlist read (a session still listed is reported as NOT killed; a client
-that never learned its id kills nothing and names the sessions for the
-operator). Database names are locked case-insensitively.
+keeps the lock until it finishes or is killed. The gate also takes a lock named
+for this run (`gc_remote_op_run:<db>:<pid>-<epoch>`), and the CALL's own first
+argument re-checks that the session still holds it — Dolt evaluates expressions
+in CALL arguments — so a client that reconnected between the gate and the CALL
+fails before the procedure runs instead of fetching on a lockless session. The
+statement also prints its own connection id first and runs with `--use-db`, so
+when the client bound expires (exit 124, or 137 when GNU timeout had to escalate
+to SIGKILL) the script `KILL`s exactly that server-side session — in one batch
+that first checks the id still holds this run's lock, so a server that restarted
+and handed the number to someone else is never asked to kill them — and proves
+it gone with a second processlist read (a session still listed is reported as
+NOT killed; a client that never learned its id kills nothing and names the
+sessions for the operator). Database names are locked case-insensitively.
 `gc dolt health` adds one `WARN` line, and a `fetch_sessions` block in its
 JSON report, when more than `GC_DOLT_HEALTH_MAX_FETCH_SESSIONS` (default 2)
 such sessions are in flight server-wide; leftovers from runs older than this

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -1,0 +1,26 @@
+# Remote sync: one server-side fetch per database, and the kill on expiry
+
+`gc dolt sync` and `gc dolt pull` run their remote operations INSIDE the managed
+sql-server (`CALL DOLT_FETCH` / `CALL DOLT_PULL`), so a client that dies when its
+wall-clock bound expires leaves the server-side procedure running. Before this
+guard, a 15-minute patrol re-issuing `gc dolt sync` stacked one more fetch per
+run on top of the abandoned ones (boomtown, 2026-09-11: 169 of 178 sql-server
+connections in `CALL DOLT_FETCH`, the oldest two days, dolt at 180% CPU, that
+store's sync dead for weeks). Both scripts now hold to one rule per database:
+before issuing a fetch or pull they read `information_schema.processlist` and,
+when a `DOLT_FETCH` / `DOLT_PULL` session is already in flight for the database
+(or attributed to no database at all, which may be this one's), they print one
+line naming the oldest session's age and id and skip — sync skips without
+pushing. A processlist read that fails, or answers with anything that is not a
+processlist, also skips (fail closed). The statement they do issue prints its
+own connection id first and runs with `--use-db`, so when the client bound
+expires the script `KILL`s exactly that server-side session and proves it gone
+with a second processlist read (a session still listed is reported as NOT
+killed). `gc dolt health` adds one `WARN` line, and a `fetch_sessions` block in
+its JSON report, when more than `GC_DOLT_HEALTH_MAX_FETCH_SESSIONS` (default 2)
+such sessions are in flight server-wide; leftovers from runs older than this
+guard need one manual `KILL <Id>` each. Bounds: `GC_DOLT_SYNC_FETCH_TIMEOUT_SECS`
+(sync's pre-push fetch, default 60), `GC_DOLT_PULL_TIMEOUT_SECS` (pull, default
+120); each must be a positive integer, an all-zero value is rejected. Nothing
+here changes the patrol order, the fast-forward classification, the push path,
+or the CLI fallback (which has no server session to guard).

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -6,10 +6,11 @@ wall-clock bound expires leaves the server-side procedure running. Before this
 guard, a 15-minute patrol re-issuing `gc dolt sync` stacked one more fetch per
 run on top of the abandoned ones (boomtown, 2026-09-11: 169 of 178 sql-server
 connections in `CALL DOLT_FETCH`, the oldest two days, dolt at 180% CPU, that
-store's sync dead for weeks). Both scripts now hold to one rule per database:
-before issuing a fetch or pull they read `information_schema.processlist` and,
-when a `DOLT_FETCH` / `DOLT_PULL` session is already in flight for the database
-(or attributed to no database at all, which may be this one's), they print one
+store's sync dead for weeks). Both scripts now hold to one rule: before
+issuing a fetch or pull they read `information_schema.processlist` and, when a
+`DOLT_FETCH` / `DOLT_PULL` session is already in flight anywhere on the server
+— the processlist `DB` column is the connection's `--use-db`, not the
+statement's target, so no per-database filter is applied to it — they print one
 line naming the oldest session's age and id and skip — sync skips without
 pushing. A processlist read that fails, answers with anything that is not a
 processlist, or carries a row that is not `digits,digits,…`, also skips (fail
@@ -18,8 +19,7 @@ or `DOLT_PULL` as an identifier, however the call was spelled; a statement
 that merely mentions the name in a literal or comment costs one skipped run
 while it executes, which is the safe side. The processlist query itself is
 constant text — no database name is interpolated into it — so a store named,
-say, `dolt_fetch` cannot make the query match its own text; the per-database
-filter is applied to the answer. One limit, by design: the processlist shows
+say, `dolt_fetch` cannot make the query match its own text. One limit, by design: the processlist shows
 the statement text a session submitted, so a fetch run *indirectly* — through
 a text-protocol prepared statement (`EXECUTE s`), a user stored procedure that
 wraps the call, or an event — is invisible to the pre-check and to the health
@@ -36,7 +36,7 @@ connection id first and runs with `--use-db`, so when the client bound expires
 `KILL`s exactly that server-side session and proves it gone with a second
 processlist read (a session still listed is reported as NOT killed; a client
 that never learned its id kills nothing and names the sessions for the
-operator). Database names are compared and locked case-insensitively, and a session attributed to a branch- or commit-qualified name (`app/main`, `app/<hash>`) counts as the database's.
+operator). Database names are locked case-insensitively.
 `gc dolt health` adds one `WARN` line, and a `fetch_sessions` block in its
 JSON report, when more than `GC_DOLT_HEALTH_MAX_FETCH_SESSIONS` (default 2)
 such sessions are in flight server-wide; leftovers from runs older than this

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -11,13 +11,21 @@ before issuing a fetch or pull they read `information_schema.processlist` and,
 when a `DOLT_FETCH` / `DOLT_PULL` session is already in flight for the database
 (or attributed to no database at all, which may be this one's), they print one
 line naming the oldest session's age and id and skip — sync skips without
-pushing. A processlist read that fails, or answers with anything that is not a
-processlist, also skips (fail closed). The statement they do issue prints its
-own connection id first and runs with `--use-db`, so when the client bound
-expires the script `KILL`s exactly that server-side session and proves it gone
-with a second processlist read (a session still listed is reported as NOT
-killed). `gc dolt health` adds one `WARN` line, and a `fetch_sessions` block in
-its JSON report, when more than `GC_DOLT_HEALTH_MAX_FETCH_SESSIONS` (default 2)
+pushing. A processlist read that fails, answers with anything that is not a
+processlist, or carries a row that is not `digits,digits,…`, also skips (fail
+closed). "In flight" is decided by a `REGEXP` on the statement text, so
+`call dolt_fetch(`, `CALL  DOLT_PULL(` and a call behind a comment all count.
+Runners on the same host are serialized per database by a mkdir lock (root
+`GC_DOLT_REMOTE_OP_LOCK_ROOT`, default `${TMPDIR:-/tmp}/gc-dolt-remote-op`),
+held from before the processlist read until the operation and its cleanup are
+done, so two runs cannot both read "nothing in flight"; a lock whose holder
+died is reclaimed by the next run. The statement they do issue prints its own
+connection id first and runs with `--use-db`, so when the client bound expires
+(exit 124, or 137 when GNU timeout had to escalate to SIGKILL) the script
+`KILL`s exactly that server-side session and proves it gone with a second
+processlist read (a session still listed is reported as NOT killed).
+`gc dolt health` adds one `WARN` line, and a `fetch_sessions` block in its
+JSON report, when more than `GC_DOLT_HEALTH_MAX_FETCH_SESSIONS` (default 2)
 such sessions are in flight server-wide; leftovers from runs older than this
 guard need one manual `KILL <Id>` each. Bounds: `GC_DOLT_SYNC_FETCH_TIMEOUT_SECS`
 (sync's pre-push fetch, default 60), `GC_DOLT_PULL_TIMEOUT_SECS` (pull, default

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -46,11 +46,13 @@ server that restarted and handed the number to someone else is never asked to
 kill them, and a client that reconnected between the check and the kill has no
 handle to execute — and proves it gone with a second processlist read (a session
 still listed is reported as NOT killed; a client that never learned its id kills
-nothing and names the sessions for the operator). After the kill attempt the
-script also reads who holds this run's lock (`IS_USED_LOCK`) and never reports
-success while any session holds it: a live holder other than the recorded id is
-reported NOT killed and named for the operator. Database names are locked
-case-insensitively.
+nothing, names any listed session for the operator, and never confirms the
+cleanup — the gate's answer never arrived, so a gate still pending on the server
+could take this run's lock after any read). After the kill attempt the script
+also reads who holds this run's lock (`IS_USED_LOCK`) and never reports success
+while any session holds it: a holder other than the recorded id, or the recorded
+id itself when it is not listed as a remote operation, is reported NOT killed and
+named for the operator. Database names are locked case-insensitively.
 `gc dolt health` adds one `WARN` line, and a `fetch_sessions` block in its
 JSON report, when more than `GC_DOLT_HEALTH_MAX_FETCH_SESSIONS` (default 2)
 such sessions are in flight server-wide; leftovers from runs older than this

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -15,11 +15,11 @@ pushing. A processlist read that fails, answers with anything that is not a
 processlist, or carries a row that is not `digits,digits,…`, also skips (fail
 closed). "In flight" is decided by a `REGEXP` on the statement text, so
 `call dolt_fetch(`, `CALL  DOLT_PULL(` and a call behind a comment all count.
-Runners on the same host are serialized per database by a mkdir lock (root
-`GC_DOLT_REMOTE_OP_LOCK_ROOT`, default `${TMPDIR:-/tmp}/gc-dolt-remote-op`),
-held from before the processlist read until the operation and its cleanup are
-done, so two runs cannot both read "nothing in flight"; a lock whose holder
-died is reclaimed by the next run. The statement they do issue prints its own
+The statement they do issue takes the server's own session lock for the
+database (`GET_LOCK('gc_remote_op:<db>', 0)`) in the same batch as the CALL:
+two runners that both read "nothing in flight" cannot both fetch, because the
+server stops the second batch before its CALL, and a session whose client died
+keeps the lock until it finishes or is killed. The statement also prints its own
 connection id first and runs with `--use-db`, so when the client bound expires
 (exit 124, or 137 when GNU timeout had to escalate to SIGKILL) the script
 `KILL`s exactly that server-side session and proves it gone with a second

--- a/examples/bd/dolt/docs/remote-sync-single-flight.md
+++ b/examples/bd/dolt/docs/remote-sync-single-flight.md
@@ -36,7 +36,7 @@ connection id first and runs with `--use-db`, so when the client bound expires
 `KILL`s exactly that server-side session and proves it gone with a second
 processlist read (a session still listed is reported as NOT killed; a client
 that never learned its id kills nothing and names the sessions for the
-operator). Database names are compared and locked case-insensitively.
+operator). Database names are compared and locked case-insensitively, and a session attributed to a branch- or commit-qualified name (`app/main`, `app/<hash>`) counts as the database's.
 `gc dolt health` adds one `WARN` line, and a `fetch_sessions` block in its
 JSON report, when more than `GC_DOLT_HEALTH_MAX_FETCH_SESSIONS` (default 2)
 such sessions are in flight server-wide; leftovers from runs older than this

--- a/examples/bd/dolt/health_test.go
+++ b/examples/bd/dolt/health_test.go
@@ -826,6 +826,14 @@ exec %q "$@"
 // sql-server.
 func reachableServerEnv(t *testing.T, root, cityPath string) []string {
 	t.Helper()
+	return reachableServerEnvWithDolt(t, root, cityPath, "#!/bin/sh\nexit 0\n")
+}
+
+// reachableServerEnvWithDolt is reachableServerEnv with a caller-supplied fake
+// dolt body (every query the caller does not answer must still exit 0 so the
+// SELECT 1 ping reads the server as reachable).
+func reachableServerEnvWithDolt(t *testing.T, root, cityPath, doltBody string) []string {
+	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -843,7 +851,7 @@ if [ "$1" = "-z" ] && [ "$host" = "127.0.0.1" ] && [ "$probe_port" = "`+port+`" 
 fi
 exit 1
 `)
-	writeExecutable(t, filepath.Join(fakeBin, "dolt"), "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), doltBody)
 
 	return append(filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
 		"GC_CITY_PATH="+cityPath,
@@ -2210,4 +2218,145 @@ func TestHealthScriptQuarantineHumanExitCode(t *testing.T) {
 			t.Errorf("transient compact siblings reported as quarantine:\n%s", out)
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// gp-f2yq: one WARN line (and a JSON block) when server-side DOLT_FETCH /
+// DOLT_PULL sessions pile up — the "fetch herd" that boomtown found by hand
+// (169 of 178 sessions in CALL DOLT_FETCH, one per patrol run for two days).
+// The probe is read-only and server-wide; the threshold is "more than N"
+// (N = 2 by default, GC_DOLT_HEALTH_MAX_FETCH_SESSIONS).
+// ---------------------------------------------------------------------------
+
+// fakeDoltAnsweringProcesslist: every query succeeds with no rows except the
+// fetch-session probe, which answers the given `Id,Time,db` rows; `arm` set
+// replaces the probe's arm body wholesale (a failing probe, for instance).
+func fakeDoltAnsweringProcesslist(rows []string, arm string) string {
+	if arm == "" {
+		body := "Id,Time,db\\n"
+		for _, r := range rows {
+			body += r + "\\n"
+		}
+		arm = "printf '" + body + "' ; exit 0"
+	}
+	return "#!/bin/sh\ncase \"$*\" in\n  *\"information_schema.processlist\"*) " + arm + " ;;\nesac\nexit 0\n"
+}
+
+type fetchSessionsReport struct {
+	FetchSessions struct {
+		Probed       bool `json:"probed"`
+		Count        int  `json:"count"`
+		OldestAgeSec int  `json:"oldest_age_sec"`
+		WarnAbove    int  `json:"warn_above"`
+		Warn         bool `json:"warn"`
+	} `json:"fetch_sessions"`
+}
+
+func healthJSONFetchSessions(t *testing.T, env []string) (fetchSessionsReport, []byte) {
+	t.Helper()
+	root := repoRoot(t)
+	out, err := newHealthScriptCmd(root, env, "--json").Output()
+	if err != nil {
+		t.Fatalf("health.sh --json failed: %v\n%s", err, out)
+	}
+	var report fetchSessionsReport
+	if err := json.Unmarshal(out, &report); err != nil {
+		t.Fatalf("parse health JSON: %v\n%s", err, out)
+	}
+	return report, out
+}
+
+func TestHealthScriptReportsFetchSessionsInJSON(t *testing.T) {
+	cityPath := t.TempDir()
+	root := repoRoot(t)
+	env := reachableServerEnvWithDolt(t, root, cityPath,
+		fakeDoltAnsweringProcesslist([]string{"11,7200,hw", "12,3600,hw", "13,19,"}, ""))
+	report, out := healthJSONFetchSessions(t, env)
+	fs := report.FetchSessions
+	if !fs.Probed || fs.Count != 3 || fs.OldestAgeSec != 7200 || fs.WarnAbove != 2 || !fs.Warn {
+		t.Fatalf("fetch_sessions = %+v; want probed, count 3, oldest 7200, warn_above 2, warn true\n%s", fs, out)
+	}
+}
+
+func TestHealthScriptFetchSessionsBelowThresholdDoesNotWarn(t *testing.T) {
+	cityPath := t.TempDir()
+	root := repoRoot(t)
+	env := reachableServerEnvWithDolt(t, root, cityPath,
+		fakeDoltAnsweringProcesslist([]string{"11,7200,hw", "12,3600,hw"}, ""))
+	report, out := healthJSONFetchSessions(t, env)
+	fs := report.FetchSessions
+	if !fs.Probed || fs.Count != 2 || fs.Warn {
+		t.Fatalf("fetch_sessions = %+v; want probed, count 2, warn false (2 is not more than 2)\n%s", fs, out)
+	}
+	human, err := newHealthScriptCmd(root, env).CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, human)
+	}
+	if strings.Contains(string(human), "DOLT_FETCH/DOLT_PULL sessions") {
+		t.Fatalf("no WARN line below the threshold.\n%s", human)
+	}
+}
+
+func TestHealthScriptFetchSessionsWarnLineHumanMode(t *testing.T) {
+	cityPath := t.TempDir()
+	root := repoRoot(t)
+	env := reachableServerEnvWithDolt(t, root, cityPath,
+		fakeDoltAnsweringProcesslist([]string{"11,7200,hw", "12,3600,hw", "13,19,hq"}, ""))
+	human, err := newHealthScriptCmd(root, env).CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed (the line is informational, exit code must stay 0): %v\n%s", err, human)
+	}
+	want := "WARN: 3 server-side DOLT_FETCH/DOLT_PULL sessions in flight (oldest 2h0m, more than 2)"
+	if !strings.Contains(string(human), want) {
+		t.Fatalf("expected %q\n%s", want, human)
+	}
+	if strings.Count(string(human), "DOLT_FETCH/DOLT_PULL sessions") != 1 {
+		t.Fatalf("exactly one line.\n%s", human)
+	}
+}
+
+func TestHealthScriptFetchSessionsThresholdOverride(t *testing.T) {
+	cityPath := t.TempDir()
+	root := repoRoot(t)
+	env := append(reachableServerEnvWithDolt(t, root, cityPath,
+		fakeDoltAnsweringProcesslist([]string{"11,7200,hw", "12,3600,hw", "13,19,hq"}, "")),
+		"GC_DOLT_HEALTH_MAX_FETCH_SESSIONS=5")
+	report, out := healthJSONFetchSessions(t, env)
+	fs := report.FetchSessions
+	if fs.Count != 3 || fs.WarnAbove != 5 || fs.Warn {
+		t.Fatalf("fetch_sessions = %+v; want count 3, warn_above 5, warn false\n%s", fs, out)
+	}
+}
+
+func TestHealthScriptRejectsInvalidFetchSessionsThreshold(t *testing.T) {
+	cityPath := t.TempDir()
+	root := repoRoot(t)
+	for _, bad := range []string{"abc", "", "0", "00", "-5"} {
+		env := append(reachableServerEnv(t, root, cityPath), "GC_DOLT_HEALTH_MAX_FETCH_SESSIONS="+bad)
+		out, err := newHealthScriptCmd(root, env, "--json").CombinedOutput()
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) || ee.ExitCode() != 2 {
+			t.Errorf("threshold %q: want exit 2, got err=%v\nout: %s", bad, err, out)
+		}
+		if !strings.Contains(string(out), "invalid GC_DOLT_HEALTH_MAX_FETCH_SESSIONS") {
+			t.Errorf("threshold %q: want validation message\nout: %s", bad, out)
+		}
+	}
+}
+
+// A probe that fails (or answers with something that is not a processlist)
+// reports probed=false and count 0 rather than a fabricated "0 in flight".
+func TestHealthScriptFetchSessionsProbeFailureIsReported(t *testing.T) {
+	cityPath := t.TempDir()
+	root := repoRoot(t)
+	env := reachableServerEnvWithDolt(t, root, cityPath,
+		fakeDoltAnsweringProcesslist(nil, "printf 'boom\\n' >&2 ; exit 1"))
+	report, out := healthJSONFetchSessions(t, env)
+	if !strings.Contains(string(out), `"fetch_sessions"`) {
+		t.Fatalf("the report must carry fetch_sessions even when the probe failed\n%s", out)
+	}
+	fs := report.FetchSessions
+	if fs.Probed || fs.Count != 0 || fs.Warn {
+		t.Fatalf("fetch_sessions = %+v; want probed false, count 0, warn false\n%s", fs, out)
+	}
 }

--- a/examples/bd/dolt/health_test.go
+++ b/examples/bd/dolt/health_test.go
@@ -2360,3 +2360,25 @@ func TestHealthScriptFetchSessionsProbeFailureIsReported(t *testing.T) {
 		t.Fatalf("fetch_sessions = %+v; want probed false, count 0, warn false\n%s", fs, out)
 	}
 }
+
+// A threshold with leading zeros passes validation; the JSON must still be
+// JSON (`"warn_above": 02` is not) and the comparison must be numeric.
+func TestHealthScriptFetchSessionsThresholdLeadingZerosStayValidJSON(t *testing.T) {
+	cityPath := t.TempDir()
+	root := repoRoot(t)
+	env := append(reachableServerEnvWithDolt(t, root, cityPath,
+		fakeDoltAnsweringProcesslist([]string{"11,7200,hw", "12,3600,hw", "13,19,hq"}, "")),
+		"GC_DOLT_HEALTH_MAX_FETCH_SESSIONS=02")
+	report, out := healthJSONFetchSessions(t, env)
+	fs := report.FetchSessions
+	if fs.Count != 3 || fs.WarnAbove != 2 || !fs.Warn {
+		t.Fatalf("fetch_sessions = %+v; want count 3, warn_above 2, warn true\n%s", fs, out)
+	}
+	human, err := newHealthScriptCmd(root, env).CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, human)
+	}
+	if !strings.Contains(string(human), "more than 2)") {
+		t.Fatalf("the WARN line must name the canonical threshold.\n%s", human)
+	}
+}

--- a/examples/bd/dolt/pull_remote_selection_test.go
+++ b/examples/bd/dolt/pull_remote_selection_test.go
@@ -36,6 +36,9 @@ func writePullFakeDoltMultiRemote(t *testing.T, dir string) string {
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    ;;
   *"SELECT name, url FROM dolt_remotes"*)
     printf 'name,url\nalpha,file:///data/remotes/alpha\ninternal,file:///data/remotes/internal\npublic,https://public.example.invalid/repo\n'
     ;;
@@ -469,6 +472,9 @@ func writePullFakeDoltSoleRemote(t *testing.T, dir string, url string) string {
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    ;;
   *"SELECT name, url FROM dolt_remotes"*)
     printf 'name,url\norigin,` + url + `\n'
     ;;

--- a/examples/bd/dolt/pull_remote_selection_test.go
+++ b/examples/bd/dolt/pull_remote_selection_test.go
@@ -151,7 +151,7 @@ func TestPullSQLMultipleRemotesOverrideSelectsFileRemote(t *testing.T) {
 	}
 
 	log := readLog(t, doltLog)
-	want := "CALL DOLT_PULL('internal', 'main')"
+	want := "= CONNECTION_ID(), 'internal', JSON_EXTRACT('gc-remote-op-lost', '$')), 'main')" // the remote is the CALL's ownership-checked first argument (gp-f2yq)
 	if !strings.Contains(log, want) {
 		t.Fatalf("expected pull from the overridden 'internal' remote.\nwant %q\nlog:\n%s\noutput:\n%s", want, log, out)
 	}
@@ -250,7 +250,7 @@ func TestPullSQLMultipleRemotesNonFileOverrideWithAllowFlagProceeds(t *testing.T
 	}
 
 	log := readLog(t, doltLog)
-	want := "CALL DOLT_PULL('public', 'main')"
+	want := "= CONNECTION_ID(), 'public', JSON_EXTRACT('gc-remote-op-lost', '$')), 'main')" // the remote is the CALL's ownership-checked first argument (gp-f2yq)
 	if !strings.Contains(log, want) {
 		t.Fatalf("expected pull from the overridden 'public' remote.\nwant %q\nlog:\n%s\noutput:\n%s", want, log, out)
 	}
@@ -588,7 +588,7 @@ func TestPullSQLSoleNonLocalRemoteWithAllowFlagProceeds(t *testing.T) {
 	}
 
 	log := readLog(t, doltLog)
-	want := "CALL DOLT_PULL('origin', 'main')"
+	want := "= CONNECTION_ID(), 'origin', JSON_EXTRACT('gc-remote-op-lost', '$')), 'main')" // the remote is the CALL's ownership-checked first argument (gp-f2yq)
 	if !strings.Contains(log, want) {
 		t.Fatalf("expected pull from the sole 'origin' remote.\nwant %q\nlog:\n%s\noutput:\n%s", want, log, out)
 	}
@@ -635,7 +635,7 @@ func TestPullSQLSoleFileRemoteProceedsWithoutOverride(t *testing.T) {
 	}
 
 	log := readLog(t, doltLog)
-	want := "CALL DOLT_PULL('origin', 'main')"
+	want := "= CONNECTION_ID(), 'origin', JSON_EXTRACT('gc-remote-op-lost', '$')), 'main')" // the remote is the CALL's ownership-checked first argument (gp-f2yq)
 	if !strings.Contains(log, want) {
 		t.Fatalf("expected pull from the sole 'origin' remote.\nwant %q\nlog:\n%s\noutput:\n%s", want, log, out)
 	}

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -198,6 +198,31 @@ func TestPullInFlightSkipsNeverPulls(t *testing.T) {
 	}
 }
 
+// A processlist probe that fails (exit 1 with stderr, the bound expiring with
+// 124, or an answer without the header) skips the pull, fail closed, with a
+// non-zero exit and the reason replayed (codex r11: the pull side had no such
+// case, so `-ne 0` mutated to `-lt 0` passed).
+func TestPullProcesslistFailureSkipsNeverPulls(t *testing.T) {
+	for _, tc := range []struct{ arm, want string }{
+		{"printf 'processlist: boom\\n' >&2 ; exit 1", "app: processlist: boom"},
+		{"exit 124", "processlist query failed (exit 124)"},
+		{"printf 'nothing here\\n' ; exit 0", "not a processlist answer"},
+	} {
+		binDir := t.TempDir()
+		logPath := writePullFakeDolt(t, binDir, tc.arm, "exit 0")
+		out, err := runPull(t, binDir, nil, "--db", "app")
+		if err == nil {
+			t.Fatalf("arm %q: a failed processlist probe must exit non-zero.\nout:\n%s", tc.arm, out)
+		}
+		if strings.Contains(readLog(t, logPath), "CALL DOLT_PULL(") {
+			t.Fatalf("arm %q: a failed processlist probe must never pull.\nout:\n%s", tc.arm, out)
+		}
+		if !strings.Contains(out, "app: ERROR: processlist query failed") || !strings.Contains(out, tc.want) {
+			t.Fatalf("arm %q: expected the failure line with %q.\nout:\n%s", tc.arm, tc.want, out)
+		}
+	}
+}
+
 // The same rule for pull: a session attributed to another database blocks
 // too (attribution is not proof of the target — codex r9), and the query text
 // carries no database name (constant text; codex r6).

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -142,8 +142,18 @@ func runPull(t *testing.T, binDir string, env []string, args ...string) (string,
 // `pullArm` (complete case arm bodies), KILLs logged and marked.
 func writePullFakeDolt(t *testing.T, dir, processlistArm, pullArm string) string {
 	t.Helper()
-	logPath := filepath.Join(dir, "dolt.log")
 	killedPrefix := filepath.Join(dir, "killed-") // KILL marks only the addressed session (codex r10)
+	killArm := "k=$(printf '%s' \"$*\" | sed -n 's/.*KILL \\([0-9][0-9]*\\).*/\\1/p') ; : > \"" + killedPrefix + "${k}\" ; exit 0"
+	// The run-lock holder query (gp-f2yq round 2) answers "free" unless a test
+	// says otherwise: the helper refuses to confirm a kill without an answer.
+	return writePullFakeDoltArms(t, dir, processlistArm, pullArm, killArm, "printf 'holder\\n0\\n' ; exit 0")
+}
+
+// writePullFakeDoltArms is writePullFakeDolt with the KILL batch and the
+// run-lock holder query answered by the given arms too.
+func writePullFakeDoltArms(t *testing.T, dir, processlistArm, pullArm, killArm, holderArm string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
 	body := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$*\" >> \"" + logPath + "\"\n" +
 		"case \"$*\" in\n" +
@@ -151,7 +161,8 @@ func writePullFakeDolt(t *testing.T, dir, processlistArm, pullArm string) string
 		"    printf 'name,url\\norigin,https://example.invalid/repo\\n' ; exit 0 ;;\n" +
 		"  *\"information_schema.processlist\"*) " + processlistArm + " ;;\n" +
 		"  *\"CALL DOLT_PULL(\"*) " + pullArm + " ;;\n" +
-		"  *\"KILL \"*) k=$(printf '%s' \"$*\" | sed -n 's/.*KILL \\([0-9][0-9]*\\).*/\\1/p') ; : > \"" + killedPrefix + "${k}\" ; exit 0 ;;\n" +
+		"  *\"KILL \"*) " + killArm + " ;;\n" +
+		"  *\"COALESCE(IS_USED_LOCK(\"*) " + holderArm + " ;;\n" +
 		"esac\nexit 0\n"
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
 		t.Fatalf("write fake dolt: %v", err)
@@ -337,8 +348,8 @@ func TestPullIsAttributedAndSelfIdentifying(t *testing.T) {
 	if pullLine == "" {
 		t.Fatalf("no pull issued.\nout:\n%s", out)
 	}
-	if !strings.Contains(pullLine, "--use-db app") || !strings.Contains(pullLine, "SELECT CONNECTION_ID() AS id;") {
-		t.Fatalf("the pull must run with --use-db app and print its own connection id first.\nline: %s", pullLine)
+	if !strings.Contains(pullLine, "--use-db app") {
+		t.Fatalf("the pull must run with --use-db app so the server attributes the session.\nline: %s", pullLine)
 	}
 	assertGateBeforeCall(t, pullLine, "app", "CALL DOLT_PULL(")
 	if !strings.Contains(out, "app: pulled from https://example.invalid/repo") {
@@ -454,4 +465,39 @@ func TestPullTimeoutOutranksGateText(t *testing.T) {
 		t.Fatalf("the timeout must outrank the gate text.\nout:\n%s", out)
 	}
 	assertGuardedKill(t, readLog(t, logPath), "81")
+}
+
+// gp-f2yq round 2: the pull's id is the gate statement's own answer (no
+// standalone SELECT CONNECTION_ID() before the locks are taken).
+func TestPullIDIsTheGateStatement(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0", "exit 0")
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	if err != nil {
+		t.Fatalf("gc dolt pull failed: %v\n%s", err, out)
+	}
+	line := fetchLineOf(t, readLog(t, logPath), "CALL DOLT_PULL(")
+	if line == "" {
+		t.Fatalf("no pull issued.\nout:\n%s", out)
+	}
+	assertIDIsTheGate(t, line, "app", "CALL DOLT_PULL(")
+}
+
+// The pull's timeout path: the recorded id is gone but another live session
+// holds this run's lock — NOT killed, named, never "already ended".
+func TestPullTimeoutKillRefusesWhenAnotherSessionHoldsTheRunLock(t *testing.T) {
+	binDir := t.TempDir()
+	notOwner := "printf 'error on line 1 for query SELECT IF(IS_USED_LOCK(...)) AS own: Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-not-owner\"\\n' >&2 ; exit 1"
+	logPath := writePullFakeDoltArms(t, binDir, "printf 'Id,Time,db\\n' ; exit 0",
+		"printf 'id\\n78\\n' ; printf 'context deadline exceeded\\n' >&2 ; exit 124",
+		notOwner, "printf 'holder\\n92\\n' ; exit 0")
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	if err == nil {
+		t.Fatalf("a timed-out pull must exit non-zero.\nout:\n%s", out)
+	}
+	assertGuardedKill(t, readLog(t, logPath), "78")
+	want := "app: server-side pull NOT killed: session 78 is gone but session 92 holds this run's lock (gc_remote_op_run:app:"
+	if !strings.Contains(out, want) || strings.Contains(out, "already ended") || strings.Contains(out, "no longer in flight") || strings.Contains(out, "pulled from") {
+		t.Fatalf("expected %q and never an ended/killed/pulled line.\nout:\n%s", want, out)
+	}
 }

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -174,7 +174,7 @@ func writePullFakeDolt(t *testing.T, dir, processlistArm, pullArm string) string
 		"    printf 'name,url\\norigin,https://example.invalid/repo\\n' ; exit 0 ;;\n" +
 		"  *\"information_schema.processlist\"*) " + processlistArm + " ;;\n" +
 		"  *\"CALL DOLT_PULL(\"*) " + pullArm + " ;;\n" +
-		"  *\"KILL \"*) k=\"$*\" ; : > \"" + killedPrefix + "${k##* }\" ; exit 0 ;;\n" +
+		"  *\"KILL \"*) k=$(printf '%s' \"$*\" | sed -n 's/.*KILL \\([0-9][0-9]*\\).*/\\1/p') ; : > \"" + killedPrefix + "${k}\" ; exit 0 ;;\n" +
 		"esac\nexit 0\n"
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
 		t.Fatalf("write fake dolt: %v", err)
@@ -322,7 +322,7 @@ func TestPullTimeoutKillsItsServerSideSession(t *testing.T) {
 	}
 	log := readLog(t, logPath)
 	pullAt := strings.Index(log, "CALL DOLT_PULL(")
-	killAt := strings.Index(log, "KILL 78\n")
+	killAt := guardedKillAt(t, log, "78")
 	if pullAt < 0 || killAt < 0 || killAt < pullAt {
 		t.Fatalf("the session the pull printed about itself must be KILLed after the bound expires.\nlog:\n%s", log)
 	}
@@ -408,7 +408,7 @@ func TestPullClientExit137StillKillsServerSideSession(t *testing.T) {
 	if !strings.Contains(out, "pull timed out after 120s") || !strings.Contains(out, "client exit 137") {
 		t.Fatalf("exit 137 must be reported as the bound expiring.\nout:\n%s", out)
 	}
-	if !strings.Contains(readLog(t, logPath), "KILL 79\n") || !strings.Contains(out, "app: server-side pull killed (session 79 no longer in flight)") {
+	if guardedKillAt(t, readLog(t, logPath), "79") < 0 || !strings.Contains(out, "app: server-side pull killed (session 79 no longer in flight)") {
 		t.Fatalf("the recorded session must be KILLed after exit 137.\nout:\n%s\nlog:\n%s", out, readLog(t, logPath))
 	}
 }
@@ -476,7 +476,5 @@ func TestPullTimeoutOutranksGateText(t *testing.T) {
 	if !strings.Contains(out, "pull timed out after 120s") || strings.Contains(out, "server refused") {
 		t.Fatalf("the timeout must outrank the gate text.\nout:\n%s", out)
 	}
-	if !strings.Contains(readLog(t, logPath), "KILL 81\n") {
-		t.Fatalf("the recorded session must be KILLed.\nlog:\n%s", readLog(t, logPath))
-	}
+	assertGuardedKill(t, readLog(t, logPath), "81")
 }

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -198,19 +198,22 @@ func TestPullInFlightSkipsNeverPulls(t *testing.T) {
 	}
 }
 
-// The same per-database filter on the answer for pull: another database's
-// in-flight session does not block this one, and the query text carries no
-// database name (constant text; codex r6).
-func TestPullInFlightOtherDatabaseDoesNotCount(t *testing.T) {
+// The same rule for pull: a session attributed to another database blocks
+// too (attribution is not proof of the target — codex r9), and the query text
+// carries no database name (constant text; codex r6).
+func TestPullInFlightOtherDatabaseCountsToo(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n52,300,other\\n' ; exit 0", "exit 0")
 	out, err := runPull(t, binDir, nil, "--db", "app")
 	log := readLog(t, logPath)
-	if err != nil {
-		t.Fatalf("another database's session must not block this pull: %v\nout:\n%s\nlog:\n%s", err, out, log)
+	if err == nil {
+		t.Fatalf("a pull skipped for an in-flight session must exit non-zero.\nout:\n%s", out)
 	}
-	if !strings.Contains(log, "CALL DOLT_PULL(") {
-		t.Fatalf("expected the pull to run.\nout:\n%s\nlog:\n%s", out, log)
+	if strings.Contains(log, "CALL DOLT_PULL(") {
+		t.Fatalf("a remote operation in flight anywhere on the server must block this pull.\nout:\n%s\nlog:\n%s", out, log)
+	}
+	if !strings.Contains(out, "app: pull already in flight for 300s (session 52) — skipped") {
+		t.Fatalf("expected the in-flight skip line.\nout:\n%s", out)
 	}
 	if q := processlistQuery(t, log); strings.Contains(q, "app") || strings.Contains(q, "LOWER(db)") {
 		t.Fatalf("the processlist query must carry no database literal.\nquery:\n%s", q)

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -217,8 +217,34 @@ func TestPullInFlightOtherDatabaseDoesNotCount(t *testing.T) {
 	}
 }
 
+// writeRecordingGtimeout installs a fake `gtimeout` first on PATH (runtime.sh
+// prefers it) that logs its arguments (`--kill-after=2 SECS cmd…`) and then
+// runs the command, so a test can prove WHICH bound reached WHICH call.
+func writeRecordingGtimeout(t *testing.T, dir string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "gtimeout.log")
+	body := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"" + logPath + "\"\nshift 2\nexec \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "gtimeout"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake gtimeout: %v", err)
+	}
+	return logPath
+}
+
+// assertBounded pins that some bounded invocation ran under `secs` seconds and
+// carried `needle` in its command line.
+func assertBounded(t *testing.T, tlog, secs, needle string) {
+	t.Helper()
+	for _, line := range strings.Split(tlog, "\n") {
+		if strings.HasPrefix(line, "--kill-after=2 "+secs+" ") && strings.Contains(line, needle) {
+			return
+		}
+	}
+	t.Fatalf("no bounded call under %ss carrying %q.\ngtimeout log:\n%s", secs, needle, tlog)
+}
+
 func TestPullTimeoutKillsItsServerSideSession(t *testing.T) {
 	binDir := t.TempDir()
+	tlogPath := writeRecordingGtimeout(t, binDir)
 	started := filepath.Join(binDir, "pull-started")
 	killed := filepath.Join(binDir, "killed")
 	processlist := "if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'; " +
@@ -245,6 +271,12 @@ func TestPullTimeoutKillsItsServerSideSession(t *testing.T) {
 	if strings.Contains(out, "pulled from") {
 		t.Fatalf("a timed-out pull must not be reported as pulled.\nout:\n%s", out)
 	}
+	// The configured bound is what the pull ran under (not the 120 s the
+	// metadata queries use), proven by the recorded gtimeout arguments
+	// (codex r7: a fake that exits 124 on its own satisfied the line alone).
+	tlog := readLog(t, tlogPath)
+	assertBounded(t, tlog, "7", "CALL DOLT_PULL(")
+	assertBounded(t, tlog, "120", "information_schema.processlist")
 }
 
 func TestPullIsAttributedAndSelfIdentifying(t *testing.T) {
@@ -320,6 +352,7 @@ func TestPullClientExit137StillKillsServerSideSession(t *testing.T) {
 // A bound with leading zeros is accepted as the integer it is, and reported so.
 func TestPullTimeoutLeadingZerosAreCanonical(t *testing.T) {
 	binDir := t.TempDir()
+	tlogPath := writeRecordingGtimeout(t, binDir)
 	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0", "printf 'id\\n80\\n' ; exit 124")
 	out, err := runPull(t, binDir, []string{"GC_DOLT_PULL_TIMEOUT_SECS=0007"}, "--db", "app")
 	if err == nil {
@@ -337,6 +370,8 @@ func TestPullTimeoutLeadingZerosAreCanonical(t *testing.T) {
 	if pullLine == "" {
 		t.Fatalf("no pull issued.\nout:\n%s", out)
 	}
+	// The canonical value (7, not 0007) is the bound the pull ran under.
+	assertBounded(t, readLog(t, tlogPath), "7", "CALL DOLT_PULL(")
 }
 
 // The server refused the pull's gate (another session holds the database's

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -198,6 +198,25 @@ func TestPullInFlightSkipsNeverPulls(t *testing.T) {
 	}
 }
 
+// The same per-database filter on the answer for pull: another database's
+// in-flight session does not block this one, and the query text carries no
+// database name (constant text; codex r6).
+func TestPullInFlightOtherDatabaseDoesNotCount(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n52,300,other\\n' ; exit 0", "exit 0")
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	log := readLog(t, logPath)
+	if err != nil {
+		t.Fatalf("another database's session must not block this pull: %v\nout:\n%s\nlog:\n%s", err, out, log)
+	}
+	if !strings.Contains(log, "CALL DOLT_PULL(") {
+		t.Fatalf("expected the pull to run.\nout:\n%s\nlog:\n%s", out, log)
+	}
+	if q := processlistQuery(t, log); strings.Contains(q, "app") || strings.Contains(q, "LOWER(db)") {
+		t.Fatalf("the processlist query must carry no database literal.\nquery:\n%s", q)
+	}
+}
+
 func TestPullTimeoutKillsItsServerSideSession(t *testing.T) {
 	binDir := t.TempDir()
 	started := filepath.Join(binDir, "pull-started")

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -1,6 +1,7 @@
 package dolt_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -115,7 +116,161 @@ func TestPullReportsLiveSQLRemoteLookupFailure(t *testing.T) {
 	if !strings.Contains(log, "SELECT name, url FROM dolt_remotes ORDER BY name") {
 		t.Fatalf("dolt log missing remote lookup:\n%s", log)
 	}
-	if strings.Contains(log, "DOLT_PULL") {
+	if strings.Contains(log, "CALL DOLT_PULL(") {
 		t.Fatalf("pull should not run after remote lookup failure:\n%s", log)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gp-f2yq: the pull path carries the same two guards as sync — one server-side
+// DOLT_PULL / DOLT_FETCH per database at a time, and the server-side call is
+// killed (and proven gone) when the client bound expires — plus its own
+// validated bound, GC_DOLT_PULL_TIMEOUT_SECS.
+// ---------------------------------------------------------------------------
+
+// runPull runs `gc dolt pull <args>` against a one-DB ("app") SQL-mode city
+// with the fake dolt already installed in binDir.
+func runPull(t *testing.T, binDir string, env []string, args ...string) (string, error) {
+	t.Helper()
+	root := repoRoot(t)
+	script := filepath.Join(root, pullScript)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", append([]string{script}, args...)...)
+	cmd.Env = append(append(filteredEnv("PATH"),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		// upstream's pull refuses a sole non-file:// remote without this opt-in
+		"GC_DOLT_PULL_ALLOW_REMOTE_APP=1",
+	), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// writePullFakeDolt installs a fake dolt for the SQL pull path: remote lookup
+// answered, the processlist answered by `processlistArm`, DOLT_PULL by
+// `pullArm` (complete case arm bodies), KILLs logged and marked.
+func writePullFakeDolt(t *testing.T, dir, processlistArm, pullArm string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	killed := filepath.Join(dir, "killed")
+	body := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"case \"$*\" in\n" +
+		"  *\"SELECT name, url FROM dolt_remotes\"*)\n" +
+		"    printf 'name,url\\norigin,https://example.invalid/repo\\n' ; exit 0 ;;\n" +
+		"  *\"information_schema.processlist\"*) " + processlistArm + " ;;\n" +
+		"  *\"CALL DOLT_PULL(\"*) " + pullArm + " ;;\n" +
+		"  *\"KILL \"*) : > \"" + killed + "\" ; exit 0 ;;\n" +
+		"esac\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return logPath
+}
+
+func TestPullInFlightSkipsNeverPulls(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n51,900,app\\n' ; exit 0", "exit 0")
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	if err == nil {
+		t.Fatalf("a pull skipped for an in-flight session must exit non-zero.\nout:\n%s", out)
+	}
+	log := readLog(t, logPath)
+	if strings.Contains(log, "CALL DOLT_PULL(") {
+		t.Fatalf("a remote operation already in flight for the db must NOT start a pull.\nout:\n%s\nlog:\n%s", out, log)
+	}
+	if !strings.Contains(out, "app: pull already in flight for 900s (session 51) — skipped") {
+		t.Fatalf("expected the in-flight skip line.\nout:\n%s", out)
+	}
+}
+
+func TestPullTimeoutKillsItsServerSideSession(t *testing.T) {
+	binDir := t.TempDir()
+	started := filepath.Join(binDir, "pull-started")
+	killed := filepath.Join(binDir, "killed")
+	processlist := "if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'; " +
+		"elif [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n78,120,app\\n'; " +
+		"else printf 'Id,Time,db\\n'; fi ; exit 0"
+	pull := ": > \"" + started + "\" ; printf 'id\\n78\\n' ; printf 'context deadline exceeded\\n' >&2 ; exit 124"
+	logPath := writePullFakeDolt(t, binDir, processlist, pull)
+	out, err := runPull(t, binDir, []string{"GC_DOLT_PULL_TIMEOUT_SECS=7"}, "--db", "app")
+	if err == nil {
+		t.Fatalf("a timed-out pull must exit non-zero.\nout:\n%s", out)
+	}
+	log := readLog(t, logPath)
+	pullAt := strings.Index(log, "CALL DOLT_PULL(")
+	killAt := strings.Index(log, "KILL 78")
+	if pullAt < 0 || killAt < 0 || killAt < pullAt {
+		t.Fatalf("the session the pull printed about itself must be KILLed after the bound expires.\nlog:\n%s", log)
+	}
+	if !strings.Contains(out, "app: pull timed out after 7s") {
+		t.Fatalf("expected the pull timeout line naming the bound.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "app: server-side pull killed (session 78 no longer in flight)") {
+		t.Fatalf("expected the kill line proven by the processlist after KILL.\nout:\n%s", out)
+	}
+	if strings.Contains(out, "pulled from") {
+		t.Fatalf("a timed-out pull must not be reported as pulled.\nout:\n%s", out)
+	}
+}
+
+func TestPullIsAttributedAndSelfIdentifying(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0", "exit 0")
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	if err != nil {
+		t.Fatalf("gc dolt pull failed: %v\n%s", err, out)
+	}
+	var pullLine string
+	for _, line := range strings.Split(readLog(t, logPath), "\n") {
+		if strings.Contains(line, "CALL DOLT_PULL(") {
+			pullLine = line
+			break
+		}
+	}
+	if pullLine == "" {
+		t.Fatalf("no pull issued.\nout:\n%s", out)
+	}
+	if !strings.Contains(pullLine, "--use-db app") || !strings.Contains(pullLine, "SELECT CONNECTION_ID() AS id;") {
+		t.Fatalf("the pull must run with --use-db app and print its own connection id first.\nline: %s", pullLine)
+	}
+	if !strings.Contains(out, "app: pulled from https://example.invalid/repo") {
+		t.Fatalf("expected the pulled line.\nout:\n%s", out)
+	}
+}
+
+// TestPullRejectsInvalidTimeout: GC_DOLT_PULL_TIMEOUT_SECS is validated at
+// startup the way the sync bounds are — empty / non-numeric / all-zero aborts
+// with exit 2 before any database is touched (GNU `timeout 0` would run the
+// pull unbounded).
+func TestPullRejectsInvalidTimeout(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0", "exit 0")
+	for _, bad := range []string{"abc", "", "0", "00", "-5"} {
+		out, err := runPull(t, binDir, []string{"GC_DOLT_PULL_TIMEOUT_SECS=" + bad}, "--db", "app")
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) || ee.ExitCode() != 2 {
+			t.Errorf("pull timeout %q: want exit 2, got err=%v\nout: %s", bad, err, out)
+		}
+		if !strings.Contains(out, "invalid GC_DOLT_PULL_TIMEOUT_SECS") {
+			t.Errorf("pull timeout %q: want validation message\nout: %s", bad, out)
+		}
+	}
+	if readLog(t, logPath) != "" {
+		t.Fatalf("an invalid bound must abort before dolt is ever invoked.\nlog:\n%s", readLog(t, logPath))
 	}
 }

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -59,7 +59,7 @@ func TestPullUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
 	log := string(data)
 	for _, want := range []string{
 		"SELECT name, url FROM dolt_remotes ORDER BY name",
-		"CALL DOLT_PULL('origin', 'main')",
+		"CALL DOLT_PULL(", "= CONNECTION_ID(), 'origin', JSON_EXTRACT('gc-remote-op-lost', '$')), 'main')", // the remote is the CALL's ownership-checked first argument
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("dolt log missing %q\nlog:\n%s\noutput:\n%s", want, log, out)

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -155,7 +155,6 @@ func runPull(t *testing.T, binDir string, env []string, args ...string) (string,
 		"GC_DOLT_PASSWORD=",
 		// upstream's pull refuses a sole non-file:// remote without this opt-in
 		"GC_DOLT_PULL_ALLOW_REMOTE_APP=1",
-		"GC_DOLT_REMOTE_OP_LOCK_ROOT="+t.TempDir(),
 	), env...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
@@ -249,6 +248,7 @@ func TestPullIsAttributedAndSelfIdentifying(t *testing.T) {
 	if !strings.Contains(pullLine, "--use-db app") || !strings.Contains(pullLine, "SELECT CONNECTION_ID() AS id;") {
 		t.Fatalf("the pull must run with --use-db app and print its own connection id first.\nline: %s", pullLine)
 	}
+	assertGateBeforeCall(t, pullLine, "app", "CALL DOLT_PULL(")
 	if !strings.Contains(out, "app: pulled from https://example.invalid/repo") {
 		t.Fatalf("expected the pulled line.\nout:\n%s", out)
 	}
@@ -273,38 +273,6 @@ func TestPullRejectsInvalidTimeout(t *testing.T) {
 	}
 	if readLog(t, logPath) != "" {
 		t.Fatalf("an invalid bound must abort before dolt is ever invoked.\nlog:\n%s", readLog(t, logPath))
-	}
-}
-
-// A live runner holding this database's runner lock (here: the test process
-// itself) means the pull is skipped without touching the server's remote
-// operation path.
-func TestPullRunnerLockHeldSkips(t *testing.T) {
-	binDir := t.TempDir()
-	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0", "exit 0")
-	port, cleanup := startReachableTCPListener(t)
-	defer cleanup()
-	lockRoot := t.TempDir()
-	dir := remoteOpLockDir(lockRoot, port, "app")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatalf("mkdir lock: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "pid"), []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o600); err != nil {
-		t.Fatalf("write pid: %v", err)
-	}
-	out, err := runPull(t, binDir, []string{fmt.Sprintf("GC_DOLT_PORT=%d", port), "GC_DOLT_REMOTE_OP_LOCK_ROOT=" + lockRoot}, "--db", "app")
-	if err == nil {
-		t.Fatalf("a pull skipped for a held lock must exit non-zero.\nout:\n%s", out)
-	}
-	if strings.Contains(readLog(t, logPath), "CALL DOLT_PULL(") {
-		t.Fatalf("a held lock must not start a pull.\nout:\n%s", out)
-	}
-	want := fmt.Sprintf("app: another gc dolt sync/pull (pid %d) holds this database's runner lock — skipped", os.Getpid())
-	if !strings.Contains(out, want) {
-		t.Fatalf("expected %q\nout:\n%s", want, out)
-	}
-	if _, statErr := os.Stat(dir); statErr != nil {
-		t.Fatalf("a live holder's lock must be left alone: %v", statErr)
 	}
 }
 
@@ -349,5 +317,24 @@ func TestPullTimeoutLeadingZerosAreCanonical(t *testing.T) {
 	}
 	if pullLine == "" {
 		t.Fatalf("no pull issued.\nout:\n%s", out)
+	}
+}
+
+// The server refused the pull's gate (another session holds the database's
+// lock): reported as in flight, exit non-zero, nothing KILLed.
+func TestPullGateRefusedSkips(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0",
+		"printf 'id\\n62\\n' ; printf 'error on line 1 for query SELECT IF(GET_LOCK(...)) AS gate: Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-lock-held\"\\n' >&2 ; exit 1")
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	if err == nil {
+		t.Fatalf("a refused gate must exit non-zero.\nout:\n%s", out)
+	}
+	if strings.Contains(readLog(t, logPath), "KILL ") {
+		t.Fatalf("a refused gate sent no CALL: nothing to KILL.\nlog:\n%s", readLog(t, logPath))
+	}
+	want := "app: pull already in flight — the server refused a second one (session lock gc_remote_op:app held) — skipped"
+	if !strings.Contains(out, want) || strings.Contains(out, "pulled from") || strings.Contains(out, "pull failed") {
+		t.Fatalf("expected %q and no success/failure line.\nout:\n%s", want, out)
 	}
 }

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -155,6 +155,7 @@ func runPull(t *testing.T, binDir string, env []string, args ...string) (string,
 		"GC_DOLT_PASSWORD=",
 		// upstream's pull refuses a sole non-file:// remote without this opt-in
 		"GC_DOLT_PULL_ALLOW_REMOTE_APP=1",
+		"GC_DOLT_REMOTE_OP_LOCK_ROOT="+t.TempDir(),
 	), env...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
@@ -272,5 +273,81 @@ func TestPullRejectsInvalidTimeout(t *testing.T) {
 	}
 	if readLog(t, logPath) != "" {
 		t.Fatalf("an invalid bound must abort before dolt is ever invoked.\nlog:\n%s", readLog(t, logPath))
+	}
+}
+
+// A live runner holding this database's runner lock (here: the test process
+// itself) means the pull is skipped without touching the server's remote
+// operation path.
+func TestPullRunnerLockHeldSkips(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0", "exit 0")
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+	lockRoot := t.TempDir()
+	dir := remoteOpLockDir(lockRoot, port, "app")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir lock: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pid"), []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+	out, err := runPull(t, binDir, []string{fmt.Sprintf("GC_DOLT_PORT=%d", port), "GC_DOLT_REMOTE_OP_LOCK_ROOT=" + lockRoot}, "--db", "app")
+	if err == nil {
+		t.Fatalf("a pull skipped for a held lock must exit non-zero.\nout:\n%s", out)
+	}
+	if strings.Contains(readLog(t, logPath), "CALL DOLT_PULL(") {
+		t.Fatalf("a held lock must not start a pull.\nout:\n%s", out)
+	}
+	want := fmt.Sprintf("app: another gc dolt sync/pull (pid %d) holds this database's runner lock — skipped", os.Getpid())
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected %q\nout:\n%s", want, out)
+	}
+	if _, statErr := os.Stat(dir); statErr != nil {
+		t.Fatalf("a live holder's lock must be left alone: %v", statErr)
+	}
+}
+
+// GNU timeout's SIGKILL escalation exits 137: the same cleanup as 124.
+func TestPullClientExit137StillKillsServerSideSession(t *testing.T) {
+	binDir := t.TempDir()
+	started := filepath.Join(binDir, "pull-started")
+	killed := filepath.Join(binDir, "killed")
+	processlist := "if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'; " +
+		"elif [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n79,130,app\\n'; " +
+		"else printf 'Id,Time,db\\n'; fi ; exit 0"
+	pull := ": > \"" + started + "\" ; printf 'id\\n79\\n' ; exit 137"
+	logPath := writePullFakeDolt(t, binDir, processlist, pull)
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	if err == nil {
+		t.Fatalf("exit 137 must exit non-zero.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "pull timed out after 120s") || !strings.Contains(out, "client exit 137") {
+		t.Fatalf("exit 137 must be reported as the bound expiring.\nout:\n%s", out)
+	}
+	if !strings.Contains(readLog(t, logPath), "KILL 79") || !strings.Contains(out, "app: server-side pull killed (session 79 no longer in flight)") {
+		t.Fatalf("the recorded session must be KILLed after exit 137.\nout:\n%s\nlog:\n%s", out, readLog(t, logPath))
+	}
+}
+
+// A bound with leading zeros is accepted as the integer it is, and reported so.
+func TestPullTimeoutLeadingZerosAreCanonical(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0", "printf 'id\\n80\\n' ; exit 124")
+	out, err := runPull(t, binDir, []string{"GC_DOLT_PULL_TIMEOUT_SECS=0007"}, "--db", "app")
+	if err == nil {
+		t.Fatalf("a timed-out pull must exit non-zero.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "app: pull timed out after 7s") {
+		t.Fatalf("0007 must be reported as 7s.\nout:\n%s", out)
+	}
+	var pullLine string
+	for _, line := range strings.Split(readLog(t, logPath), "\n") {
+		if strings.Contains(line, "CALL DOLT_PULL(") {
+			pullLine = line
+		}
+	}
+	if pullLine == "" {
+		t.Fatalf("no pull issued.\nout:\n%s", out)
 	}
 }

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -132,31 +132,8 @@ func TestPullReportsLiveSQLRemoteLookupFailure(t *testing.T) {
 // with the fake dolt already installed in binDir.
 func runPull(t *testing.T, binDir string, env []string, args ...string) (string, error) {
 	t.Helper()
-	root := repoRoot(t)
-	script := filepath.Join(root, pullScript)
-	port, cleanup := startReachableTCPListener(t)
-	defer cleanup()
-
-	cityPath := t.TempDir()
-	dataDir := filepath.Join(cityPath, "data")
-	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
-		t.Fatalf("mkdir db: %v", err)
-	}
-	_ = writeSyncFakeBeadsBD(t, cityPath)
-
-	cmd := exec.Command("sh", append([]string{script}, args...)...)
-	cmd.Env = append(append(filteredEnv("PATH"),
-		"PATH="+binDir+":"+os.Getenv("PATH"),
-		"GC_CITY_PATH="+cityPath,
-		"GC_PACK_DIR="+root,
-		"GC_DOLT_DATA_DIR="+dataDir,
-		fmt.Sprintf("GC_DOLT_PORT=%d", port),
-		"GC_DOLT_USER=root",
-		"GC_DOLT_PASSWORD=",
-		// upstream's pull refuses a sole non-file:// remote without this opt-in
-		"GC_DOLT_PULL_ALLOW_REMOTE_APP=1",
-	), env...)
-	out, err := cmd.CombinedOutput()
+	// upstream's pull refuses a sole non-file:// remote without this opt-in
+	out, err := packScriptCmd(t, pullScript, binDir, append(filteredEnv("PATH"), "GC_DOLT_PULL_ALLOW_REMOTE_APP=1"), env, args...).CombinedOutput()
 	return string(out), err
 }
 

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -223,6 +223,24 @@ func TestPullProcesslistFailureSkipsNeverPulls(t *testing.T) {
 	}
 }
 
+// The pull's CALL refused itself (the session lost this run's lock before
+// the CALL — codex r12): its own line, nothing KILLed, non-zero exit.
+func TestPullLostRunLockBeforeCallSkipsKillsNothing(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0",
+		"printf 'id\\n66\\n' ; printf 'error on line 1 for query CALL DOLT_PULL(IF(...)): Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-lost\"\\n' >&2 ; exit 1")
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	if err == nil {
+		t.Fatalf("a pull whose CALL refused itself must exit non-zero.\nout:\n%s", out)
+	}
+	if strings.Contains(readLog(t, logPath), "KILL ") || strings.Contains(out, "pulled from") {
+		t.Fatalf("nothing to kill, nothing pulled.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "app: pull not sent — this session lost the run lock between the gate and the CALL") {
+		t.Fatalf("expected the lost-lock line.\nout:\n%s", out)
+	}
+}
+
 // The same rule for pull: a session attributed to another database blocks
 // too (attribution is not proof of the target — codex r9), and the query text
 // carries no database name (constant text; codex r6).

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -242,6 +242,24 @@ func assertBounded(t *testing.T, tlog, secs, needle string) {
 	t.Fatalf("no bounded call under %ss carrying %q.\ngtimeout log:\n%s", secs, needle, tlog)
 }
 
+// The same marker-collision rule for pull: an ordinary error whose echoed
+// statement carries gc-remote-op-lock-held is a pull failure, not a refusal.
+func TestPullGateMarkerInOrdinaryErrorIsNotRefusal(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writePullFakeDolt(t, binDir, "printf 'Id,Time,db\\n' ; exit 0",
+		"printf 'id\\n64\\n' ; printf 'error on line 1 for query CALL DOLT_PULL(''gc-remote-op-lock-held'', ''main''): Error 1105 (HY000): remote not found\\n' >&2 ; exit 1")
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	if err == nil {
+		t.Fatalf("a failed pull must exit non-zero.\nout:\n%s", out)
+	}
+	if strings.Contains(out, "already in flight") {
+		t.Fatalf("an ordinary error echoing the marker must not read as a gate refusal.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "pull failed (exit 1)") || !strings.Contains(out, "remote not found") {
+		t.Fatalf("expected the ordinary pull error with dolt's stderr replayed.\nout:\n%s\nlog:\n%s", out, readLog(t, logPath))
+	}
+}
+
 func TestPullTimeoutKillsItsServerSideSession(t *testing.T) {
 	binDir := t.TempDir()
 	tlogPath := writeRecordingGtimeout(t, binDir)

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -338,3 +338,27 @@ func TestPullGateRefusedSkips(t *testing.T) {
 		t.Fatalf("expected %q and no success/failure line.\nout:\n%s", want, out)
 	}
 }
+
+// The bound's verdict outranks the gate marker too: a client that printed the
+// refusal and then stalled until the bound killed it is a dead client whose
+// session (ours by the id it printed) is KILLed, not a quiet skip.
+func TestPullTimeoutOutranksGateText(t *testing.T) {
+	binDir := t.TempDir()
+	started := filepath.Join(binDir, "pull-started")
+	killed := filepath.Join(binDir, "killed")
+	processlist := "if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'; " +
+		"elif [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n81,9,app\\n'; " +
+		"else printf 'Id,Time,db\\n'; fi ; exit 0"
+	pull := ": > \"" + started + "\" ; printf 'id\\n81\\n' ; printf 'Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-lock-held\"\\n' >&2 ; exit 124"
+	logPath := writePullFakeDolt(t, binDir, processlist, pull)
+	out, err := runPull(t, binDir, nil, "--db", "app")
+	if err == nil {
+		t.Fatalf("a timed-out pull must exit non-zero.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "pull timed out after 120s") || strings.Contains(out, "server refused") {
+		t.Fatalf("the timeout must outrank the gate text.\nout:\n%s", out)
+	}
+	if !strings.Contains(readLog(t, logPath), "KILL 81") {
+		t.Fatalf("the recorded session must be KILLed.\nlog:\n%s", readLog(t, logPath))
+	}
+}

--- a/examples/bd/dolt/pull_test.go
+++ b/examples/bd/dolt/pull_test.go
@@ -166,7 +166,7 @@ func runPull(t *testing.T, binDir string, env []string, args ...string) (string,
 func writePullFakeDolt(t *testing.T, dir, processlistArm, pullArm string) string {
 	t.Helper()
 	logPath := filepath.Join(dir, "dolt.log")
-	killed := filepath.Join(dir, "killed")
+	killedPrefix := filepath.Join(dir, "killed-") // KILL marks only the addressed session (codex r10)
 	body := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$*\" >> \"" + logPath + "\"\n" +
 		"case \"$*\" in\n" +
@@ -174,7 +174,7 @@ func writePullFakeDolt(t *testing.T, dir, processlistArm, pullArm string) string
 		"    printf 'name,url\\norigin,https://example.invalid/repo\\n' ; exit 0 ;;\n" +
 		"  *\"information_schema.processlist\"*) " + processlistArm + " ;;\n" +
 		"  *\"CALL DOLT_PULL(\"*) " + pullArm + " ;;\n" +
-		"  *\"KILL \"*) : > \"" + killed + "\" ; exit 0 ;;\n" +
+		"  *\"KILL \"*) k=\"$*\" ; : > \"" + killedPrefix + "${k##* }\" ; exit 0 ;;\n" +
 		"esac\nexit 0\n"
 	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
 		t.Fatalf("write fake dolt: %v", err)
@@ -267,7 +267,7 @@ func TestPullTimeoutKillsItsServerSideSession(t *testing.T) {
 	binDir := t.TempDir()
 	tlogPath := writeRecordingGtimeout(t, binDir)
 	started := filepath.Join(binDir, "pull-started")
-	killed := filepath.Join(binDir, "killed")
+	killed := filepath.Join(binDir, "killed-78")
 	processlist := "if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'; " +
 		"elif [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n78,120,app\\n'; " +
 		"else printf 'Id,Time,db\\n'; fi ; exit 0"
@@ -279,7 +279,7 @@ func TestPullTimeoutKillsItsServerSideSession(t *testing.T) {
 	}
 	log := readLog(t, logPath)
 	pullAt := strings.Index(log, "CALL DOLT_PULL(")
-	killAt := strings.Index(log, "KILL 78")
+	killAt := strings.Index(log, "KILL 78\n")
 	if pullAt < 0 || killAt < 0 || killAt < pullAt {
 		t.Fatalf("the session the pull printed about itself must be KILLed after the bound expires.\nlog:\n%s", log)
 	}
@@ -352,7 +352,7 @@ func TestPullRejectsInvalidTimeout(t *testing.T) {
 func TestPullClientExit137StillKillsServerSideSession(t *testing.T) {
 	binDir := t.TempDir()
 	started := filepath.Join(binDir, "pull-started")
-	killed := filepath.Join(binDir, "killed")
+	killed := filepath.Join(binDir, "killed-79")
 	processlist := "if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'; " +
 		"elif [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n79,130,app\\n'; " +
 		"else printf 'Id,Time,db\\n'; fi ; exit 0"
@@ -365,7 +365,7 @@ func TestPullClientExit137StillKillsServerSideSession(t *testing.T) {
 	if !strings.Contains(out, "pull timed out after 120s") || !strings.Contains(out, "client exit 137") {
 		t.Fatalf("exit 137 must be reported as the bound expiring.\nout:\n%s", out)
 	}
-	if !strings.Contains(readLog(t, logPath), "KILL 79") || !strings.Contains(out, "app: server-side pull killed (session 79 no longer in flight)") {
+	if !strings.Contains(readLog(t, logPath), "KILL 79\n") || !strings.Contains(out, "app: server-side pull killed (session 79 no longer in flight)") {
 		t.Fatalf("the recorded session must be KILLed after exit 137.\nout:\n%s\nlog:\n%s", out, readLog(t, logPath))
 	}
 }
@@ -420,7 +420,7 @@ func TestPullGateRefusedSkips(t *testing.T) {
 func TestPullTimeoutOutranksGateText(t *testing.T) {
 	binDir := t.TempDir()
 	started := filepath.Join(binDir, "pull-started")
-	killed := filepath.Join(binDir, "killed")
+	killed := filepath.Join(binDir, "killed-81")
 	processlist := "if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'; " +
 		"elif [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n81,9,app\\n'; " +
 		"else printf 'Id,Time,db\\n'; fi ; exit 0"
@@ -433,7 +433,7 @@ func TestPullTimeoutOutranksGateText(t *testing.T) {
 	if !strings.Contains(out, "pull timed out after 120s") || strings.Contains(out, "server refused") {
 		t.Fatalf("the timeout must outrank the gate text.\nout:\n%s", out)
 	}
-	if !strings.Contains(readLog(t, logPath), "KILL 81") {
+	if !strings.Contains(readLog(t, logPath), "KILL 81\n") {
 		t.Fatalf("the recorded session must be KILLed.\nlog:\n%s", readLog(t, logPath))
 	}
 }

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -629,7 +629,7 @@ func writeSyncFakeDoltFetchTimeoutKill(t *testing.T, dir, sessionID string, list
 		"    else printf 'Id,Time,db\\n'; fi\n" +
 		"    exit 0 ;;\n" +
 		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; " + idEmit + "printf 'context deadline exceeded\\n' >&2 ; exit 124 ;;\n" +
-		"  *\"KILL \"*) k=\"$*\" ; : > \"" + killedPrefix + "${k##* }\" ; exit 0 ;;\n" +
+		"  *\"KILL \"*) k=$(printf '%s' \"$*\" | sed -n 's/.*KILL \\([0-9][0-9]*\\).*/\\1/p') ; : > \"" + killedPrefix + "${k}\" ; exit 0 ;;\n" +
 		"esac\nexit 0\n"
 	return installFFFakeDolt(t, dir, body)
 }
@@ -842,7 +842,7 @@ func TestSyncFetchTimeoutKillsItsServerSideSession(t *testing.T) {
 		t.Fatalf("expected the 'fetch timed out' status.\nout:\n%s", out)
 	}
 	fetchAt := strings.Index(log, "CALL DOLT_FETCH(")
-	killAt := strings.Index(log, "KILL 77\n")
+	killAt := guardedKillAt(t, log, "77")
 	if fetchAt < 0 || killAt < 0 || killAt < fetchAt {
 		t.Fatalf("the session the fetch printed about itself must be KILLed after the fetch times out.\nlog:\n%s", log)
 	}
@@ -861,9 +861,7 @@ func TestSyncFetchTimeoutKillNotConfirmedReportsStillInFlight(t *testing.T) {
 	if pushed(log) {
 		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
 	}
-	if !strings.Contains(log, "KILL 77\n") {
-		t.Fatalf("KILL must be issued.\nlog:\n%s", log)
-	}
+	assertGuardedKill(t, log, "77")
 	if !strings.Contains(out, "app: server-side fetch NOT killed (session 77 still in flight after KILL)") {
 		t.Fatalf("a session still listed after KILL must be reported as NOT killed.\nout:\n%s", out)
 	}
@@ -884,9 +882,7 @@ func TestSyncFetchBoundReachesTheFetch(t *testing.T) {
 	if !strings.Contains(out, "app: fetch timed out after 9s") {
 		t.Fatalf("expected the timeout line naming the configured bound.\nout:\n%s", out)
 	}
-	if !strings.Contains(readLog(t, logPath), "KILL 77\n") {
-		t.Fatalf("KILL must be issued.\nout:\n%s", out)
-	}
+	assertGuardedKill(t, readLog(t, logPath), "77")
 	assertBounded(t, readLog(t, tlogPath), "9", "CALL DOLT_FETCH(")
 }
 
@@ -938,9 +934,7 @@ func TestSyncFetchTimeoutKillGuardedByRunLock(t *testing.T) {
 		if pushed(log) {
 			t.Fatalf("%s: a fetch timeout must NEVER push.\nout:\n%s", tc.name, out)
 		}
-		if !strings.Contains(log, "IS_USED_LOCK('gc_remote_op_run:app:") || !strings.Contains(log, "JSON_EXTRACT('gc-remote-op-not-owner', '$')) AS own; KILL 77\n") {
-			t.Fatalf("%s: the KILL must be guarded by this run's lock in the same batch.\nlog:\n%s", tc.name, log)
-		}
+		assertGuardedKill(t, log, "77")
 		if !strings.Contains(out, tc.want) || strings.Contains(out, "no longer in flight") {
 			t.Fatalf("%s: expected %q and never a kill confirmation.\nout:\n%s", tc.name, tc.want, out)
 		}
@@ -959,9 +953,7 @@ func TestSyncFetchTimeoutKillVerdictRefusesMalformedAnswer(t *testing.T) {
 	if pushed(log) {
 		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
 	}
-	if !strings.Contains(log, "KILL 77\n") {
-		t.Fatalf("KILL must be issued.\nlog:\n%s", log)
-	}
+	assertGuardedKill(t, log, "77")
 	if strings.Contains(out, "no longer in flight") {
 		t.Fatalf("a malformed processlist answer after KILL must not confirm the kill.\nout:\n%s", out)
 	}
@@ -1034,6 +1026,38 @@ func TestSyncFetchIsAttributedAndSelfIdentifying(t *testing.T) {
 	assertGateBeforeCall(t, fetchLine, "app", "CALL DOLT_FETCH(")
 }
 
+// runNonceRe is the run nonce's shape: 16 hex digits from /dev/urandom, or
+// pid-epoch when the device is unavailable.
+const runNonceRe = `([0-9a-f]{16}|[0-9]+-[0-9]+)`
+
+// guardedKillAt returns the index in the fake dolt log of the COMPLETE guarded
+// KILL batch for id (the fixtures' database is always `app`) — `PREPARE gc_kill FROM 'KILL <id>'; SELECT
+// IF(IS_USED_LOCK('<this run's lock for db>') = <id>, 1, JSON_EXTRACT(
+// 'gc-remote-op-not-owner', '$')) AS own; EXECUTE gc_kill; DEALLOCATE PREPARE
+// gc_kill` — where the run lock is the one the fetch/pull gate took (its nonce
+// is read from the gate line), or -1. A KILL of another id, an unguarded KILL,
+// a guard on another lock or a guard that is not a comparison to the id do
+// not count (codex r10, r13).
+func guardedKillAt(t *testing.T, log, id string) int {
+	t.Helper()
+	const db = "app"
+	gate := regexp.MustCompile(regexp.QuoteMeta("GET_LOCK('gc_remote_op_run:"+db+":") + runNonceRe + regexp.QuoteMeta("', 0)"))
+	m := gate.FindStringSubmatch(log)
+	if m == nil {
+		t.Fatalf("no gate with a run lock for %s in the log.\nlog:\n%s", db, log)
+	}
+	batch := "PREPARE gc_kill FROM 'KILL " + id + "'; SELECT IF(IS_USED_LOCK('gc_remote_op_run:" + db + ":" + m[1] + "') = " + id + ", 1, JSON_EXTRACT('gc-remote-op-not-owner', '$')) AS own; EXECUTE gc_kill; DEALLOCATE PREPARE gc_kill\n"
+	return strings.Index(log, batch)
+}
+
+// assertGuardedKill requires the complete guarded KILL batch for id in the log.
+func assertGuardedKill(t *testing.T, log, id string) {
+	t.Helper()
+	if guardedKillAt(t, log, id) < 0 {
+		t.Fatalf("expected the complete guarded KILL batch for session %s (prepared KILL, ownership check on this run's lock, EXECUTE, DEALLOCATE).\nlog:\n%s", id, log)
+	}
+}
+
 // assertGateBeforeCall pins the batch shape `… CONNECTION_ID() … GET_LOCK('gc_remote_op:<db>', 0) … CALL …`.
 func assertGateBeforeCall(t *testing.T, line, db, call string) {
 	t.Helper()
@@ -1046,8 +1070,8 @@ func assertGateBeforeCall(t *testing.T, line, db, call string) {
 	// FIRST ARGUMENT re-proves that the session still holds the same run lock
 	// (codex r12: a pooled client that reconnected between the gate and the
 	// CALL would otherwise fetch on a lockless session).
-	gateRe := regexp.MustCompile(regexp.QuoteMeta("SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('"+db+"')), 0) = 1 AND GET_LOCK('gc_remote_op_run:"+db+":") + `([0-9]+-[0-9]+)` + regexp.QuoteMeta("', 0) = 1, 1, JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS gate;"))
-	callRe := regexp.MustCompile(regexp.QuoteMeta(call+"IF(IS_USED_LOCK('gc_remote_op_run:"+db+":") + `([0-9]+-[0-9]+)` + regexp.QuoteMeta("') = CONNECTION_ID(), '") + `[^']+` + regexp.QuoteMeta("', JSON_EXTRACT('gc-remote-op-lost', '$')), "))
+	gateRe := regexp.MustCompile(regexp.QuoteMeta("SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('"+db+"')), 0) = 1 AND GET_LOCK('gc_remote_op_run:"+db+":") + runNonceRe + regexp.QuoteMeta("', 0) = 1, 1, JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS gate;"))
+	callRe := regexp.MustCompile(regexp.QuoteMeta(call+"IF(IS_USED_LOCK('gc_remote_op_run:"+db+":") + runNonceRe + regexp.QuoteMeta("') = CONNECTION_ID(), '") + `[^']+` + regexp.QuoteMeta("', JSON_EXTRACT('gc-remote-op-lost', '$')), "))
 	gateM, callM := gateRe.FindStringSubmatchIndex(line), callRe.FindStringSubmatchIndex(line)
 	idAt := strings.Index(line, "SELECT CONNECTION_ID() AS id;")
 	if idAt < 0 || gateM == nil || callM == nil || idAt >= gateM[0] || gateM[0] >= callM[0] {
@@ -1106,7 +1130,7 @@ func TestSyncFetchClientExit137StillKillsServerSideSession(t *testing.T) {
 		"    else printf 'Id,Time,db\\n'; fi\n" +
 		"    exit 0 ;;\n" +
 		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n91\\n' ; exit 137 ;;\n" +
-		"  *\"KILL \"*) k=\"$*\" ; : > \"" + killedPrefix + "${k##* }\" ; exit 0 ;;\n" +
+		"  *\"KILL \"*) k=$(printf '%s' \"$*\" | sed -n 's/.*KILL \\([0-9][0-9]*\\).*/\\1/p') ; : > \"" + killedPrefix + "${k}\" ; exit 0 ;;\n" +
 		"esac\nexit 0\n"
 	installFFFakeDolt(t, binDir, body)
 	out := runFFSync(t, binDir, "--db", "app")
@@ -1117,7 +1141,7 @@ func TestSyncFetchClientExit137StillKillsServerSideSession(t *testing.T) {
 	if !strings.Contains(out, "fetch timed out") || !strings.Contains(out, "client exit 137") {
 		t.Fatalf("exit 137 is the bound's SIGKILL escalation and must be reported as a timeout.\nout:\n%s", out)
 	}
-	if !strings.Contains(log, "KILL 91\n") || !strings.Contains(out, "server-side fetch killed (session 91 no longer in flight)") {
+	if guardedKillAt(t, log, "91") < 0 || !strings.Contains(out, "server-side fetch killed (session 91 no longer in flight)") {
 		t.Fatalf("the recorded session must be KILLed after exit 137.\nout:\n%s\nlog:\n%s", out, log)
 	}
 }
@@ -1176,7 +1200,7 @@ func TestSyncFetchTimeoutOutranksFirstPushText(t *testing.T) {
 			"    else printf 'Id,Time,db\\n'; fi\n" +
 			"    exit 0 ;;\n" +
 			"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n93\\n' ; printf '" + tc.text + "\\n' >&2 ; exit " + fmt.Sprint(tc.code) + " ;;\n" +
-			"  *\"KILL \"*) k=\"$*\" ; : > \"" + killedPrefix + "${k##* }\" ; exit 0 ;;\n" +
+			"  *\"KILL \"*) k=$(printf '%s' \"$*\" | sed -n 's/.*KILL \\([0-9][0-9]*\\).*/\\1/p') ; : > \"" + killedPrefix + "${k}\" ; exit 0 ;;\n" +
 			"esac\nexit 0\n"
 		installFFFakeDolt(t, binDir, body)
 		out := runFFSyncFails(t, binDir, "--db", "app")
@@ -1187,7 +1211,7 @@ func TestSyncFetchTimeoutOutranksFirstPushText(t *testing.T) {
 		if !strings.Contains(out, "fetch timed out") || strings.Contains(out, "first push") {
 			t.Fatalf("exit %d with %q: the timeout must outrank the first-push text.\nout:\n%s", tc.code, tc.text, out)
 		}
-		if !strings.Contains(log, "KILL 93\n") || !strings.Contains(out, "server-side fetch killed (session 93 no longer in flight)") {
+		if guardedKillAt(t, log, "93") < 0 || !strings.Contains(out, "server-side fetch killed (session 93 no longer in flight)") {
 			t.Fatalf("exit %d with %q: the recorded session must be KILLed.\nout:\n%s\nlog:\n%s", tc.code, tc.text, out, log)
 		}
 	}

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -1396,7 +1396,10 @@ func TestKillRemoteOpSessionNeverReturnsZeroWhileTheRunLockIsHeld(t *testing.T) 
 		{"holder answer is not a holder answer", "77", none, killed, "printf 'nothing here\\n' ; exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
 		{"holder answer is empty", "77", none, killed, "exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
 		{"no id, nothing listed, lock free", "", none, killed, holder("0"), 0, "app: server-side fetch already ended (nothing in flight to kill)", "NOT killed"},
-		{"no id, nothing listed, a session holds this run's lock", "", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: this client never learned its session id, and session 91 holds this run's lock (" + runLock + ")", "already ended"},
+		// The holder passed this run's gate and its answer died with the client;
+		// it runs no remote operation, so health cannot name it (codex round-2
+		// r2: the line must not promise that it does).
+		{"no id, nothing listed, a session holds this run's lock", "", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: this client never learned its session id, and session 91 holds this run's lock (" + runLock + ") — the session that passed this run's gate, its answer lost with the client; it runs no remote operation, so gc dolt health does not name it — left for the operator (KILL 91)", "health names it"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			binDir := t.TempDir()

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -1386,6 +1386,12 @@ func TestKillRemoteOpSessionNeverReturnsZeroWhileTheRunLockIsHeld(t *testing.T) 
 		{"guarded, gone, another session holds this run's lock", "77", none, notOwner, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ")", "already ended"},
 		{"killed, gone, another session holds this run's lock", "77", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ")", "no longer in flight"},
 		{"guarded, still listed", "77", listed77, notOwner, holder("77"), 1, "app: server-side fetch NOT killed: session 77 does not hold this run's lock (" + runLock + ")", "already ended"},
+		// The recorded id still holds the lock but runs no DOLT_FETCH/DOLT_PULL
+		// statement (the bound expired between the gate and the CALL), so the
+		// remote-op-filtered processlist does not list it and the KILL did not
+		// take: it is not "gone", it still holds the lock (codex round-2 r1).
+		{"killed, not listed, the recorded id still holds this run's lock", "77", none, killed, holder("77"), 1, "app: server-side fetch NOT killed: session 77 still holds this run's lock (" + runLock + ") after the KILL", "is gone"},
+		{"guarded, not listed, the recorded id still holds this run's lock", "77", none, notOwner, holder("77"), 1, "app: server-side fetch NOT killed: session 77 still holds this run's lock (" + runLock + ") after the KILL", "is gone"},
 		{"holder query fails", "77", none, killed, "printf 'holder: boom\\n' >&2 ; exit 1", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
 		{"holder answer is not a holder answer", "77", none, killed, "printf 'nothing here\\n' ; exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
 		{"holder answer is empty", "77", none, killed, "exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -804,6 +804,31 @@ func TestSyncProcesslistAnswerWithoutHeaderSkips(t *testing.T) {
 	}
 }
 
+// A header that is not exactly `Id,Time,db` (three fields, each bare or
+// quoted as a whole) is not a processlist answer either: `"Id,Time,db"` is
+// ONE quoted field and `Id",Time,db` a broken one (codex r11 — stripping every
+// quote before the compare accepted both as an empty processlist).
+func TestSyncProcesslistMalformedHeaderSkips(t *testing.T) {
+	for _, hdr := range []string{`"Id,Time,db"`, `Id",Time,db`, `Id,Time`, `Id,Time,db,Info`} {
+		binDir := t.TempDir()
+		logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf '"+strings.ReplaceAll(hdr, `"`, `\"`)+"\\n' ; exit 0")
+		out := runFFSyncFails(t, binDir, "--db", "app")
+		if fetched(readLog(t, logPath)) {
+			t.Fatalf("header %q: not a processlist answer, the fetch must be skipped.\nout:\n%s", hdr, out)
+		}
+		if !strings.Contains(out, "not a processlist answer") {
+			t.Fatalf("header %q: expected the unrecognized-answer skip line.\nout:\n%s", hdr, out)
+		}
+	}
+	// A header quoted field by field is fine.
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf '\"Id\",\"Time\",\"db\"\\n' ; exit 0")
+	out := runFFSync(t, binDir, "--db", "app")
+	if !fetched(readLog(t, logPath)) {
+		t.Fatalf("a header with each field quoted is a processlist answer with no rows: the fetch must run.\nout:\n%s", out)
+	}
+}
+
 func TestSyncFetchTimeoutKillsItsServerSideSession(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "77", []string{"77,60,app"}, false)

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -658,8 +658,12 @@ func TestSyncFetchInFlightSkipsNeverFetches(t *testing.T) {
 	// the query match its own text and skip on every run (codex r6, evidence
 	// 04g). There is no per-database filter at all: attribution is not proof
 	// of a statement's target (TestSyncFetchInFlightOtherDatabaseCountsToo).
-	if q := processlistQuery(t, log); strings.Contains(q, "app") || strings.Contains(q, "LOWER(db)") {
-		t.Fatalf("the processlist query must carry no database literal.\nquery:\n%s", q)
+	// The COMPLETE constant query is the spec (codex r14: a `NOT` slipped
+	// into the WHERE clause passed a substring check — the fake answers the
+	// same rows either way, the server would not).
+	const processlistSQL = "SELECT Id, Time, COALESCE(db, '') AS db FROM information_schema.processlist WHERE UPPER(Info) REGEXP '(^|[^A-Z0-9_])DOLT_(FETCH|PULL)([^A-Z0-9_]|$)' ORDER BY Time DESC, Id ASC"
+	if q := processlistQuery(t, log); !strings.HasSuffix(q, " -q "+processlistSQL) || strings.Contains(q, "app") {
+		t.Fatalf("the processlist query must be exactly the constant text %q (no database literal).\nquery:\n%s", processlistSQL, q)
 	}
 	// The predicate is the whole-identifier token test on the statement text,
 	// not a LIKE prefix and not a grammar of spellings: any statement naming
@@ -884,6 +888,29 @@ func TestSyncFetchBoundReachesTheFetch(t *testing.T) {
 	}
 	assertGuardedKill(t, readLog(t, logPath), "77")
 	assertBounded(t, readLog(t, tlogPath), "9", "CALL DOLT_FETCH(")
+}
+
+// No random bytes, no run: with an `od` that fails, sync stops before any
+// dolt call with exit 2 — a nonce that could repeat (pid-epoch) would let a
+// restarted server's reused id pass the ownership check (codex r14).
+func TestSyncRefusesToRunWithoutARandomNonce(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n' ; exit 0")
+	if err := os.WriteFile(filepath.Join(binDir, "od"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake od: %v", err)
+	}
+	outB, err := ffSyncCmd(t, binDir, nil, "--db", "app").CombinedOutput()
+	out := string(outB)
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) || ee.ExitCode() != 2 {
+		t.Fatalf("want exit 2 before any database is touched, got err=%v\nout:\n%s", err, out)
+	}
+	if !strings.Contains(out, "cannot read 8 random bytes") || !strings.Contains(out, "gc dolt sync: no run nonce") {
+		t.Fatalf("expected the nonce refusal lines.\nout:\n%s", out)
+	}
+	if readLog(t, logPath) != "" {
+		t.Fatalf("no dolt call may run without a nonce.\nlog:\n%s", readLog(t, logPath))
+	}
 }
 
 // The CALL refused itself: the session that sent it no longer held this run's

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -13,7 +13,6 @@ package dolt_test
 // and an absent remote ref yields "branch not found: remotes/...".
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -21,14 +20,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 // ffSyncCmd builds a `gc dolt sync` invocation against an idle reachable
-// server with the fake dolt in binDir first on PATH. The per-database runner
-// lock gets a private root. Later `env` entries override earlier ones (Go
-// keeps the last value of a duplicated key), so a test can pin the port and
-// the lock root two runners must share.
+// server with the fake dolt in binDir first on PATH. Later `env` entries
+// override earlier ones (Go keeps the last value of a duplicated key).
 func ffSyncCmd(t *testing.T, binDir string, env []string, args ...string) *exec.Cmd {
 	t.Helper()
 	root := repoRoot(t)
@@ -52,7 +48,6 @@ func ffSyncCmd(t *testing.T, binDir string, env []string, args ...string) *exec.
 		fmt.Sprintf("GC_DOLT_PORT=%d", port),
 		"GC_DOLT_USER=root",
 		"GC_DOLT_PASSWORD=",
-		"GC_DOLT_REMOTE_OP_LOCK_ROOT="+t.TempDir(),
 	), env...)
 	return cmd
 }
@@ -74,26 +69,6 @@ func runFFSync(t *testing.T, binDir string, args ...string) string {
 	t.Helper()
 	out, _ := runFFSyncEnv(t, binDir, nil, args...)
 	return out
-}
-
-// waitForFile polls until path exists (the fake dolt's "I am mid-operation"
-// marker) or the deadline passes.
-func waitForFile(t *testing.T, path string, within time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(within)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(path); err == nil {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("%s did not appear within %s", path, within)
-}
-
-// remoteOpLockDir is the lock directory the scripts use for host 127.0.0.1,
-// the given port and database under lockRoot (remote_op_lock_dir, runtime.sh).
-func remoteOpLockDir(lockRoot string, port int, db string) string {
-	return filepath.Join(lockRoot, fmt.Sprintf("127.0.0.1-%d-%s.lock", port, db))
 }
 
 // fakeDoltHeader is the shared preamble for an IDLE server: log argv, answer
@@ -812,6 +787,23 @@ func TestSyncFetchIsAttributedAndSelfIdentifying(t *testing.T) {
 	if !strings.Contains(fetchLine, "SELECT CONNECTION_ID() AS id;") {
 		t.Fatalf("the fetch statement must print its own connection id first.\nline: %s", fetchLine)
 	}
+	// The server-side gate sits between the id and the CALL in the SAME batch:
+	// this session takes the database's lock (timeout 0) or the batch stops
+	// before the CALL is sent (verified on Dolt 2.1.10).
+	assertGateBeforeCall(t, fetchLine, "app", "CALL DOLT_FETCH(")
+}
+
+// assertGateBeforeCall pins the batch shape `… CONNECTION_ID() … GET_LOCK('gc_remote_op:<db>', 0) … CALL …`.
+func assertGateBeforeCall(t *testing.T, line, db, call string) {
+	t.Helper()
+	gate := "GET_LOCK('gc_remote_op:" + db + "', 0)"
+	idAt, gateAt, callAt := strings.Index(line, "SELECT CONNECTION_ID() AS id;"), strings.Index(line, gate), strings.Index(line, call)
+	if idAt < 0 || gateAt < 0 || callAt < 0 || (idAt >= gateAt || gateAt >= callAt) {
+		t.Fatalf("the batch must be id, then the GET_LOCK gate, then the CALL.\nline: %s", line)
+	}
+	if !strings.Contains(line, "JSON_EXTRACT('gc-remote-op-lock-held', '$')") {
+		t.Fatalf("the gate's else branch must raise the marked error.\nline: %s", line)
+	}
 }
 
 // A processlist answer with a row that is not `digits,digits,…` (a NULL Time,
@@ -861,78 +853,31 @@ func TestSyncFetchClientExit137StillKillsServerSideSession(t *testing.T) {
 	}
 }
 
-// Two runners on this host: the second must not read "nothing in flight" and
-// fetch while the first is mid-fetch. The runner lock is held from before the
-// processlist check until the operation is done, so exactly one CALL is issued
-// and the second run says who holds the lock.
-func TestSyncRunnerLockSerializesConcurrentRunners(t *testing.T) {
+// Two runners that both read "nothing in flight" cannot both fetch: the fetch
+// batch takes the server's session lock for the database before its CALL, and
+// when another session holds it the server stops the batch with the marked
+// error. The script reports the refusal, pushes nothing, and has nothing to
+// KILL (our CALL was never sent).
+func TestSyncFetchGateRefusedSkipsNeverPushes(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := filepath.Join(binDir, "dolt.log")
-	started := filepath.Join(binDir, "fetch-started")
-	release := filepath.Join(binDir, "fetch-release")
 	body := fakeDoltHeader(logPath, "main") +
-		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; while [ ! -f \"" + release + "\" ]; do sleep 0.1; done ; exit 0 ;;\n" +
-		"  *\"dolt_log(\"*) printf 'n\\n0\\n' ; exit 0 ;;\n" +
+		"  *\"CALL DOLT_FETCH(\"*) printf 'id\\n61\\n' ; printf 'error on line 1 for query SELECT IF(GET_LOCK(...)) AS gate: Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-lock-held\"\\n' >&2 ; exit 1 ;;\n" +
 		"esac\nexit 0\n"
 	installFFFakeDolt(t, binDir, body)
-	port, cleanup := startReachableTCPListener(t)
-	defer cleanup()
-	shared := []string{fmt.Sprintf("GC_DOLT_PORT=%d", port), "GC_DOLT_REMOTE_OP_LOCK_ROOT=" + t.TempDir()}
-
-	first := ffSyncCmd(t, binDir, shared, "--db", "app")
-	var firstOut bytes.Buffer
-	first.Stdout, first.Stderr = &firstOut, &firstOut
-	if err := first.Start(); err != nil {
-		t.Fatalf("start first runner: %v", err)
-	}
-	waitForFile(t, started, 10*time.Second)
-	secondOut, secondErr := ffSyncCmd(t, binDir, shared, "--db", "app").CombinedOutput()
-	if err := os.WriteFile(release, nil, 0o644); err != nil {
-		t.Fatalf("release the first fetch: %v", err)
-	}
-	if err := first.Wait(); err != nil {
-		t.Fatalf("first runner failed: %v\n%s", err, firstOut.String())
-	}
+	out := runFFSync(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
-	if n := strings.Count(log, "CALL DOLT_FETCH("); n != 1 {
-		t.Fatalf("exactly one fetch may be in flight per database; got %d.\nlog:\n%s\nsecond:\n%s", n, log, secondOut)
-	}
-	if secondErr == nil {
-		t.Fatalf("the second runner must exit non-zero (skipped).\nout:\n%s", secondOut)
-	}
-	want := fmt.Sprintf("app: another gc dolt sync/pull (pid %d) holds this database's runner lock — skipped (NOT pushed)", first.Process.Pid)
-	if !strings.Contains(string(secondOut), want) {
-		t.Fatalf("expected %q\nout:\n%s", want, secondOut)
-	}
 	if pushed(log) {
-		t.Fatalf("neither runner may push here (0 ahead).\nlog:\n%s", log)
+		t.Fatalf("a refused gate must NEVER push.\nout:\n%s", out)
 	}
-}
-
-// A lock whose holder died (pid gone) is stale: the next runner reclaims it,
-// runs, and leaves no lock behind.
-func TestSyncStaleRunnerLockIsReclaimed(t *testing.T) {
-	binDir := t.TempDir()
-	logPath := writeSyncFakeDoltClassify(t, binDir, 1, 0)
-	port, cleanup := startReachableTCPListener(t)
-	defer cleanup()
-	lockRoot := t.TempDir()
-	dir := remoteOpLockDir(lockRoot, port, "app")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatalf("mkdir stale lock: %v", err)
+	if strings.Contains(log, "KILL ") {
+		t.Fatalf("a refused gate sent no CALL: nothing to KILL.\nlog:\n%s", log)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "pid"), []byte("4194305\n"), 0o600); err != nil {
-		t.Fatalf("write stale pid: %v", err)
+	want := "app: fetch already in flight — the server refused a second one (session lock gc_remote_op:app held) — skipped (NOT pushed)"
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected %q\nout:\n%s", want, out)
 	}
-	out, err := ffSyncCmd(t, binDir, []string{fmt.Sprintf("GC_DOLT_PORT=%d", port), "GC_DOLT_REMOTE_OP_LOCK_ROOT=" + lockRoot}, "--db", "app").CombinedOutput()
-	if err != nil {
-		t.Fatalf("a stale lock (holder gone) must be reclaimed and the sync run: %v\n%s", err, out)
-	}
-	log := readLog(t, logPath)
-	if !fetched(log) || !pushed(log) {
-		t.Fatalf("reclaimed lock: fetch and push must run.\nout:\n%s\nlog:\n%s", out, log)
-	}
-	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
-		t.Fatalf("the lock must be released after the run (stat err = %v)", statErr)
+	if strings.Contains(out, "fetch failed (exit 1)") {
+		t.Fatalf("a gate refusal is a skip, not a fetch failure.\nout:\n%s", out)
 	}
 }

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -71,6 +71,19 @@ func runFFSync(t *testing.T, binDir string, args ...string) string {
 	return out
 }
 
+// runFFSyncFails runs sync and requires a NON-ZERO exit: every skip (in
+// flight, gate refused, processlist failure, timeout, malformed answer) is a
+// database that did not sync, and the script's exit code says so (codex r10:
+// a `return 0` on a failure path passed the output-only assertions).
+func runFFSyncFails(t *testing.T, binDir string, args ...string) string {
+	t.Helper()
+	out, err := ffSyncCmd(t, binDir, nil, args...).CombinedOutput()
+	if err == nil {
+		t.Fatalf("a run that skipped or failed a database must exit non-zero.\nout:\n%s", out)
+	}
+	return string(out)
+}
+
 // fakeDoltHeader is the shared preamble for an IDLE server: log argv, answer
 // the remote-lookup + active_branch metadata queries the sync path issues
 // before classification, and answer the single-flight processlist query with
@@ -209,7 +222,7 @@ func TestSyncUpToDateSkipsPush(t *testing.T) {
 func TestSyncFetchTimeoutSkipsNeverPushes(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltFetchTimeout(t, binDir, "main")
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	if pushed(readLog(t, logPath)) {
 		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
 	}
@@ -592,7 +605,10 @@ func writeSyncFakeDoltFetchTimeoutKill(t *testing.T, dir, sessionID string, list
 	t.Helper()
 	logPath := filepath.Join(dir, "dolt.log")
 	started := filepath.Join(dir, "fetch-started")
-	killed := filepath.Join(dir, "killed")
+	// KILL marks only the ADDRESSED session (`killed-<id>`), so a KILL of the
+	// wrong id never reads as a successful cleanup (codex r10).
+	killedPrefix := filepath.Join(dir, "killed-")
+	killed := killedPrefix + sessionID
 	idEmit := ""
 	if sessionID != "" {
 		idEmit = "printf 'id\\n" + sessionID + "\\n' ; "
@@ -612,7 +628,7 @@ func writeSyncFakeDoltFetchTimeoutKill(t *testing.T, dir, sessionID string, list
 		"    else printf 'Id,Time,db\\n'; fi\n" +
 		"    exit 0 ;;\n" +
 		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; " + idEmit + "printf 'context deadline exceeded\\n' >&2 ; exit 124 ;;\n" +
-		"  *\"KILL \"*) : > \"" + killed + "\" ; exit 0 ;;\n" +
+		"  *\"KILL \"*) k=\"$*\" ; : > \"" + killedPrefix + "${k##* }\" ; exit 0 ;;\n" +
 		"esac\nexit 0\n"
 	return installFFFakeDolt(t, dir, body)
 }
@@ -625,7 +641,7 @@ func fetched(log string) bool { return strings.Contains(log, "CALL DOLT_FETCH(")
 func TestSyncFetchInFlightSkipsNeverFetches(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n42,7200,app\\n' ; exit 0")
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
 	if fetched(log) {
 		t.Fatalf("a fetch already in flight for the db must NOT start another.\nout:\n%s\nlog:\n%s", out, log)
@@ -675,7 +691,7 @@ func processlistQuery(t *testing.T, log string) string {
 func TestSyncFetchInFlightOtherDatabaseCountsToo(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n44,500,other\\n45,10,\"other-two\"\\n' ; exit 0")
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
 	if fetched(log) {
 		t.Fatalf("a remote operation in flight anywhere on the server must block this fetch (attribution is not proof of its target).\nout:\n%s\nlog:\n%s", out, log)
@@ -690,7 +706,7 @@ func TestSyncFetchInFlightOtherDatabaseCountsToo(t *testing.T) {
 func TestSyncFetchInFlightCaseInsensitiveDatabase(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n46,20,APP\\n' ; exit 0")
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	if fetched(readLog(t, logPath)) {
 		t.Fatalf("a session attributed to APP is this database's (app): it must block the fetch.\nout:\n%s", out)
 	}
@@ -706,7 +722,7 @@ func TestSyncFetchInFlightCaseInsensitiveDatabase(t *testing.T) {
 func TestSyncFetchInFlightRevisionQualifiedDatabaseCounts(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n47,40,APP/feature/x\\n' ; exit 0")
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	if fetched(readLog(t, logPath)) {
 		t.Fatalf("a session attributed to APP/feature/x is this database's: it must block the fetch.\nout:\n%s", out)
 	}
@@ -715,7 +731,7 @@ func TestSyncFetchInFlightRevisionQualifiedDatabaseCounts(t *testing.T) {
 	}
 	binDir = t.TempDir()
 	logPath = writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n48,5,other/main\\n' ; exit 0")
-	out = runFFSync(t, binDir, "--db", "app")
+	out = runFFSyncFails(t, binDir, "--db", "app")
 	if fetched(readLog(t, logPath)) {
 		t.Fatalf("another database's revision (other/main) blocks too: attribution is not proof of the target.\nout:\n%s", out)
 	}
@@ -733,7 +749,7 @@ func TestSyncGateMarkerInOrdinaryErrorIsNotRefusal(t *testing.T) {
 		"  *\"CALL DOLT_FETCH(\"*) printf 'id\\n63\\n' ; printf 'error on line 1 for query CALL DOLT_FETCH(''gc-remote-op-lock-held'', ''main''): Error 1105 (HY000): remote not found\\n' >&2 ; exit 1 ;;\n" +
 		"esac\nexit 0\n"
 	installFFFakeDolt(t, binDir, body)
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	if strings.Contains(out, "already in flight") {
 		t.Fatalf("an ordinary error echoing the marker must not read as a gate refusal.\nout:\n%s", out)
 	}
@@ -751,7 +767,7 @@ func TestSyncGateMarkerInOrdinaryErrorIsNotRefusal(t *testing.T) {
 func TestSyncFetchInFlightUnattributedSkips(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n43,30,\\n' ; exit 0")
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	if fetched(readLog(t, logPath)) {
 		t.Fatalf("an unattributed in-flight fetch must block this db's fetch.\nout:\n%s", out)
 	}
@@ -763,7 +779,7 @@ func TestSyncFetchInFlightUnattributedSkips(t *testing.T) {
 func TestSyncProcesslistQueryFailureSkipsNeverFetches(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'processlist: boom\\n' >&2 ; exit 1")
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
 	if fetched(log) || pushed(log) {
 		t.Fatalf("a failed processlist query must skip without fetching or pushing (fail closed).\nout:\n%s\nlog:\n%s", out, log)
@@ -779,7 +795,7 @@ func TestSyncProcesslistQueryFailureSkipsNeverFetches(t *testing.T) {
 func TestSyncProcesslistAnswerWithoutHeaderSkips(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "exit 0")
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	if fetched(readLog(t, logPath)) {
 		t.Fatalf("a header-less processlist answer must skip the fetch (fail closed).\nout:\n%s", out)
 	}
@@ -791,7 +807,7 @@ func TestSyncProcesslistAnswerWithoutHeaderSkips(t *testing.T) {
 func TestSyncFetchTimeoutKillsItsServerSideSession(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "77", []string{"77,60,app"}, false)
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
 	if pushed(log) {
 		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
@@ -800,7 +816,7 @@ func TestSyncFetchTimeoutKillsItsServerSideSession(t *testing.T) {
 		t.Fatalf("expected the 'fetch timed out' status.\nout:\n%s", out)
 	}
 	fetchAt := strings.Index(log, "CALL DOLT_FETCH(")
-	killAt := strings.Index(log, "KILL 77")
+	killAt := strings.Index(log, "KILL 77\n")
 	if fetchAt < 0 || killAt < 0 || killAt < fetchAt {
 		t.Fatalf("the session the fetch printed about itself must be KILLed after the fetch times out.\nlog:\n%s", log)
 	}
@@ -814,12 +830,12 @@ func TestSyncFetchTimeoutKillsItsServerSideSession(t *testing.T) {
 func TestSyncFetchTimeoutKillNotConfirmedReportsStillInFlight(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "77", []string{"77,60,app"}, true)
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
 	if pushed(log) {
 		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
 	}
-	if !strings.Contains(log, "KILL 77") {
+	if !strings.Contains(log, "KILL 77\n") {
 		t.Fatalf("KILL must be issued.\nlog:\n%s", log)
 	}
 	if !strings.Contains(out, "app: server-side fetch NOT killed (session 77 still in flight after KILL)") {
@@ -834,12 +850,15 @@ func TestSyncFetchBoundReachesTheFetch(t *testing.T) {
 	binDir := t.TempDir()
 	tlogPath := writeRecordingGtimeout(t, binDir)
 	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "77", []string{"77,60,app"}, false)
-	outB, _ := ffSyncCmd(t, binDir, []string{"GC_DOLT_SYNC_FETCH_TIMEOUT_SECS=9"}, "--db", "app").CombinedOutput()
+	outB, err := ffSyncCmd(t, binDir, []string{"GC_DOLT_SYNC_FETCH_TIMEOUT_SECS=9"}, "--db", "app").CombinedOutput()
 	out := string(outB)
+	if err == nil {
+		t.Fatalf("a timed-out fetch must exit non-zero.\nout:\n%s", out)
+	}
 	if !strings.Contains(out, "app: fetch timed out after 9s") {
 		t.Fatalf("expected the timeout line naming the configured bound.\nout:\n%s", out)
 	}
-	if !strings.Contains(readLog(t, logPath), "KILL 77") {
+	if !strings.Contains(readLog(t, logPath), "KILL 77\n") {
 		t.Fatalf("KILL must be issued.\nout:\n%s", out)
 	}
 	assertBounded(t, readLog(t, tlogPath), "9", "CALL DOLT_FETCH(")
@@ -852,12 +871,12 @@ func TestSyncFetchBoundReachesTheFetch(t *testing.T) {
 func TestSyncFetchTimeoutKillVerdictRefusesMalformedAnswer(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "77", []string{"77,60,app,extra"}, true)
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
 	if pushed(log) {
 		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
 	}
-	if !strings.Contains(log, "KILL 77") {
+	if !strings.Contains(log, "KILL 77\n") {
 		t.Fatalf("KILL must be issued.\nlog:\n%s", log)
 	}
 	if strings.Contains(out, "no longer in flight") {
@@ -876,7 +895,7 @@ func TestSyncFetchTimeoutKillVerdictRefusesMalformedAnswer(t *testing.T) {
 func TestSyncFetchTimeoutWithoutIDKillsNothingAndReportsUnproven(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "", []string{"88,61,app", "89,5,"}, false)
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
 	if pushed(log) {
 		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
@@ -893,7 +912,7 @@ func TestSyncFetchTimeoutWithoutIDKillsNothingAndReportsUnproven(t *testing.T) {
 func TestSyncFetchTimeoutWithoutIDAndNothingListedKillsNothing(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "", nil, false)
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
 	if strings.Contains(log, "KILL ") {
 		t.Fatalf("nothing in flight after the timeout: nothing to KILL.\nlog:\n%s", log)
@@ -968,7 +987,7 @@ func TestSyncProcesslistMalformedRowSkips(t *testing.T) {
 	} {
 		binDir := t.TempDir()
 		logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n"+strings.ReplaceAll(row, `"`, `\"`)+"\\n' ; exit 0")
-		out := runFFSync(t, binDir, "--db", "app")
+		out := runFFSyncFails(t, binDir, "--db", "app")
 		log := readLog(t, logPath)
 		if fetched(log) || pushed(log) {
 			t.Fatalf("row %q: a malformed processlist row must skip without fetching or pushing.\nout:\n%s\nlog:\n%s", row, out, log)
@@ -986,7 +1005,8 @@ func TestSyncFetchClientExit137StillKillsServerSideSession(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := filepath.Join(binDir, "dolt.log")
 	started := filepath.Join(binDir, "fetch-started")
-	killed := filepath.Join(binDir, "killed")
+	killedPrefix := filepath.Join(binDir, "killed-")
+	killed := killedPrefix + "91"
 	body := fakeDoltPreamble(logPath, "main") +
 		"  *\"information_schema.processlist\"*)\n" +
 		"    if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'\n" +
@@ -994,7 +1014,7 @@ func TestSyncFetchClientExit137StillKillsServerSideSession(t *testing.T) {
 		"    else printf 'Id,Time,db\\n'; fi\n" +
 		"    exit 0 ;;\n" +
 		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n91\\n' ; exit 137 ;;\n" +
-		"  *\"KILL \"*) : > \"" + killed + "\" ; exit 0 ;;\n" +
+		"  *\"KILL \"*) k=\"$*\" ; : > \"" + killedPrefix + "${k##* }\" ; exit 0 ;;\n" +
 		"esac\nexit 0\n"
 	installFFFakeDolt(t, binDir, body)
 	out := runFFSync(t, binDir, "--db", "app")
@@ -1005,7 +1025,7 @@ func TestSyncFetchClientExit137StillKillsServerSideSession(t *testing.T) {
 	if !strings.Contains(out, "fetch timed out") || !strings.Contains(out, "client exit 137") {
 		t.Fatalf("exit 137 is the bound's SIGKILL escalation and must be reported as a timeout.\nout:\n%s", out)
 	}
-	if !strings.Contains(log, "KILL 91") || !strings.Contains(out, "server-side fetch killed (session 91 no longer in flight)") {
+	if !strings.Contains(log, "KILL 91\n") || !strings.Contains(out, "server-side fetch killed (session 91 no longer in flight)") {
 		t.Fatalf("the recorded session must be KILLed after exit 137.\nout:\n%s\nlog:\n%s", out, log)
 	}
 }
@@ -1022,7 +1042,7 @@ func TestSyncFetchGateRefusedSkipsNeverPushes(t *testing.T) {
 		"  *\"CALL DOLT_FETCH(\"*) printf 'id\\n61\\n' ; printf 'error on line 1 for query SELECT IF(GET_LOCK(...)) AS gate: Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-lock-held\"\\n' >&2 ; exit 1 ;;\n" +
 		"esac\nexit 0\n"
 	installFFFakeDolt(t, binDir, body)
-	out := runFFSync(t, binDir, "--db", "app")
+	out := runFFSyncFails(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
 	if pushed(log) {
 		t.Fatalf("a refused gate must NEVER push.\nout:\n%s", out)
@@ -1055,7 +1075,8 @@ func TestSyncFetchTimeoutOutranksFirstPushText(t *testing.T) {
 		binDir := t.TempDir()
 		logPath := filepath.Join(binDir, "dolt.log")
 		started := filepath.Join(binDir, "fetch-started")
-		killed := filepath.Join(binDir, "killed")
+		killedPrefix := filepath.Join(binDir, "killed-")
+		killed := killedPrefix + "93"
 		body := fakeDoltPreamble(logPath, "main") +
 			"  *\"information_schema.processlist\"*)\n" +
 			"    if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'\n" +
@@ -1063,10 +1084,10 @@ func TestSyncFetchTimeoutOutranksFirstPushText(t *testing.T) {
 			"    else printf 'Id,Time,db\\n'; fi\n" +
 			"    exit 0 ;;\n" +
 			"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n93\\n' ; printf '" + tc.text + "\\n' >&2 ; exit " + fmt.Sprint(tc.code) + " ;;\n" +
-			"  *\"KILL \"*) : > \"" + killed + "\" ; exit 0 ;;\n" +
+			"  *\"KILL \"*) k=\"$*\" ; : > \"" + killedPrefix + "${k##* }\" ; exit 0 ;;\n" +
 			"esac\nexit 0\n"
 		installFFFakeDolt(t, binDir, body)
-		out := runFFSync(t, binDir, "--db", "app")
+		out := runFFSyncFails(t, binDir, "--db", "app")
 		log := readLog(t, logPath)
 		if pushed(log) {
 			t.Fatalf("exit %d with %q: a dead client must NEVER push.\nout:\n%s\nlog:\n%s", tc.code, tc.text, out, log)
@@ -1074,7 +1095,7 @@ func TestSyncFetchTimeoutOutranksFirstPushText(t *testing.T) {
 		if !strings.Contains(out, "fetch timed out") || strings.Contains(out, "first push") {
 			t.Fatalf("exit %d with %q: the timeout must outrank the first-push text.\nout:\n%s", tc.code, tc.text, out)
 		}
-		if !strings.Contains(log, "KILL 93") || !strings.Contains(out, "server-side fetch killed (session 93 no longer in flight)") {
+		if !strings.Contains(log, "KILL 93\n") || !strings.Contains(out, "server-side fetch killed (session 93 no longer in flight)") {
 			t.Fatalf("exit %d with %q: the recorded session must be KILLed.\nout:\n%s\nlog:\n%s", tc.code, tc.text, out, log)
 		}
 	}

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -1385,17 +1385,18 @@ func TestKillRemoteOpSessionNeverReturnsZeroWhileTheRunLockIsHeld(t *testing.T) 
 	}{
 		{"killed, gone, lock free", "77", none, killed, holder("0"), 0, "app: server-side fetch killed (session 77 no longer in flight)", "NOT killed"},
 		{"guarded, gone, lock free (the server restarted)", "77", none, notOwner, holder("0"), 0, "app: server-side fetch already ended (session 77 is gone; nothing killed)", "NOT killed"},
-		// The complete diagnostic is asserted (codex round-2 r3): the holder may
-		// be idle, so the line must not promise that health names it.
-		{"guarded, gone, another session holds this run's lock", "77", none, notOwner, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ") — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number); gc dolt health names it only while it runs a remote operation — left for the operator (KILL 91)", "already ended"},
-		{"killed, gone, another session holds this run's lock", "77", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ") — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number); gc dolt health names it only while it runs a remote operation — left for the operator (KILL 91)", "no longer in flight"},
+		// The complete diagnostic is asserted (codex round-2 r3, r4): health
+		// reports counts and ages, never session ids, so no line may promise
+		// that health names a session.
+		{"guarded, gone, another session holds this run's lock", "77", none, notOwner, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ") — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number) — left for the operator (KILL 91)", "health"},
+		{"killed, gone, another session holds this run's lock", "77", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ") — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number) — left for the operator (KILL 91)", "health"},
 		{"guarded, still listed", "77", listed77, notOwner, holder("77"), 1, "app: server-side fetch NOT killed: session 77 does not hold this run's lock (" + runLock + ")", "already ended"},
 		// The recorded id still holds the lock but runs no DOLT_FETCH/DOLT_PULL
 		// statement (the bound expired between the gate and the CALL), so the
 		// remote-op-filtered processlist does not list it and the KILL did not
 		// take: it is not "gone", it still holds the lock (codex round-2 r1).
-		{"killed, not listed, the recorded id still holds this run's lock", "77", none, killed, holder("77"), 1, "app: server-side fetch NOT killed: session 77 still holds this run's lock (" + runLock + ") after the KILL", "is gone"},
-		{"guarded, not listed, the recorded id still holds this run's lock", "77", none, notOwner, holder("77"), 1, "app: server-side fetch NOT killed: session 77 still holds this run's lock (" + runLock + ") after the KILL", "is gone"},
+		{"killed, not listed, the recorded id still holds this run's lock", "77", none, killed, holder("77"), 1, "app: server-side fetch NOT killed: session 77 still holds this run's lock (" + runLock + ") after the KILL — not listed as a remote operation (idle, or between the gate and the CALL) — left for the operator (KILL 77)", "health"},
+		{"guarded, not listed, the recorded id still holds this run's lock", "77", none, notOwner, holder("77"), 1, "app: server-side fetch NOT killed: session 77 still holds this run's lock (" + runLock + ") after the KILL — not listed as a remote operation (idle, or between the gate and the CALL) — left for the operator (KILL 77)", "health"},
 		{"holder query fails", "77", none, killed, "printf 'holder: boom\\n' >&2 ; exit 1", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
 		{"holder answer is not a holder answer", "77", none, killed, "printf 'nothing here\\n' ; exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
 		{"holder answer is empty", "77", none, killed, "exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
@@ -1407,7 +1408,7 @@ func TestKillRemoteOpSessionNeverReturnsZeroWhileTheRunLockIsHeld(t *testing.T) 
 		// The holder passed this run's gate and its answer died with the client;
 		// it runs no remote operation, so health cannot name it (codex round-2
 		// r2: the line must not promise that it does).
-		{"no id, nothing listed, a session holds this run's lock", "", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: this client never learned its session id, and session 91 holds this run's lock (" + runLock + ") — the session that passed this run's gate, its answer lost with the client; it runs no remote operation, so gc dolt health does not name it — left for the operator (KILL 91)", "health names it"},
+		{"no id, nothing listed, a session holds this run's lock", "", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: this client never learned its session id, and session 91 holds this run's lock (" + runLock + ") — the session that passed this run's gate, its answer lost with the client; it runs no remote operation — left for the operator (KILL 91)", "health"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			binDir := t.TempDir()

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -636,13 +636,16 @@ func TestSyncFetchInFlightSkipsNeverFetches(t *testing.T) {
 	if !strings.Contains(out, "app: fetch already in flight for 7200s (session 42)") || !strings.Contains(out, "NOT pushed") {
 		t.Fatalf("expected the in-flight skip line naming the oldest session's age and id.\nout:\n%s", out)
 	}
-	if !strings.Contains(log, "db = 'app'") {
-		t.Fatalf("the single-flight check must be scoped to this database.\nlog:\n%s", log)
+	// Scoped to this database, case-insensitively: Dolt resolves `app` and
+	// `APP` to one database and the processlist shows the client's spelling.
+	if !strings.Contains(log, "LOWER(db) = LOWER('app')") {
+		t.Fatalf("the single-flight check must be scoped to this database, case-insensitively.\nlog:\n%s", log)
 	}
 	// The predicate is a REGEXP on the statement text (whitespace, comments,
-	// case), not a LIKE prefix: `CALL  DOLT_FETCH`, `/* x */ CALL DOLT_PULL(`
-	// and `call dolt_fetch(` are all in flight (verified on Dolt 2.1.10).
-	if !strings.Contains(log, "UPPER(Info) REGEXP '") || !strings.Contains(log, `CALL\\s+DOLT_(FETCH|PULL)\\s*\\(`) {
+	// case, backticks, a db qualifier), not a LIKE prefix: `CALL  DOLT_FETCH`,
+	// `/* x */ CALL DOLT_PULL(`, `call dolt_fetch(`, `CALL \`dolt_fetch\`(` and
+	// `CALL app.DOLT_FETCH(` are all in flight (verified on Dolt 2.1.10).
+	if !strings.Contains(log, "UPPER(Info) REGEXP '") || !strings.Contains(log, "`?DOLT_(FETCH|PULL)`?") {
 		t.Fatalf("the in-flight predicate must be the REGEXP on UPPER(Info).\nlog:\n%s", log)
 	}
 }
@@ -730,10 +733,11 @@ func TestSyncFetchTimeoutKillNotConfirmedReportsStillInFlight(t *testing.T) {
 }
 
 // No connection id captured (the client died before the server answered):
-// every in-flight remote operation attributed to the db is ended — the
-// single-flight check found none before ours started, so each is ours or a
-// concurrent runner's that raced the same window, and none may survive.
-func TestSyncFetchTimeoutWithoutIDKillsEveryAttributedSession(t *testing.T) {
+// nothing is KILLed. Absence from the earlier processlist read does not prove
+// that a session listed now is ours (an operator's unattributed pull for
+// another database can appear in the same window), so the in-flight sessions
+// attributed to the db are reported for the operator and the run fails.
+func TestSyncFetchTimeoutWithoutIDKillsNothingAndReportsUnproven(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "", []string{"88,61,app", "89,5,"}, false)
 	out := runFFSync(t, binDir, "--db", "app")
@@ -741,13 +745,12 @@ func TestSyncFetchTimeoutWithoutIDKillsEveryAttributedSession(t *testing.T) {
 	if pushed(log) {
 		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
 	}
-	for _, id := range []string{"88", "89"} {
-		if !strings.Contains(log, "KILL "+id) {
-			t.Fatalf("session %s must be KILLed.\nlog:\n%s", id, log)
-		}
-		if !strings.Contains(out, "server-side fetch killed (session "+id+" no longer in flight)") {
-			t.Fatalf("expected the kill line for session %s.\nout:\n%s", id, out)
-		}
+	if strings.Contains(log, "KILL ") {
+		t.Fatalf("without a session id, ownership is unproven: nothing may be KILLed.\nlog:\n%s", log)
+	}
+	want := "app: server-side fetch NOT killed: this client never learned its session id, and ownership of the in-flight session(s) attributed to app (Id 88 89) cannot be proven"
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected %q\nout:\n%s", want, out)
 	}
 }
 
@@ -796,7 +799,9 @@ func TestSyncFetchIsAttributedAndSelfIdentifying(t *testing.T) {
 // assertGateBeforeCall pins the batch shape `… CONNECTION_ID() … GET_LOCK('gc_remote_op:<db>', 0) … CALL …`.
 func assertGateBeforeCall(t *testing.T, line, db, call string) {
 	t.Helper()
-	gate := "GET_LOCK('gc_remote_op:" + db + "', 0)"
+	// The lock name is lowercased on the server: `app` and `APP` are one
+	// database and must be one lock.
+	gate := "GET_LOCK(CONCAT('gc_remote_op:', LOWER('" + db + "')), 0)"
 	idAt, gateAt, callAt := strings.Index(line, "SELECT CONNECTION_ID() AS id;"), strings.Index(line, gate), strings.Index(line, call)
 	if idAt < 0 || gateAt < 0 || callAt < 0 || (idAt >= gateAt || gateAt >= callAt) {
 		t.Fatalf("the batch must be id, then the GET_LOCK gate, then the CALL.\nline: %s", line)
@@ -810,15 +815,24 @@ func assertGateBeforeCall(t *testing.T, line, db, call string) {
 // a truncated line) is a session whose state is unknown: the whole answer is
 // refused and the fetch skipped, fail closed — never "nothing in flight".
 func TestSyncProcesslistMalformedRowSkips(t *testing.T) {
-	binDir := t.TempDir()
-	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n42,NULL,app\\n' ; exit 0")
-	out := runFFSync(t, binDir, "--db", "app")
-	log := readLog(t, logPath)
-	if fetched(log) || pushed(log) {
-		t.Fatalf("a malformed processlist row must skip without fetching or pushing.\nout:\n%s\nlog:\n%s", out, log)
-	}
-	if !strings.Contains(out, "processlist query failed") || !strings.Contains(out, "malformed processlist row") {
-		t.Fatalf("expected the malformed-row skip line.\nout:\n%s", out)
+	for _, row := range []string{
+		`42,NULL,app`,    // a NULL Time
+		`"12,34",60,app`, // a quoted field that field-splitting would read as Id 12, Time 34
+		`"4""2",60,app`,  // a quoted, escaped Id
+		`42`,             // a truncated line
+		`abc,60,app`,     // a non-numeric Id
+		` 42,60,app`,     // leading whitespace
+	} {
+		binDir := t.TempDir()
+		logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n"+strings.ReplaceAll(row, `"`, `\"`)+"\\n' ; exit 0")
+		out := runFFSync(t, binDir, "--db", "app")
+		log := readLog(t, logPath)
+		if fetched(log) || pushed(log) {
+			t.Fatalf("row %q: a malformed processlist row must skip without fetching or pushing.\nout:\n%s\nlog:\n%s", row, out, log)
+		}
+		if !strings.Contains(out, "processlist query failed") || !strings.Contains(out, "malformed processlist row") {
+			t.Fatalf("row %q: expected the malformed-row skip line.\nout:\n%s", row, out)
+		}
 	}
 }
 

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -28,8 +28,17 @@ import (
 // override earlier ones (Go keeps the last value of a duplicated key).
 func ffSyncCmd(t *testing.T, binDir string, env []string, args ...string) *exec.Cmd {
 	t.Helper()
+	return packScriptCmd(t, syncScript, binDir, syncFilteredEnv(), env, args...)
+}
+
+// packScriptCmd builds `sh <script> <args>` for a one-DB ("app") SQL-mode city
+// against an idle reachable server, with the fake dolt in binDir first on
+// PATH and the fake bd installed: the ONE command-construction site the sync
+// and pull runners share (the repository's resource census counts os/exec
+// call sites and must not grow). Later `env` entries override earlier ones.
+func packScriptCmd(t *testing.T, script, binDir string, baseEnv, env []string, args ...string) *exec.Cmd {
+	t.Helper()
 	root := repoRoot(t)
-	script := filepath.Join(root, syncScript)
 	port, cleanup := startReachableTCPListener(t)
 	t.Cleanup(cleanup)
 
@@ -40,8 +49,8 @@ func ffSyncCmd(t *testing.T, binDir string, env []string, args ...string) *exec.
 	}
 	writeSyncFakeBeadsBD(t, cityPath)
 
-	cmd := exec.Command("sh", append([]string{script}, args...)...)
-	cmd.Env = append(append(syncFilteredEnv(),
+	cmd := exec.Command("sh", append([]string{filepath.Join(root, script)}, args...)...)
+	cmd.Env = append(append(baseEnv,
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -639,8 +639,8 @@ func TestSyncFetchInFlightSkipsNeverFetches(t *testing.T) {
 	// The processlist query is CONSTANT text: no database name is interpolated
 	// into it. A store named `dolt_fetch` (a valid name) would otherwise make
 	// the query match its own text and skip on every run (codex r6, evidence
-	// 04g). The per-database filter is applied on the answer instead
-	// (TestSyncFetchInFlightOtherDatabaseDoesNotCount, …CaseInsensitiveDatabase).
+	// 04g). There is no per-database filter at all: attribution is not proof
+	// of a statement's target (TestSyncFetchInFlightOtherDatabaseCountsToo).
 	if q := processlistQuery(t, log); strings.Contains(q, "app") || strings.Contains(q, "LOWER(db)") {
 		t.Fatalf("the processlist query must carry no database literal.\nquery:\n%s", q)
 	}
@@ -666,26 +666,27 @@ func processlistQuery(t *testing.T, log string) string {
 	return ""
 }
 
-// A session in flight for ANOTHER database does not block this one: the
-// per-database filter is applied on the answer (attributed to this db, or to
-// none), so the query text never carries a database name. A quoted db column
-// is read the way the CSV means it.
-func TestSyncFetchInFlightOtherDatabaseDoesNotCount(t *testing.T) {
+// A session attributed to ANOTHER database blocks this one too: the processlist
+// DB column is the connection's --use-db, not the statement's target (a client
+// on --use-db other running `USE app; CALL DOLT_FETCH` is attributed to other —
+// codex r9; evidence 04h b), so attribution proves nothing and every in-flight
+// remote operation on the server counts, fail closed. A quoted db column is
+// still validated as one CSV field.
+func TestSyncFetchInFlightOtherDatabaseCountsToo(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n44,500,other\\n45,10,\"other-two\"\\n' ; exit 0")
 	out := runFFSync(t, binDir, "--db", "app")
 	log := readLog(t, logPath)
-	if !fetched(log) {
-		t.Fatalf("a remote operation in flight for another database must not block this one's fetch.\nout:\n%s\nlog:\n%s", out, log)
+	if fetched(log) {
+		t.Fatalf("a remote operation in flight anywhere on the server must block this fetch (attribution is not proof of its target).\nout:\n%s\nlog:\n%s", out, log)
 	}
-	if strings.Contains(out, "already in flight") {
-		t.Fatalf("no in-flight line for another database's session.\nout:\n%s", out)
+	if !strings.Contains(out, "fetch already in flight for 500s (session 44)") {
+		t.Fatalf("expected the in-flight skip line naming the oldest session.\nout:\n%s", out)
 	}
 }
 
-// Database names compare case-insensitively on the answer: Dolt resolves
-// `app` and `APP` to one database and the processlist shows the client's
-// spelling.
+// A session attributed in another spelling (APP) blocks too — every attribution
+// does; the processlist shows the client's spelling.
 func TestSyncFetchInFlightCaseInsensitiveDatabase(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n46,20,APP\\n' ; exit 0")
@@ -699,9 +700,9 @@ func TestSyncFetchInFlightCaseInsensitiveDatabase(t *testing.T) {
 }
 
 // A session attributed to a revision-qualified name (`app/main`: the client
-// connected with --use-db app/main or ran USE app/main — Dolt's branch-qualified
-// database) is this database's and counts; another database's revision does
-// not (codex r8, evidence 04h).
+// connected with --use-db app/main — Dolt's branch-qualified database) counts,
+// and so does another database's revision: attribution is not proof of the
+// target (codex r8, r9; evidence 04h).
 func TestSyncFetchInFlightRevisionQualifiedDatabaseCounts(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n47,40,APP/feature/x\\n' ; exit 0")
@@ -715,8 +716,8 @@ func TestSyncFetchInFlightRevisionQualifiedDatabaseCounts(t *testing.T) {
 	binDir = t.TempDir()
 	logPath = writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n48,5,other/main\\n' ; exit 0")
 	out = runFFSync(t, binDir, "--db", "app")
-	if !fetched(readLog(t, logPath)) {
-		t.Fatalf("another database's revision (other/main) must not block this one.\nout:\n%s", out)
+	if fetched(readLog(t, logPath)) {
+		t.Fatalf("another database's revision (other/main) blocks too: attribution is not proof of the target.\nout:\n%s", out)
 	}
 }
 
@@ -869,9 +870,9 @@ func TestSyncFetchTimeoutKillVerdictRefusesMalformedAnswer(t *testing.T) {
 
 // No connection id captured (the client died before the server answered):
 // nothing is KILLed. Absence from the earlier processlist read does not prove
-// that a session listed now is ours (an operator's unattributed pull for
-// another database can appear in the same window), so the in-flight sessions
-// attributed to the db are reported for the operator and the run fails.
+// that a session listed now is ours (an operator's pull can appear in the
+// same window), so the in-flight remote operations on the server are
+// reported for the operator and the run fails.
 func TestSyncFetchTimeoutWithoutIDKillsNothingAndReportsUnproven(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "", []string{"88,61,app", "89,5,"}, false)
@@ -883,7 +884,7 @@ func TestSyncFetchTimeoutWithoutIDKillsNothingAndReportsUnproven(t *testing.T) {
 	if strings.Contains(log, "KILL ") {
 		t.Fatalf("without a session id, ownership is unproven: nothing may be KILLed.\nlog:\n%s", log)
 	}
-	want := "app: server-side fetch NOT killed: this client never learned its session id, and ownership of the in-flight session(s) attributed to app (Id 88 89) cannot be proven"
+	want := "app: server-side fetch NOT killed: this client never learned its session id, and ownership of the in-flight remote operation(s) on the server (Id 88 89) cannot be proven"
 	if !strings.Contains(out, want) {
 		t.Fatalf("expected %q\nout:\n%s", want, out)
 	}
@@ -934,12 +935,15 @@ func TestSyncFetchIsAttributedAndSelfIdentifying(t *testing.T) {
 // assertGateBeforeCall pins the batch shape `… CONNECTION_ID() … GET_LOCK('gc_remote_op:<db>', 0) … CALL …`.
 func assertGateBeforeCall(t *testing.T, line, db, call string) {
 	t.Helper()
-	// The lock name is lowercased on the server: `app` and `APP` are one
-	// database and must be one lock.
-	gate := "GET_LOCK(CONCAT('gc_remote_op:', LOWER('" + db + "')), 0)"
+	// The COMPLETE gate expression is the spec (codex r9: a check on the
+	// GET_LOCK substring alone accepted `>= 0`, which lets the CALL through
+	// while another session holds the lock): the lock name lowercased on the
+	// server (`app` and `APP` are one database and must be one lock), timeout
+	// 0, the `= 1` test, the 1 branch, and the marked JSON error branch.
+	gate := "SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('" + db + "')), 0) = 1, 1, JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS gate;"
 	idAt, gateAt, callAt := strings.Index(line, "SELECT CONNECTION_ID() AS id;"), strings.Index(line, gate), strings.Index(line, call)
 	if idAt < 0 || gateAt < 0 || callAt < 0 || (idAt >= gateAt || gateAt >= callAt) {
-		t.Fatalf("the batch must be id, then the GET_LOCK gate, then the CALL.\nline: %s", line)
+		t.Fatalf("the batch must be id, then the complete GET_LOCK gate %q, then the CALL.\nline: %s", gate, line)
 	}
 	if !strings.Contains(line, "JSON_EXTRACT('gc-remote-op-lock-held', '$')") {
 		t.Fatalf("the gate's else branch must raise the marked error.\nline: %s", line)

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -34,11 +34,17 @@ func ffSyncCmd(t *testing.T, binDir string, env []string, args ...string) *exec.
 // packScriptCmd builds `sh <script> <args>` for a one-DB ("app") SQL-mode city
 // against an idle reachable server, with the fake dolt in binDir first on
 // PATH and the fake bd installed: the ONE command-construction site the sync
-// and pull runners share (the repository's resource census counts os/exec
-// call sites and must not grow). Later `env` entries override earlier ones.
+// and pull runners — and the kill-helper wrapper (runKillHelper) — share (the
+// repository's resource census counts os/exec call sites and must not grow).
+// script is repo-root-relative, or absolute for a test-written wrapper. Later
+// `env` entries override earlier ones.
 func packScriptCmd(t *testing.T, script, binDir string, baseEnv, env []string, args ...string) *exec.Cmd {
 	t.Helper()
 	root := repoRoot(t)
+	scriptPath := script
+	if !filepath.IsAbs(script) {
+		scriptPath = filepath.Join(root, script)
+	}
 	port, cleanup := startReachableTCPListener(t)
 	t.Cleanup(cleanup)
 
@@ -49,7 +55,7 @@ func packScriptCmd(t *testing.T, script, binDir string, baseEnv, env []string, a
 	}
 	writeSyncFakeBeadsBD(t, cityPath)
 
-	cmd := exec.Command("sh", append([]string{filepath.Join(root, script)}, args...)...)
+	cmd := exec.Command("sh", append([]string{scriptPath}, args...)...)
 	cmd.Env = append(append(baseEnv,
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
@@ -1319,22 +1325,18 @@ func assertIDIsTheGate(t *testing.T, line, db, call string) {
 	}
 }
 
-// killHelperEnv runs kill_remote_op_session alone (runtime.sh sourced, the
-// fake dolt in binDir first on PATH, this run's nonce fixed) and returns the
-// helper's stderr and exit code — the return code IS the rule under test.
+// runKillHelper runs kill_remote_op_session alone — a test-written wrapper
+// script sources runtime.sh, fixes this run's nonce and calls the helper —
+// through packScriptCmd (the fake dolt in binDir first on PATH) and returns
+// the helper's stderr and exit code: the return code IS the rule under test.
 func runKillHelper(t *testing.T, binDir, label, db, id string) (string, int) {
 	t.Helper()
-	root := repoRoot(t)
-	cmd := exec.Command("sh", "-c", `. "$GC_PACK_DIR/assets/scripts/runtime.sh"; REMOTE_OP_RUN_NONCE=0123456789abcdef; kill_remote_op_session "$1" "$2" "$3"`, "sh", label, db, id)
-	cmd.Env = append(filteredEnv("PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_CITY_PATH", "GC_PACK_DIR"),
-		"PATH="+binDir+":"+os.Getenv("PATH"),
-		"GC_CITY_PATH="+t.TempDir(),
-		"GC_PACK_DIR="+root,
-		"GC_DOLT_PORT=1",
-		"GC_DOLT_USER=root",
-		"GC_DOLT_PASSWORD=",
-	)
-	out, err := cmd.CombinedOutput()
+	wrapper := filepath.Join(binDir, "kill-helper.sh")
+	body := "#!/bin/sh\n. \"$GC_PACK_DIR/assets/scripts/runtime.sh\"\nREMOTE_OP_RUN_NONCE=0123456789abcdef\nkill_remote_op_session \"$1\" \"$2\" \"$3\"\n"
+	if err := os.WriteFile(wrapper, []byte(body), 0o755); err != nil {
+		t.Fatalf("write kill-helper wrapper: %v", err)
+	}
+	out, err := packScriptCmd(t, wrapper, binDir, filteredEnv("PATH"), nil, label, db, id).CombinedOutput()
 	rc := 0
 	if err != nil {
 		var ee *exec.ExitError

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -636,10 +636,13 @@ func TestSyncFetchInFlightSkipsNeverFetches(t *testing.T) {
 	if !strings.Contains(out, "app: fetch already in flight for 7200s (session 42)") || !strings.Contains(out, "NOT pushed") {
 		t.Fatalf("expected the in-flight skip line naming the oldest session's age and id.\nout:\n%s", out)
 	}
-	// Scoped to this database, case-insensitively: Dolt resolves `app` and
-	// `APP` to one database and the processlist shows the client's spelling.
-	if !strings.Contains(log, "LOWER(db) = LOWER('app')") {
-		t.Fatalf("the single-flight check must be scoped to this database, case-insensitively.\nlog:\n%s", log)
+	// The processlist query is CONSTANT text: no database name is interpolated
+	// into it. A store named `dolt_fetch` (a valid name) would otherwise make
+	// the query match its own text and skip on every run (codex r6, evidence
+	// 04g). The per-database filter is applied on the answer instead
+	// (TestSyncFetchInFlightOtherDatabaseDoesNotCount, …CaseInsensitiveDatabase).
+	if q := processlistQuery(t, log); strings.Contains(q, "app") || strings.Contains(q, "LOWER(db)") {
+		t.Fatalf("the processlist query must carry no database literal.\nquery:\n%s", q)
 	}
 	// The predicate is the whole-identifier token test on the statement text,
 	// not a LIKE prefix and not a grammar of spellings: any statement naming
@@ -647,6 +650,51 @@ func TestSyncFetchInFlightSkipsNeverFetches(t *testing.T) {
 	// comments, qualifiers, any case (verified on Dolt 2.1.10, evidence 04f).
 	if !strings.Contains(log, "UPPER(Info) REGEXP '(^|[^A-Z0-9_])DOLT_(FETCH|PULL)([^A-Z0-9_]|$)'") {
 		t.Fatalf("the in-flight predicate must be the whole-identifier REGEXP on UPPER(Info).\nlog:\n%s", log)
+	}
+}
+
+// processlistQuery returns the single-flight processlist invocation the fake
+// dolt logged (one `$*` line per invocation).
+func processlistQuery(t *testing.T, log string) string {
+	t.Helper()
+	for _, line := range strings.Split(log, "\n") {
+		if strings.Contains(line, "information_schema.processlist") {
+			return line
+		}
+	}
+	t.Fatalf("no processlist query in the log:\n%s", log)
+	return ""
+}
+
+// A session in flight for ANOTHER database does not block this one: the
+// per-database filter is applied on the answer (attributed to this db, or to
+// none), so the query text never carries a database name. A quoted db column
+// is read the way the CSV means it.
+func TestSyncFetchInFlightOtherDatabaseDoesNotCount(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n44,500,other\\n45,10,\"other-two\"\\n' ; exit 0")
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if !fetched(log) {
+		t.Fatalf("a remote operation in flight for another database must not block this one's fetch.\nout:\n%s\nlog:\n%s", out, log)
+	}
+	if strings.Contains(out, "already in flight") {
+		t.Fatalf("no in-flight line for another database's session.\nout:\n%s", out)
+	}
+}
+
+// Database names compare case-insensitively on the answer: Dolt resolves
+// `app` and `APP` to one database and the processlist shows the client's
+// spelling.
+func TestSyncFetchInFlightCaseInsensitiveDatabase(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n46,20,APP\\n' ; exit 0")
+	out := runFFSync(t, binDir, "--db", "app")
+	if fetched(readLog(t, logPath)) {
+		t.Fatalf("a session attributed to APP is this database's (app): it must block the fetch.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "fetch already in flight for 20s (session 46)") {
+		t.Fatalf("expected the in-flight skip line.\nout:\n%s", out)
 	}
 }
 

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -1036,8 +1036,10 @@ func TestSyncFetchTimeoutWithoutIDAndNothingListedKillsNothing(t *testing.T) {
 	if strings.Contains(log, "KILL ") {
 		t.Fatalf("nothing in flight after the timeout: nothing to KILL.\nlog:\n%s", log)
 	}
-	if !strings.Contains(out, "app: server-side fetch already ended (nothing in flight to kill)") {
-		t.Fatalf("expected the already-ended line.\nout:\n%s", out)
+	// The no-id path never confirms a cleanup (codex round-2 r3): the gate's
+	// answer never arrived, so a gate may still be pending on the server.
+	if !strings.Contains(out, "app: server-side fetch cleanup NOT confirmed: this client never learned its session id") || strings.Contains(out, "already ended") {
+		t.Fatalf("expected the cleanup-not-confirmed line and never already ended.\nout:\n%s", out)
 	}
 }
 
@@ -1383,8 +1385,10 @@ func TestKillRemoteOpSessionNeverReturnsZeroWhileTheRunLockIsHeld(t *testing.T) 
 	}{
 		{"killed, gone, lock free", "77", none, killed, holder("0"), 0, "app: server-side fetch killed (session 77 no longer in flight)", "NOT killed"},
 		{"guarded, gone, lock free (the server restarted)", "77", none, notOwner, holder("0"), 0, "app: server-side fetch already ended (session 77 is gone; nothing killed)", "NOT killed"},
-		{"guarded, gone, another session holds this run's lock", "77", none, notOwner, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ")", "already ended"},
-		{"killed, gone, another session holds this run's lock", "77", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ")", "no longer in flight"},
+		// The complete diagnostic is asserted (codex round-2 r3): the holder may
+		// be idle, so the line must not promise that health names it.
+		{"guarded, gone, another session holds this run's lock", "77", none, notOwner, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ") — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number); gc dolt health names it only while it runs a remote operation — left for the operator (KILL 91)", "already ended"},
+		{"killed, gone, another session holds this run's lock", "77", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ") — the recorded id was not the lock holder (a record from before the id came from the gate statement, or a server that restarted and reused the number); gc dolt health names it only while it runs a remote operation — left for the operator (KILL 91)", "no longer in flight"},
 		{"guarded, still listed", "77", listed77, notOwner, holder("77"), 1, "app: server-side fetch NOT killed: session 77 does not hold this run's lock (" + runLock + ")", "already ended"},
 		// The recorded id still holds the lock but runs no DOLT_FETCH/DOLT_PULL
 		// statement (the bound expired between the gate and the CALL), so the
@@ -1395,7 +1399,11 @@ func TestKillRemoteOpSessionNeverReturnsZeroWhileTheRunLockIsHeld(t *testing.T) 
 		{"holder query fails", "77", none, killed, "printf 'holder: boom\\n' >&2 ; exit 1", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
 		{"holder answer is not a holder answer", "77", none, killed, "printf 'nothing here\\n' ; exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
 		{"holder answer is empty", "77", none, killed, "exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
-		{"no id, nothing listed, lock free", "", none, killed, holder("0"), 0, "app: server-side fetch already ended (nothing in flight to kill)", "NOT killed"},
+		// No id: the gate's answer never arrived. With the id inside the gate
+		// that no longer proves the gate never ran — a gate still pending on
+		// the server can take this run's lock AFTER a "free" read (codex
+		// round-2 r3) — so the no-id path never confirms a cleanup: exit 1.
+		{"no id, nothing listed, lock free", "", none, killed, holder("0"), 1, "app: server-side fetch cleanup NOT confirmed: this client never learned its session id (the gate's answer never arrived) and this run's lock (" + runLock + ") reads free — the gate never reached the server, or is still pending and could take the lock after this read; nothing killed", "already ended"},
 		// The holder passed this run's gate and its answer died with the client;
 		// it runs no remote operation, so health cannot name it (codex round-2
 		// r2: the line must not promise that it does).

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -698,6 +698,52 @@ func TestSyncFetchInFlightCaseInsensitiveDatabase(t *testing.T) {
 	}
 }
 
+// A session attributed to a revision-qualified name (`app/main`: the client
+// connected with --use-db app/main or ran USE app/main — Dolt's branch-qualified
+// database) is this database's and counts; another database's revision does
+// not (codex r8, evidence 04h).
+func TestSyncFetchInFlightRevisionQualifiedDatabaseCounts(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n47,40,APP/feature/x\\n' ; exit 0")
+	out := runFFSync(t, binDir, "--db", "app")
+	if fetched(readLog(t, logPath)) {
+		t.Fatalf("a session attributed to APP/feature/x is this database's: it must block the fetch.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "fetch already in flight for 40s (session 47)") {
+		t.Fatalf("expected the in-flight skip line.\nout:\n%s", out)
+	}
+	binDir = t.TempDir()
+	logPath = writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n48,5,other/main\\n' ; exit 0")
+	out = runFFSync(t, binDir, "--db", "app")
+	if !fetched(readLog(t, logPath)) {
+		t.Fatalf("another database's revision (other/main) must not block this one.\nout:\n%s", out)
+	}
+}
+
+// The gate-refusal verdict is Dolt's Error 3141 with the marker echoed as
+// json_extract's argument — not the marker anywhere in stderr: the CLI echoes
+// the failing statement in every batch diagnostic, so an ordinary error on a
+// fetch whose remote is literally named gc-remote-op-lock-held must be
+// reported as the fetch error it is, never as "already in flight" (codex r8).
+func TestSyncGateMarkerInOrdinaryErrorIsNotRefusal(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "dolt.log")
+	body := fakeDoltHeader(logPath, "main") +
+		"  *\"CALL DOLT_FETCH(\"*) printf 'id\\n63\\n' ; printf 'error on line 1 for query CALL DOLT_FETCH(''gc-remote-op-lock-held'', ''main''): Error 1105 (HY000): remote not found\\n' >&2 ; exit 1 ;;\n" +
+		"esac\nexit 0\n"
+	installFFFakeDolt(t, binDir, body)
+	out := runFFSync(t, binDir, "--db", "app")
+	if strings.Contains(out, "already in flight") {
+		t.Fatalf("an ordinary error echoing the marker must not read as a gate refusal.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "fetch failed (exit 1)") || !strings.Contains(out, "remote not found") {
+		t.Fatalf("expected the ordinary fetch error with dolt's stderr replayed.\nout:\n%s", out)
+	}
+	if pushed(readLog(t, logPath)) {
+		t.Fatalf("a failed fetch must NEVER push.\nout:\n%s", out)
+	}
+}
+
 // An in-flight DOLT_FETCH with no database attribution (an older gc dolt sync
 // issued it, or an operator did, without --use-db) may be this database's:
 // it counts, fail closed.

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -66,9 +66,23 @@ func runFFSync(t *testing.T, binDir string, args ...string) string {
 	return out
 }
 
-// fakeDoltHeader is the shared preamble: log argv and answer the remote-lookup
-// + active_branch metadata queries the sync path issues before classification.
+// fakeDoltHeader is the shared preamble for an IDLE server: log argv, answer
+// the remote-lookup + active_branch metadata queries the sync path issues
+// before classification, and answer the single-flight processlist query with
+// its header only (nothing in flight, so the fetch proceeds).
 func fakeDoltHeader(logPath, branch string) string {
+	return fakeDoltPreamble(logPath, branch) + fakeDoltProcesslistIdleArm
+}
+
+// fakeDoltProcesslistIdleArm answers the single-flight processlist query with
+// the `Id,Time,db` header and no rows. The header is load-bearing: the parser
+// (remote_op_sessions_parse, runtime.sh) treats an answer without it as "not a
+// processlist answer" and the fetch is skipped, fail closed.
+const fakeDoltProcesslistIdleArm = "  *\"information_schema.processlist\"*) printf 'Id,Time,db\\n' ; exit 0 ;;\n"
+
+// fakeDoltPreamble logs argv and answers the remote-lookup + active_branch
+// metadata queries; the caller appends the processlist / fetch / push arms.
+func fakeDoltPreamble(logPath, branch string) string {
 	return "#!/bin/sh\n" +
 		"printf '%s\\n' \"$*\" >> \"" + logPath + "\"\n" +
 		"case \"$*\" in\n" +
@@ -533,5 +547,233 @@ func TestSyncRejectsInvalidFetchTimeout(t *testing.T) {
 		if !strings.Contains(string(out), "invalid GC_DOLT_SYNC_FETCH_TIMEOUT_SECS") {
 			t.Errorf("fetch timeout %q: want validation message\nout: %s", bad, out)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gp-f2yq: ONE server-side DOLT_FETCH per database at a time, and the
+// server-side call dies with the client bound.
+//
+// A `CALL DOLT_FETCH` runs INSIDE the sql-server. When the client's wall-clock
+// bound expired only the client died; the server-side fetch kept running, and
+// the 15-minute patrol stacked one more on every run (boomtown 2026-09-11: 169
+// of 178 sql-server sessions in DOLT_FETCH, one per run for two days). The
+// fakes below answer the single-flight processlist query, print the fetch's
+// own connection id the way the real CLI does before the procedure starts,
+// and log KILLs; marker files in binDir let the processlist answer change as
+// the fetch starts and as it is killed, the way the live server's does.
+// ---------------------------------------------------------------------------
+
+// writeSyncFakeDoltProcesslist installs a fake dolt whose single-flight
+// processlist answer is `arm` (a complete case arm body: printf/exit); a fetch,
+// if one is ever issued, succeeds silently and is logged.
+func writeSyncFakeDoltProcesslist(t *testing.T, dir, arm string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := fakeDoltPreamble(logPath, "main") +
+		"  *\"information_schema.processlist\"*) " + arm + " ;;\n" +
+		"  *\"CALL DOLT_FETCH(\"*) exit 0 ;;\n" +
+		"esac\nexit 0\n"
+	return installFFFakeDolt(t, dir, body)
+}
+
+// writeSyncFakeDoltFetchTimeoutKill models the live sequence: the processlist
+// is empty before the fetch; the fetch prints its connection id (sessionID;
+// nothing when empty) and then hits the bound (exit 124), after which the
+// processlist lists `listedAfterFetch` (Id,Time,db rows); every KILL is logged
+// and afterwards the processlist is empty again — unless stayAlive, in which
+// case the rows keep being listed after the KILL (a KILL that did not take).
+func writeSyncFakeDoltFetchTimeoutKill(t *testing.T, dir, sessionID string, listedAfterFetch []string, stayAlive bool) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	started := filepath.Join(dir, "fetch-started")
+	killed := filepath.Join(dir, "killed")
+	idEmit := ""
+	if sessionID != "" {
+		idEmit = "printf 'id\\n" + sessionID + "\\n' ; "
+	}
+	rows := ""
+	for _, r := range listedAfterFetch {
+		rows += r + "\\n"
+	}
+	afterKill := "printf 'Id,Time,db\\n'"
+	if stayAlive {
+		afterKill = "printf 'Id,Time,db\\n" + rows + "'"
+	}
+	body := fakeDoltPreamble(logPath, "main") +
+		"  *\"information_schema.processlist\"*)\n" +
+		"    if [ -f \"" + killed + "\" ]; then " + afterKill + "\n" +
+		"    elif [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n" + rows + "'\n" +
+		"    else printf 'Id,Time,db\\n'; fi\n" +
+		"    exit 0 ;;\n" +
+		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; " + idEmit + "printf 'context deadline exceeded\\n' >&2 ; exit 124 ;;\n" +
+		"  *\"KILL \"*) : > \"" + killed + "\" ; exit 0 ;;\n" +
+		"esac\nexit 0\n"
+	return installFFFakeDolt(t, dir, body)
+}
+
+// fetched reports whether the fake dolt was asked to run the fetch procedure.
+// It matches the CALL itself, not the bare procedure name: the single-flight
+// processlist query names DOLT_FETCH inside its LIKE pattern too.
+func fetched(log string) bool { return strings.Contains(log, "CALL DOLT_FETCH(") }
+
+func TestSyncFetchInFlightSkipsNeverFetches(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n42,7200,app\\n' ; exit 0")
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if fetched(log) {
+		t.Fatalf("a fetch already in flight for the db must NOT start another.\nout:\n%s\nlog:\n%s", out, log)
+	}
+	if pushed(log) {
+		t.Fatalf("a fetch already in flight must NEVER push.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "app: fetch already in flight for 7200s (session 42)") || !strings.Contains(out, "NOT pushed") {
+		t.Fatalf("expected the in-flight skip line naming the oldest session's age and id.\nout:\n%s", out)
+	}
+	if !strings.Contains(log, "db = 'app'") {
+		t.Fatalf("the single-flight check must be scoped to this database.\nlog:\n%s", log)
+	}
+}
+
+// An in-flight DOLT_FETCH with no database attribution (an older gc dolt sync
+// issued it, or an operator did, without --use-db) may be this database's:
+// it counts, fail closed.
+func TestSyncFetchInFlightUnattributedSkips(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n43,30,\\n' ; exit 0")
+	out := runFFSync(t, binDir, "--db", "app")
+	if fetched(readLog(t, logPath)) {
+		t.Fatalf("an unattributed in-flight fetch must block this db's fetch.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "fetch already in flight for 30s (session 43)") {
+		t.Fatalf("expected the in-flight skip line.\nout:\n%s", out)
+	}
+}
+
+func TestSyncProcesslistQueryFailureSkipsNeverFetches(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'processlist: boom\\n' >&2 ; exit 1")
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if fetched(log) || pushed(log) {
+		t.Fatalf("a failed processlist query must skip without fetching or pushing (fail closed).\nout:\n%s\nlog:\n%s", out, log)
+	}
+	if !strings.Contains(out, "app: ERROR: processlist query failed (exit 1)") || !strings.Contains(out, "app: processlist: boom") {
+		t.Fatalf("expected the processlist failure line with dolt's stderr replayed.\nout:\n%s", out)
+	}
+}
+
+// An answer without the `Id,Time,db` header is not a processlist answer (an
+// empty stdout, a banner, a wrapper that swallowed the result): it must not
+// be read as "nothing in flight".
+func TestSyncProcesslistAnswerWithoutHeaderSkips(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "exit 0")
+	out := runFFSync(t, binDir, "--db", "app")
+	if fetched(readLog(t, logPath)) {
+		t.Fatalf("a header-less processlist answer must skip the fetch (fail closed).\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "processlist query failed") || !strings.Contains(out, "not a processlist answer") {
+		t.Fatalf("expected the unrecognized-answer skip line.\nout:\n%s", out)
+	}
+}
+
+func TestSyncFetchTimeoutKillsItsServerSideSession(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "77", []string{"77,60,app"}, false)
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if pushed(log) {
+		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "fetch timed out") {
+		t.Fatalf("expected the 'fetch timed out' status.\nout:\n%s", out)
+	}
+	fetchAt := strings.Index(log, "CALL DOLT_FETCH(")
+	killAt := strings.Index(log, "KILL 77")
+	if fetchAt < 0 || killAt < 0 || killAt < fetchAt {
+		t.Fatalf("the session the fetch printed about itself must be KILLed after the fetch times out.\nlog:\n%s", log)
+	}
+	if !strings.Contains(out, "app: server-side fetch killed (session 77 no longer in flight)") {
+		t.Fatalf("expected the kill line proven by the processlist after KILL.\nout:\n%s", out)
+	}
+}
+
+// The verdict is the processlist AFTER the KILL, not KILL's exit code (Dolt
+// 2.1.10 answers KILL of any id, gone or not, with exit 0 and no text).
+func TestSyncFetchTimeoutKillNotConfirmedReportsStillInFlight(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "77", []string{"77,60,app"}, true)
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if pushed(log) {
+		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
+	}
+	if !strings.Contains(log, "KILL 77") {
+		t.Fatalf("KILL must be issued.\nlog:\n%s", log)
+	}
+	if !strings.Contains(out, "app: server-side fetch NOT killed (session 77 still in flight after KILL)") {
+		t.Fatalf("a session still listed after KILL must be reported as NOT killed.\nout:\n%s", out)
+	}
+}
+
+// No connection id captured (the client died before the server answered):
+// every in-flight remote operation attributed to the db is ended — the
+// single-flight check found none before ours started, so each is ours or a
+// concurrent runner's that raced the same window, and none may survive.
+func TestSyncFetchTimeoutWithoutIDKillsEveryAttributedSession(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "", []string{"88,61,app", "89,5,"}, false)
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if pushed(log) {
+		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
+	}
+	for _, id := range []string{"88", "89"} {
+		if !strings.Contains(log, "KILL "+id) {
+			t.Fatalf("session %s must be KILLed.\nlog:\n%s", id, log)
+		}
+		if !strings.Contains(out, "server-side fetch killed (session "+id+" no longer in flight)") {
+			t.Fatalf("expected the kill line for session %s.\nout:\n%s", id, out)
+		}
+	}
+}
+
+func TestSyncFetchTimeoutWithoutIDAndNothingListedKillsNothing(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "", nil, false)
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if strings.Contains(log, "KILL ") {
+		t.Fatalf("nothing in flight after the timeout: nothing to KILL.\nlog:\n%s", log)
+	}
+	if !strings.Contains(out, "app: server-side fetch already ended (nothing in flight to kill)") {
+		t.Fatalf("expected the already-ended line.\nout:\n%s", out)
+	}
+}
+
+// The fetch statement attributes its session to the database (--use-db fills
+// the processlist DB column; a `USE` inside the query does not) and prints its
+// own connection id first, so the KILL operand is the session's own word.
+func TestSyncFetchIsAttributedAndSelfIdentifying(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltClassify(t, binDir, 1, 0)
+	out := runFFSync(t, binDir, "--db", "app")
+	var fetchLine string
+	for _, line := range strings.Split(readLog(t, logPath), "\n") {
+		if strings.Contains(line, "CALL DOLT_FETCH(") {
+			fetchLine = line
+			break
+		}
+	}
+	if fetchLine == "" {
+		t.Fatalf("no fetch issued.\nout:\n%s", out)
+	}
+	if !strings.Contains(fetchLine, "--use-db app") {
+		t.Fatalf("the fetch must run with --use-db app so the server attributes the session.\nline: %s", fetchLine)
+	}
+	if !strings.Contains(fetchLine, "SELECT CONNECTION_ID() AS id;") {
+		t.Fatalf("the fetch statement must print its own connection id first.\nline: %s", fetchLine)
 	}
 }

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -895,3 +895,44 @@ func TestSyncFetchGateRefusedSkipsNeverPushes(t *testing.T) {
 		t.Fatalf("a gate refusal is a skip, not a fetch failure.\nout:\n%s", out)
 	}
 }
+
+// The bound's verdict outranks anything the client printed: a client the
+// bound killed may have written the first-push signal ("no branches found in
+// remote" / "invalid ref spec") before stalling. Exit 124 or 137 with that
+// text is a timeout — the recorded session is KILLed and nothing is pushed —
+// never a first push.
+func TestSyncFetchTimeoutOutranksFirstPushText(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		text string
+	}{
+		{124, "no branches found in remote"},
+		{137, "fetch failed: invalid ref spec"},
+	} {
+		binDir := t.TempDir()
+		logPath := filepath.Join(binDir, "dolt.log")
+		started := filepath.Join(binDir, "fetch-started")
+		killed := filepath.Join(binDir, "killed")
+		body := fakeDoltPreamble(logPath, "main") +
+			"  *\"information_schema.processlist\"*)\n" +
+			"    if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'\n" +
+			"    elif [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n93,61,app\\n'\n" +
+			"    else printf 'Id,Time,db\\n'; fi\n" +
+			"    exit 0 ;;\n" +
+			"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n93\\n' ; printf '" + tc.text + "\\n' >&2 ; exit " + fmt.Sprint(tc.code) + " ;;\n" +
+			"  *\"KILL \"*) : > \"" + killed + "\" ; exit 0 ;;\n" +
+			"esac\nexit 0\n"
+		installFFFakeDolt(t, binDir, body)
+		out := runFFSync(t, binDir, "--db", "app")
+		log := readLog(t, logPath)
+		if pushed(log) {
+			t.Fatalf("exit %d with %q: a dead client must NEVER push.\nout:\n%s\nlog:\n%s", tc.code, tc.text, out, log)
+		}
+		if !strings.Contains(out, "fetch timed out") || strings.Contains(out, "first push") {
+			t.Fatalf("exit %d with %q: the timeout must outrank the first-push text.\nout:\n%s", tc.code, tc.text, out)
+		}
+		if !strings.Contains(log, "KILL 93") || !strings.Contains(out, "server-side fetch killed (session 93 no longer in flight)") {
+			t.Fatalf("exit %d with %q: the recorded session must be KILLed.\nout:\n%s\nlog:\n%s", tc.code, tc.text, out, log)
+		}
+	}
+}

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -889,6 +890,63 @@ func TestSyncFetchBoundReachesTheFetch(t *testing.T) {
 	assertBounded(t, readLog(t, tlogPath), "9", "CALL DOLT_FETCH(")
 }
 
+// The CALL refused itself: the session that sent it no longer held this run's
+// lock (the client reconnected between the gate and the CALL — codex r12).
+// Reported on its own line, nothing KILLed, nothing pushed, non-zero exit.
+func TestSyncFetchLostRunLockBeforeCallSkipsKillsNothing(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "dolt.log")
+	body := fakeDoltHeader(logPath, "main") +
+		"  *\"CALL DOLT_FETCH(\"*) printf 'id\\n65\\n' ; printf 'error on line 1 for query CALL DOLT_FETCH(IF(...)): Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-lost\"\\n' >&2 ; exit 1 ;;\n" +
+		"  *\"KILL \"*) : > \"" + filepath.Join(binDir, "killed") + "\" ; exit 0 ;;\n" +
+		"esac\nexit 0\n"
+	installFFFakeDolt(t, binDir, body)
+	out := runFFSyncFails(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if pushed(log) || strings.Contains(log, "KILL ") {
+		t.Fatalf("a CALL that refused itself ran no procedure: nothing to kill, nothing to push.\nout:\n%s\nlog:\n%s", out, log)
+	}
+	if !strings.Contains(out, "app: fetch not sent — this session lost the run lock between the gate and the CALL") || !strings.Contains(out, "NOT pushed") {
+		t.Fatalf("expected the lost-lock line.\nout:\n%s", out)
+	}
+}
+
+// The KILL is guarded by this run's lock in its own batch: when the id no
+// longer holds it — a restarted server reused the number for someone else —
+// the batch stops before the KILL and a session still listed is reported as
+// NOT ours; a session already gone is reported as ended (codex r12).
+func TestSyncFetchTimeoutKillGuardedByRunLock(t *testing.T) {
+	notOwner := "printf 'error on line 1 for query SELECT IF(IS_USED_LOCK(...)) AS own: Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-not-owner\"\\n' >&2 ; exit 1 ;;\n"
+	for _, tc := range []struct{ name, rowsAfter, want string }{
+		{"reused id still listed", "77,60,app\\n", "app: server-side fetch NOT killed: session 77 does not hold this run's lock (gc_remote_op_run:app:"},
+		{"session already gone", "", "app: server-side fetch already ended (session 77 is gone; nothing killed)"},
+	} {
+		binDir := t.TempDir()
+		logPath := filepath.Join(binDir, "dolt.log")
+		started := filepath.Join(binDir, "fetch-started")
+		body := fakeDoltPreamble(logPath, "main") +
+			"  *\"information_schema.processlist\"*)\n" +
+			"    if [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n" + tc.rowsAfter + "'\n" +
+			"    else printf 'Id,Time,db\\n'; fi\n" +
+			"    exit 0 ;;\n" +
+			"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n77\\n' ; printf 'context deadline exceeded\\n' >&2 ; exit 124 ;;\n" +
+			"  *\"KILL \"*) " + notOwner +
+			"esac\nexit 0\n"
+		installFFFakeDolt(t, binDir, body)
+		out := runFFSyncFails(t, binDir, "--db", "app")
+		log := readLog(t, logPath)
+		if pushed(log) {
+			t.Fatalf("%s: a fetch timeout must NEVER push.\nout:\n%s", tc.name, out)
+		}
+		if !strings.Contains(log, "IS_USED_LOCK('gc_remote_op_run:app:") || !strings.Contains(log, "JSON_EXTRACT('gc-remote-op-not-owner', '$')) AS own; KILL 77\n") {
+			t.Fatalf("%s: the KILL must be guarded by this run's lock in the same batch.\nlog:\n%s", tc.name, log)
+		}
+		if !strings.Contains(out, tc.want) || strings.Contains(out, "no longer in flight") {
+			t.Fatalf("%s: expected %q and never a kill confirmation.\nout:\n%s", tc.name, tc.want, out)
+		}
+	}
+}
+
 // The verdict after KILL is a processlist read too: an answer with a malformed
 // row (here a fourth column, which an earlier parser dropped as "another
 // database" — codex r7) must refuse to confirm the kill, never report the
@@ -983,11 +1041,20 @@ func assertGateBeforeCall(t *testing.T, line, db, call string) {
 	// GET_LOCK substring alone accepted `>= 0`, which lets the CALL through
 	// while another session holds the lock): the lock name lowercased on the
 	// server (`app` and `APP` are one database and must be one lock), timeout
-	// 0, the `= 1` test, the 1 branch, and the marked JSON error branch.
-	gate := "SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('" + db + "')), 0) = 1, 1, JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS gate;"
-	idAt, gateAt, callAt := strings.Index(line, "SELECT CONNECTION_ID() AS id;"), strings.Index(line, gate), strings.Index(line, call)
-	if idAt < 0 || gateAt < 0 || callAt < 0 || (idAt >= gateAt || gateAt >= callAt) {
-		t.Fatalf("the batch must be id, then the complete GET_LOCK gate %q, then the CALL.\nline: %s", gate, line)
+	// 0, this run's own lock (`gc_remote_op_run:<db>:<pid>-<epoch>`), the
+	// `= 1` tests, the 1 branch, and the marked JSON error branch. The CALL's
+	// FIRST ARGUMENT re-proves that the session still holds the same run lock
+	// (codex r12: a pooled client that reconnected between the gate and the
+	// CALL would otherwise fetch on a lockless session).
+	gateRe := regexp.MustCompile(regexp.QuoteMeta("SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('"+db+"')), 0) = 1 AND GET_LOCK('gc_remote_op_run:"+db+":") + `([0-9]+-[0-9]+)` + regexp.QuoteMeta("', 0) = 1, 1, JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS gate;"))
+	callRe := regexp.MustCompile(regexp.QuoteMeta(call+"IF(IS_USED_LOCK('gc_remote_op_run:"+db+":") + `([0-9]+-[0-9]+)` + regexp.QuoteMeta("') = CONNECTION_ID(), '") + `[^']+` + regexp.QuoteMeta("', JSON_EXTRACT('gc-remote-op-lost', '$')), "))
+	gateM, callM := gateRe.FindStringSubmatchIndex(line), callRe.FindStringSubmatchIndex(line)
+	idAt := strings.Index(line, "SELECT CONNECTION_ID() AS id;")
+	if idAt < 0 || gateM == nil || callM == nil || idAt >= gateM[0] || gateM[0] >= callM[0] {
+		t.Fatalf("the batch must be id, then the complete gate %s, then the CALL whose first argument is the ownership check %s.\nline: %s", gateRe, callRe, line)
+	}
+	if line[gateM[2]:gateM[3]] != line[callM[2]:callM[3]] {
+		t.Fatalf("the CALL must re-check the SAME run lock the gate took (%q vs %q).\nline: %s", line[gateM[2]:gateM[3]], line[callM[2]:callM[3]], line)
 	}
 	if !strings.Contains(line, "JSON_EXTRACT('gc-remote-op-lock-held', '$')") {
 		t.Fatalf("the gate's else branch must raise the marked error.\nline: %s", line)

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -639,9 +639,16 @@ func writeSyncFakeDoltFetchTimeoutKill(t *testing.T, dir, sessionID string, list
 		"    exit 0 ;;\n" +
 		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; " + idEmit + "printf 'context deadline exceeded\\n' >&2 ; exit 124 ;;\n" +
 		"  *\"KILL \"*) k=$(printf '%s' \"$*\" | sed -n 's/.*KILL \\([0-9][0-9]*\\).*/\\1/p') ; : > \"" + killedPrefix + "${k}\" ; exit 0 ;;\n" +
+		fakeDoltRunLockFreeArm +
 		"esac\nexit 0\n"
 	return installFFFakeDolt(t, dir, body)
 }
+
+// fakeDoltRunLockFreeArm answers the kill helper's run-lock holder query
+// (gp-f2yq round 2) with "free" (0): the helper never confirms a kill, or an
+// ended session, without that answer — a test that wants a live holder
+// writes its own arm.
+const fakeDoltRunLockFreeArm = "  *\"COALESCE(IS_USED_LOCK(\"*) printf 'holder\\n0\\n' ; exit 0 ;;\n"
 
 // fetched reports whether the fake dolt was asked to run the fetch procedure.
 // It matches the CALL itself, not the bare procedure name: the single-flight
@@ -963,6 +970,7 @@ func TestSyncFetchTimeoutKillGuardedByRunLock(t *testing.T) {
 			"    exit 0 ;;\n" +
 			"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n77\\n' ; printf 'context deadline exceeded\\n' >&2 ; exit 124 ;;\n" +
 			"  *\"KILL \"*) " + notOwner +
+			fakeDoltRunLockFreeArm +
 			"esac\nexit 0\n"
 		installFFFakeDolt(t, binDir, body)
 		out := runFFSyncFails(t, binDir, "--db", "app")
@@ -1053,12 +1061,10 @@ func TestSyncFetchIsAttributedAndSelfIdentifying(t *testing.T) {
 	if !strings.Contains(fetchLine, "--use-db app") {
 		t.Fatalf("the fetch must run with --use-db app so the server attributes the session.\nline: %s", fetchLine)
 	}
-	if !strings.Contains(fetchLine, "SELECT CONNECTION_ID() AS id;") {
-		t.Fatalf("the fetch statement must print its own connection id first.\nline: %s", fetchLine)
-	}
-	// The server-side gate sits between the id and the CALL in the SAME batch:
-	// this session takes the database's lock (timeout 0) or the batch stops
-	// before the CALL is sent (verified on Dolt 2.1.10).
+	// The server-side gate is the id: this session takes the database's lock
+	// and this run's lock (timeout 0) and prints its own connection id in the
+	// same statement, or the batch stops before the CALL is sent (verified on
+	// Dolt 2.1.10).
 	assertGateBeforeCall(t, fetchLine, "app", "CALL DOLT_FETCH(")
 }
 
@@ -1094,24 +1100,30 @@ func assertGuardedKill(t *testing.T, log, id string) {
 	}
 }
 
-// assertGateBeforeCall pins the batch shape `… CONNECTION_ID() … GET_LOCK('gc_remote_op:<db>', 0) … CALL …`.
+// assertGateBeforeCall pins the batch shape `… GET_LOCK('gc_remote_op:<db>', 0) … CONNECTION_ID() … AS id; CALL …`.
 func assertGateBeforeCall(t *testing.T, line, db, call string) {
 	t.Helper()
 	// The COMPLETE gate expression is the spec (codex r9: a check on the
 	// GET_LOCK substring alone accepted `>= 0`, which lets the CALL through
 	// while another session holds the lock): the lock name lowercased on the
 	// server (`app` and `APP` are one database and must be one lock), timeout
-	// 0, this run's own lock (`gc_remote_op_run:<db>:<pid>-<epoch>`), the
-	// `= 1` tests, the 1 branch, and the marked JSON error branch. The CALL's
-	// FIRST ARGUMENT re-proves that the session still holds the same run lock
-	// (codex r12: a pooled client that reconnected between the gate and the
-	// CALL would otherwise fetch on a lockless session).
-	gateRe := regexp.MustCompile(regexp.QuoteMeta("SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('"+db+"')), 0) = 1 AND GET_LOCK('gc_remote_op_run:"+db+":") + runNonceRe + regexp.QuoteMeta("', 0) = 1, 1, JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS gate;"))
+	// 0, this run's own lock (`gc_remote_op_run:<db>:<16 hex>`), the `= 1`
+	// tests, CONNECTION_ID() as the true branch — the gate statement IS the
+	// id the KILL targets, so the recorded id held the locks by construction
+	// (the mayor's gate r1: a separate id statement before the gate recorded
+	// a session that a reconnect could leave lockless) — and the marked JSON
+	// error branch. The CALL's FIRST ARGUMENT re-proves that the session
+	// still holds the same run lock (codex r12: a pooled client that
+	// reconnected between the gate and the CALL would otherwise fetch on a
+	// lockless session).
+	gateRe := regexp.MustCompile(regexp.QuoteMeta("SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('"+db+"')), 0) = 1 AND GET_LOCK('gc_remote_op_run:"+db+":") + runNonceRe + regexp.QuoteMeta("', 0) = 1, CONNECTION_ID(), JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS id;"))
 	callRe := regexp.MustCompile(regexp.QuoteMeta(call+"IF(IS_USED_LOCK('gc_remote_op_run:"+db+":") + runNonceRe + regexp.QuoteMeta("') = CONNECTION_ID(), '") + `[^']+` + regexp.QuoteMeta("', JSON_EXTRACT('gc-remote-op-lost', '$')), "))
 	gateM, callM := gateRe.FindStringSubmatchIndex(line), callRe.FindStringSubmatchIndex(line)
-	idAt := strings.Index(line, "SELECT CONNECTION_ID() AS id;")
-	if idAt < 0 || gateM == nil || callM == nil || idAt >= gateM[0] || gateM[0] >= callM[0] {
-		t.Fatalf("the batch must be id, then the complete gate %s, then the CALL whose first argument is the ownership check %s.\nline: %s", gateRe, callRe, line)
+	if strings.Contains(line, "SELECT CONNECTION_ID()") {
+		t.Fatalf("no standalone SELECT CONNECTION_ID() may precede the gate: the id is the gate statement's own answer.\nline: %s", line)
+	}
+	if gateM == nil || callM == nil || gateM[0] >= callM[0] {
+		t.Fatalf("the batch must be the complete gate returning the id %s, then the CALL whose first argument is the ownership check %s.\nline: %s", gateRe, callRe, line)
 	}
 	if line[gateM[2]:gateM[3]] != line[callM[2]:callM[3]] {
 		t.Fatalf("the CALL must re-check the SAME run lock the gate took (%q vs %q).\nline: %s", line[gateM[2]:gateM[3]], line[callM[2]:callM[3]], line)
@@ -1167,6 +1179,7 @@ func TestSyncFetchClientExit137StillKillsServerSideSession(t *testing.T) {
 		"    exit 0 ;;\n" +
 		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n91\\n' ; exit 137 ;;\n" +
 		"  *\"KILL \"*) k=$(printf '%s' \"$*\" | sed -n 's/.*KILL \\([0-9][0-9]*\\).*/\\1/p') ; : > \"" + killedPrefix + "${k}\" ; exit 0 ;;\n" +
+		fakeDoltRunLockFreeArm +
 		"esac\nexit 0\n"
 	installFFFakeDolt(t, binDir, body)
 	out := runFFSync(t, binDir, "--db", "app")
@@ -1237,6 +1250,7 @@ func TestSyncFetchTimeoutOutranksFirstPushText(t *testing.T) {
 			"    exit 0 ;;\n" +
 			"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n93\\n' ; printf '" + tc.text + "\\n' >&2 ; exit " + fmt.Sprint(tc.code) + " ;;\n" +
 			"  *\"KILL \"*) k=$(printf '%s' \"$*\" | sed -n 's/.*KILL \\([0-9][0-9]*\\).*/\\1/p') ; : > \"" + killedPrefix + "${k}\" ; exit 0 ;;\n" +
+			fakeDoltRunLockFreeArm +
 			"esac\nexit 0\n"
 		installFFFakeDolt(t, binDir, body)
 		out := runFFSyncFails(t, binDir, "--db", "app")
@@ -1250,5 +1264,190 @@ func TestSyncFetchTimeoutOutranksFirstPushText(t *testing.T) {
 		if guardedKillAt(t, log, "93") < 0 || !strings.Contains(out, "server-side fetch killed (session 93 no longer in flight)") {
 			t.Fatalf("exit %d with %q: the recorded session must be KILLed.\nout:\n%s\nlog:\n%s", tc.code, tc.text, out, log)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gp-f2yq round 2 (the mayor's codex gate r1): the session id the bound's
+// KILL targets comes from the SAME statement that takes the two locks, and the
+// kill helper never returns 0 while any session holds this run's lock.
+// ---------------------------------------------------------------------------
+
+// The gate statement is the id: `SELECT IF(GET_LOCK(db) = 1 AND GET_LOCK(run)
+// = 1, CONNECTION_ID(), <marked error>) AS id` is the FIRST statement after
+// USE, and no standalone `SELECT CONNECTION_ID()` precedes it — a pooled
+// client that reconnected between a separate id statement and the gate would
+// otherwise record an id that never held the locks, and the timeout path
+// would report "already ended" while the reconnected session fetched on with
+// both locks (the mayor's codex gate r1 on 1b4b4964d).
+func TestSyncFetchIDIsTheGateStatement(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltClassify(t, binDir, 1, 0)
+	out := runFFSync(t, binDir, "--db", "app")
+	line := fetchLineOf(t, readLog(t, logPath), "CALL DOLT_FETCH(")
+	if line == "" {
+		t.Fatalf("no fetch issued.\nout:\n%s", out)
+	}
+	assertIDIsTheGate(t, line, "app", "CALL DOLT_FETCH(")
+}
+
+// fetchLineOf returns the first fake-dolt log line carrying call, or "".
+func fetchLineOf(t *testing.T, log, call string) string {
+	t.Helper()
+	for _, line := range strings.Split(log, "\n") {
+		if strings.Contains(line, call) {
+			return line
+		}
+	}
+	return ""
+}
+
+// assertIDIsTheGate pins the round-2 batch shape: `USE \`<db>\`; <the complete
+// gate returning CONNECTION_ID() AS id>; CALL …` with NO standalone
+// `SELECT CONNECTION_ID()` anywhere in the batch. The id and the locks are one
+// statement, so the recorded id is the lock holder by construction.
+func assertIDIsTheGate(t *testing.T, line, db, call string) {
+	t.Helper()
+	if strings.Contains(line, "SELECT CONNECTION_ID()") {
+		t.Fatalf("no standalone SELECT CONNECTION_ID() may precede the gate: the id must come from the gate statement itself.\nline: %s", line)
+	}
+	gateRe := regexp.MustCompile(regexp.QuoteMeta("USE `"+db+"`; SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('"+db+"')), 0) = 1 AND GET_LOCK('gc_remote_op_run:"+db+":") + runNonceRe + regexp.QuoteMeta("', 0) = 1, CONNECTION_ID(), JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS id; "+call))
+	if !gateRe.MatchString(line) {
+		t.Fatalf("the batch must be USE, then the gate returning CONNECTION_ID() AS id when both locks are taken, then the CALL: %s\nline: %s", gateRe, line)
+	}
+}
+
+// killHelperEnv runs kill_remote_op_session alone (runtime.sh sourced, the
+// fake dolt in binDir first on PATH, this run's nonce fixed) and returns the
+// helper's stderr and exit code — the return code IS the rule under test.
+func runKillHelper(t *testing.T, binDir, label, db, id string) (string, int) {
+	t.Helper()
+	root := repoRoot(t)
+	cmd := exec.Command("sh", "-c", `. "$GC_PACK_DIR/assets/scripts/runtime.sh"; REMOTE_OP_RUN_NONCE=0123456789abcdef; kill_remote_op_session "$1" "$2" "$3"`, "sh", label, db, id)
+	cmd.Env = append(filteredEnv("PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_CITY_PATH", "GC_PACK_DIR"),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+t.TempDir(),
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_PORT=1",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	rc := 0
+	if err != nil {
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) {
+			t.Fatalf("kill helper: %v\n%s", err, out)
+		}
+		rc = ee.ExitCode()
+	}
+	return string(out), rc
+}
+
+// writeKillHelperFakeDolt installs a fake dolt for the helper alone: the
+// processlist answered by processlistArm, every KILL batch by killArm, the
+// run-lock holder query by holderArm (complete case arm bodies).
+func writeKillHelperFakeDolt(t *testing.T, dir, processlistArm, killArm, holderArm string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"case \"$*\" in\n" +
+		"  *\"information_schema.processlist\"*) " + processlistArm + " ;;\n" +
+		"  *\"KILL \"*) " + killArm + " ;;\n" +
+		"  *\"COALESCE(IS_USED_LOCK(\"*) " + holderArm + " ;;\n" +
+		"esac\nexit 0\n"
+	return installFFFakeDolt(t, dir, body)
+}
+
+// The kill helper's verdict, as a table (the mayor's codex gate r1): the
+// helper reads who holds THIS run's lock after the KILL attempt and never
+// returns 0 while any session holds it — a guarded id that is gone means the
+// session ended on its own ONLY when the lock is free; a live holder other
+// than the recorded id (a record from before the id came from the gate
+// statement, a server that restarted and reused the number) is reported NOT
+// killed, named for the operator, exit 1. The holder answer is parsed
+// strictly (`holder` header, one all-digit row; 0 = free): anything else
+// refuses to confirm, exit 1.
+func TestKillRemoteOpSessionNeverReturnsZeroWhileTheRunLockIsHeld(t *testing.T) {
+	const runLock = "gc_remote_op_run:app:0123456789abcdef"
+	killed := "exit 0"
+	notOwner := "printf 'error on line 1 for query SELECT IF(IS_USED_LOCK(...)) AS own: Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-not-owner\"\\n' >&2 ; exit 1"
+	none := "printf 'Id,Time,db\\n' ; exit 0"
+	listed77 := "printf 'Id,Time,db\\n77,60,app\\n' ; exit 0"
+	holder := func(v string) string { return "printf 'holder\\n" + v + "\\n' ; exit 0" }
+	for _, tc := range []struct {
+		name, id, processlist, kill, holder string
+		wantRC                              int
+		want, never                         string
+	}{
+		{"killed, gone, lock free", "77", none, killed, holder("0"), 0, "app: server-side fetch killed (session 77 no longer in flight)", "NOT killed"},
+		{"guarded, gone, lock free (the server restarted)", "77", none, notOwner, holder("0"), 0, "app: server-side fetch already ended (session 77 is gone; nothing killed)", "NOT killed"},
+		{"guarded, gone, another session holds this run's lock", "77", none, notOwner, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ")", "already ended"},
+		{"killed, gone, another session holds this run's lock", "77", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (" + runLock + ")", "no longer in flight"},
+		{"guarded, still listed", "77", listed77, notOwner, holder("77"), 1, "app: server-side fetch NOT killed: session 77 does not hold this run's lock (" + runLock + ")", "already ended"},
+		{"holder query fails", "77", none, killed, "printf 'holder: boom\\n' >&2 ; exit 1", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
+		{"holder answer is not a holder answer", "77", none, killed, "printf 'nothing here\\n' ; exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
+		{"holder answer is empty", "77", none, killed, "exit 0", 1, "app: server-side fetch kill NOT confirmed: the run-lock holder query failed", "no longer in flight"},
+		{"no id, nothing listed, lock free", "", none, killed, holder("0"), 0, "app: server-side fetch already ended (nothing in flight to kill)", "NOT killed"},
+		{"no id, nothing listed, a session holds this run's lock", "", none, killed, holder("91"), 1, "app: server-side fetch NOT killed: this client never learned its session id, and session 91 holds this run's lock (" + runLock + ")", "already ended"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			logPath := writeKillHelperFakeDolt(t, binDir, tc.processlist, tc.kill, tc.holder)
+			out, rc := runKillHelper(t, binDir, "fetch", "app", tc.id)
+			if rc != tc.wantRC {
+				t.Fatalf("exit %d, want %d.\nout:\n%s", rc, tc.wantRC, out)
+			}
+			if !strings.Contains(out, tc.want) || strings.Contains(out, tc.never) {
+				t.Fatalf("expected %q and never %q.\nout:\n%s", tc.want, tc.never, out)
+			}
+			log := readLog(t, logPath)
+			holderQ := "SELECT COALESCE(IS_USED_LOCK('" + runLock + "'), 0) AS holder\n"
+			holderAt := strings.Index(log, holderQ)
+			if holderAt < 0 {
+				t.Fatalf("the helper must ask who holds this run's lock with exactly %q.\nlog:\n%s", strings.TrimSpace(holderQ), log)
+			}
+			if tc.id != "" {
+				// The helper alone issues no gate, so the complete guarded batch is
+				// spelled out with the fixed nonce (guardedKillAt reads it from a
+				// gate line).
+				batch := "PREPARE gc_kill FROM 'KILL " + tc.id + "'; SELECT IF(IS_USED_LOCK('" + runLock + "') = " + tc.id + ", 1, JSON_EXTRACT('gc-remote-op-not-owner', '$')) AS own; EXECUTE gc_kill; DEALLOCATE PREPARE gc_kill\n"
+				if killAt := strings.Index(log, batch); killAt < 0 || holderAt < killAt {
+					t.Fatalf("the complete guarded KILL batch must run, and the holder is read AFTER it.\nlog:\n%s", log)
+				}
+			}
+			if tc.id == "" && strings.Contains(log, "KILL ") {
+				t.Fatalf("without an id nothing may be KILLed.\nlog:\n%s", log)
+			}
+		})
+	}
+}
+
+// The runner path of the same rule: the fetch's recorded id is gone (the KILL
+// batch stopped at its guard) but a live session other than the recorded id
+// holds this run's lock — the reconnected client's session, fetching on with
+// both locks. The run must say NOT killed, name that session, and never
+// "already ended" (RED on 1b4b4964d, which printed already ended).
+func TestSyncFetchTimeoutKillRefusesWhenAnotherSessionHoldsTheRunLock(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "dolt.log")
+	started := filepath.Join(binDir, "fetch-started")
+	body := fakeDoltPreamble(logPath, "main") +
+		"  *\"information_schema.processlist\"*) printf 'Id,Time,db\\n' ; exit 0 ;;\n" +
+		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n77\\n' ; printf 'context deadline exceeded\\n' >&2 ; exit 124 ;;\n" +
+		"  *\"KILL \"*) printf 'error on line 1 for query SELECT IF(IS_USED_LOCK(...)) AS own: Error 3141 (HY000): Invalid JSON text in argument 1 to function json_extract: \"gc-remote-op-not-owner\"\\n' >&2 ; exit 1 ;;\n" +
+		"  *\"COALESCE(IS_USED_LOCK(\"*) printf 'holder\\n91\\n' ; exit 0 ;;\n" +
+		"esac\nexit 0\n"
+	installFFFakeDolt(t, binDir, body)
+	out := runFFSyncFails(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if pushed(log) {
+		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
+	}
+	assertGuardedKill(t, log, "77")
+	want := "app: server-side fetch NOT killed: session 77 is gone but session 91 holds this run's lock (gc_remote_op_run:app:"
+	if !strings.Contains(out, want) || strings.Contains(out, "already ended") || strings.Contains(out, "no longer in flight") {
+		t.Fatalf("expected %q and never an ended/killed line.\nout:\n%s", want, out)
 	}
 }

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -13,6 +13,7 @@ package dolt_test
 // and an absent remote ref yields "branch not found: remotes/...".
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -20,20 +21,20 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
-// runFFSyncEnv sets up a one-DB ("app") SQL-mode city with the fake dolt
-// already installed in binDir, runs `gc dolt sync <args>` with extraEnv
-// appended after the base sync env (so an override such as
-// GC_DOLT_REMOTE_<DB> takes effect), and returns combined output plus the
-// command's error so callers that must assert the sync itself did not fail
-// (as opposed to merely producing unexpected output) can do so.
-func runFFSyncEnv(t *testing.T, binDir string, extraEnv []string, args ...string) (string, error) {
+// ffSyncCmd builds a `gc dolt sync` invocation against an idle reachable
+// server with the fake dolt in binDir first on PATH. The per-database runner
+// lock gets a private root. Later `env` entries override earlier ones (Go
+// keeps the last value of a duplicated key), so a test can pin the port and
+// the lock root two runners must share.
+func ffSyncCmd(t *testing.T, binDir string, env []string, args ...string) *exec.Cmd {
 	t.Helper()
 	root := repoRoot(t)
 	script := filepath.Join(root, syncScript)
 	port, cleanup := startReachableTCPListener(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "data")
@@ -43,7 +44,7 @@ func runFFSyncEnv(t *testing.T, binDir string, extraEnv []string, args ...string
 	writeSyncFakeBeadsBD(t, cityPath)
 
 	cmd := exec.Command("sh", append([]string{script}, args...)...)
-	cmd.Env = append(syncFilteredEnv(),
+	cmd.Env = append(append(syncFilteredEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		"GC_CITY_PATH="+cityPath,
 		"GC_PACK_DIR="+root,
@@ -51,9 +52,18 @@ func runFFSyncEnv(t *testing.T, binDir string, extraEnv []string, args ...string
 		fmt.Sprintf("GC_DOLT_PORT=%d", port),
 		"GC_DOLT_USER=root",
 		"GC_DOLT_PASSWORD=",
-	)
-	cmd.Env = append(cmd.Env, extraEnv...)
-	out, err := cmd.CombinedOutput()
+		"GC_DOLT_REMOTE_OP_LOCK_ROOT="+t.TempDir(),
+	), env...)
+	return cmd
+}
+
+// runFFSyncEnv runs `gc dolt sync <args>` through ffSyncCmd with extraEnv
+// appended after the base sync env (so an override such as GC_DOLT_REMOTE_<DB>
+// takes effect), and returns combined output plus the command's error so
+// callers that must assert the sync itself did not fail can do so.
+func runFFSyncEnv(t *testing.T, binDir string, extraEnv []string, args ...string) (string, error) {
+	t.Helper()
+	out, err := ffSyncCmd(t, binDir, extraEnv, args...).CombinedOutput()
 	return string(out), err
 }
 
@@ -64,6 +74,26 @@ func runFFSync(t *testing.T, binDir string, args ...string) string {
 	t.Helper()
 	out, _ := runFFSyncEnv(t, binDir, nil, args...)
 	return out
+}
+
+// waitForFile polls until path exists (the fake dolt's "I am mid-operation"
+// marker) or the deadline passes.
+func waitForFile(t *testing.T, path string, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("%s did not appear within %s", path, within)
+}
+
+// remoteOpLockDir is the lock directory the scripts use for host 127.0.0.1,
+// the given port and database under lockRoot (remote_op_lock_dir, runtime.sh).
+func remoteOpLockDir(lockRoot string, port int, db string) string {
+	return filepath.Join(lockRoot, fmt.Sprintf("127.0.0.1-%d-%s.lock", port, db))
 }
 
 // fakeDoltHeader is the shared preamble for an IDLE server: log argv, answer
@@ -634,6 +664,12 @@ func TestSyncFetchInFlightSkipsNeverFetches(t *testing.T) {
 	if !strings.Contains(log, "db = 'app'") {
 		t.Fatalf("the single-flight check must be scoped to this database.\nlog:\n%s", log)
 	}
+	// The predicate is a REGEXP on the statement text (whitespace, comments,
+	// case), not a LIKE prefix: `CALL  DOLT_FETCH`, `/* x */ CALL DOLT_PULL(`
+	// and `call dolt_fetch(` are all in flight (verified on Dolt 2.1.10).
+	if !strings.Contains(log, "UPPER(Info) REGEXP '") || !strings.Contains(log, `CALL\\s+DOLT_(FETCH|PULL)\\s*\\(`) {
+		t.Fatalf("the in-flight predicate must be the REGEXP on UPPER(Info).\nlog:\n%s", log)
+	}
 }
 
 // An in-flight DOLT_FETCH with no database attribution (an older gc dolt sync
@@ -775,5 +811,128 @@ func TestSyncFetchIsAttributedAndSelfIdentifying(t *testing.T) {
 	}
 	if !strings.Contains(fetchLine, "SELECT CONNECTION_ID() AS id;") {
 		t.Fatalf("the fetch statement must print its own connection id first.\nline: %s", fetchLine)
+	}
+}
+
+// A processlist answer with a row that is not `digits,digits,…` (a NULL Time,
+// a truncated line) is a session whose state is unknown: the whole answer is
+// refused and the fetch skipped, fail closed — never "nothing in flight".
+func TestSyncProcesslistMalformedRowSkips(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n42,NULL,app\\n' ; exit 0")
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if fetched(log) || pushed(log) {
+		t.Fatalf("a malformed processlist row must skip without fetching or pushing.\nout:\n%s\nlog:\n%s", out, log)
+	}
+	if !strings.Contains(out, "processlist query failed") || !strings.Contains(out, "malformed processlist row") {
+		t.Fatalf("expected the malformed-row skip line.\nout:\n%s", out)
+	}
+}
+
+// GNU timeout escalates to SIGKILL after --kill-after and then exits 137, not
+// 124. The client is just as dead and the server-side fetch just as alive: the
+// recorded session must still be KILLed.
+func TestSyncFetchClientExit137StillKillsServerSideSession(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "dolt.log")
+	started := filepath.Join(binDir, "fetch-started")
+	killed := filepath.Join(binDir, "killed")
+	body := fakeDoltPreamble(logPath, "main") +
+		"  *\"information_schema.processlist\"*)\n" +
+		"    if [ -f \"" + killed + "\" ]; then printf 'Id,Time,db\\n'\n" +
+		"    elif [ -f \"" + started + "\" ]; then printf 'Id,Time,db\\n91,70,app\\n'\n" +
+		"    else printf 'Id,Time,db\\n'; fi\n" +
+		"    exit 0 ;;\n" +
+		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; printf 'id\\n91\\n' ; exit 137 ;;\n" +
+		"  *\"KILL \"*) : > \"" + killed + "\" ; exit 0 ;;\n" +
+		"esac\nexit 0\n"
+	installFFFakeDolt(t, binDir, body)
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if pushed(log) {
+		t.Fatalf("exit 137 must NEVER push.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "fetch timed out") || !strings.Contains(out, "client exit 137") {
+		t.Fatalf("exit 137 is the bound's SIGKILL escalation and must be reported as a timeout.\nout:\n%s", out)
+	}
+	if !strings.Contains(log, "KILL 91") || !strings.Contains(out, "server-side fetch killed (session 91 no longer in flight)") {
+		t.Fatalf("the recorded session must be KILLed after exit 137.\nout:\n%s\nlog:\n%s", out, log)
+	}
+}
+
+// Two runners on this host: the second must not read "nothing in flight" and
+// fetch while the first is mid-fetch. The runner lock is held from before the
+// processlist check until the operation is done, so exactly one CALL is issued
+// and the second run says who holds the lock.
+func TestSyncRunnerLockSerializesConcurrentRunners(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "dolt.log")
+	started := filepath.Join(binDir, "fetch-started")
+	release := filepath.Join(binDir, "fetch-release")
+	body := fakeDoltHeader(logPath, "main") +
+		"  *\"CALL DOLT_FETCH(\"*) : > \"" + started + "\" ; while [ ! -f \"" + release + "\" ]; do sleep 0.1; done ; exit 0 ;;\n" +
+		"  *\"dolt_log(\"*) printf 'n\\n0\\n' ; exit 0 ;;\n" +
+		"esac\nexit 0\n"
+	installFFFakeDolt(t, binDir, body)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+	shared := []string{fmt.Sprintf("GC_DOLT_PORT=%d", port), "GC_DOLT_REMOTE_OP_LOCK_ROOT=" + t.TempDir()}
+
+	first := ffSyncCmd(t, binDir, shared, "--db", "app")
+	var firstOut bytes.Buffer
+	first.Stdout, first.Stderr = &firstOut, &firstOut
+	if err := first.Start(); err != nil {
+		t.Fatalf("start first runner: %v", err)
+	}
+	waitForFile(t, started, 10*time.Second)
+	secondOut, secondErr := ffSyncCmd(t, binDir, shared, "--db", "app").CombinedOutput()
+	if err := os.WriteFile(release, nil, 0o644); err != nil {
+		t.Fatalf("release the first fetch: %v", err)
+	}
+	if err := first.Wait(); err != nil {
+		t.Fatalf("first runner failed: %v\n%s", err, firstOut.String())
+	}
+	log := readLog(t, logPath)
+	if n := strings.Count(log, "CALL DOLT_FETCH("); n != 1 {
+		t.Fatalf("exactly one fetch may be in flight per database; got %d.\nlog:\n%s\nsecond:\n%s", n, log, secondOut)
+	}
+	if secondErr == nil {
+		t.Fatalf("the second runner must exit non-zero (skipped).\nout:\n%s", secondOut)
+	}
+	want := fmt.Sprintf("app: another gc dolt sync/pull (pid %d) holds this database's runner lock — skipped (NOT pushed)", first.Process.Pid)
+	if !strings.Contains(string(secondOut), want) {
+		t.Fatalf("expected %q\nout:\n%s", want, secondOut)
+	}
+	if pushed(log) {
+		t.Fatalf("neither runner may push here (0 ahead).\nlog:\n%s", log)
+	}
+}
+
+// A lock whose holder died (pid gone) is stale: the next runner reclaims it,
+// runs, and leaves no lock behind.
+func TestSyncStaleRunnerLockIsReclaimed(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltClassify(t, binDir, 1, 0)
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+	lockRoot := t.TempDir()
+	dir := remoteOpLockDir(lockRoot, port, "app")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir stale lock: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pid"), []byte("4194305\n"), 0o600); err != nil {
+		t.Fatalf("write stale pid: %v", err)
+	}
+	out, err := ffSyncCmd(t, binDir, []string{fmt.Sprintf("GC_DOLT_PORT=%d", port), "GC_DOLT_REMOTE_OP_LOCK_ROOT=" + lockRoot}, "--db", "app").CombinedOutput()
+	if err != nil {
+		t.Fatalf("a stale lock (holder gone) must be reclaimed and the sync run: %v\n%s", err, out)
+	}
+	log := readLog(t, logPath)
+	if !fetched(log) || !pushed(log) {
+		t.Fatalf("reclaimed lock: fetch and push must run.\nout:\n%s\nlog:\n%s", out, log)
+	}
+	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+		t.Fatalf("the lock must be released after the run (stat err = %v)", statErr)
 	}
 }

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -780,6 +780,47 @@ func TestSyncFetchTimeoutKillNotConfirmedReportsStillInFlight(t *testing.T) {
 	}
 }
 
+// The configured fetch bound is what the fetch runs under, proven by the
+// recorded gtimeout arguments (codex r7 found the pull side unproven; the sync
+// side had the same gap): a script that hardcoded the default would fail this.
+func TestSyncFetchBoundReachesTheFetch(t *testing.T) {
+	binDir := t.TempDir()
+	tlogPath := writeRecordingGtimeout(t, binDir)
+	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "77", []string{"77,60,app"}, false)
+	outB, _ := ffSyncCmd(t, binDir, []string{"GC_DOLT_SYNC_FETCH_TIMEOUT_SECS=9"}, "--db", "app").CombinedOutput()
+	out := string(outB)
+	if !strings.Contains(out, "app: fetch timed out after 9s") {
+		t.Fatalf("expected the timeout line naming the configured bound.\nout:\n%s", out)
+	}
+	if !strings.Contains(readLog(t, logPath), "KILL 77") {
+		t.Fatalf("KILL must be issued.\nout:\n%s", out)
+	}
+	assertBounded(t, readLog(t, tlogPath), "9", "CALL DOLT_FETCH(")
+}
+
+// The verdict after KILL is a processlist read too: an answer with a malformed
+// row (here a fourth column, which an earlier parser dropped as "another
+// database" — codex r7) must refuse to confirm the kill, never report the
+// session gone.
+func TestSyncFetchTimeoutKillVerdictRefusesMalformedAnswer(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := writeSyncFakeDoltFetchTimeoutKill(t, binDir, "77", []string{"77,60,app,extra"}, true)
+	out := runFFSync(t, binDir, "--db", "app")
+	log := readLog(t, logPath)
+	if pushed(log) {
+		t.Fatalf("a fetch timeout must NEVER push.\nout:\n%s", out)
+	}
+	if !strings.Contains(log, "KILL 77") {
+		t.Fatalf("KILL must be issued.\nlog:\n%s", log)
+	}
+	if strings.Contains(out, "no longer in flight") {
+		t.Fatalf("a malformed processlist answer after KILL must not confirm the kill.\nout:\n%s", out)
+	}
+	if !strings.Contains(out, "kill NOT confirmed: the processlist query failed after KILL") || !strings.Contains(out, "malformed processlist row") {
+		t.Fatalf("expected the kill-not-confirmed line with the malformed-row reason.\nout:\n%s", out)
+	}
+}
+
 // No connection id captured (the client died before the server answered):
 // nothing is KILLed. Absence from the earlier processlist read does not prove
 // that a session listed now is ours (an operator's unattributed pull for
@@ -864,12 +905,16 @@ func assertGateBeforeCall(t *testing.T, line, db, call string) {
 // refused and the fetch skipped, fail closed — never "nothing in flight".
 func TestSyncProcesslistMalformedRowSkips(t *testing.T) {
 	for _, row := range []string{
-		`42,NULL,app`,    // a NULL Time
-		`"12,34",60,app`, // a quoted field that field-splitting would read as Id 12, Time 34
-		`"4""2",60,app`,  // a quoted, escaped Id
-		`42`,             // a truncated line
-		`abc,60,app`,     // a non-numeric Id
-		` 42,60,app`,     // leading whitespace
+		`42,NULL,app`,     // a NULL Time
+		`"12,34",60,app`,  // a quoted field that field-splitting would read as Id 12, Time 34
+		`"4""2",60,app`,   // a quoted, escaped Id
+		`42`,              // a truncated line
+		`abc,60,app`,      // a non-numeric Id
+		` 42,60,app`,      // leading whitespace
+		`42,60,app,extra`, // an extra column: the db field is not ONE CSV field (codex r7 — was read as "another database" and dropped)
+		`42,60,"app`,      // an unterminated quote
+		`42,60,ap"p`,      // a stray quote in an unquoted field
+		`42,60,"app"x`,    // text after the closing quote
 	} {
 		binDir := t.TempDir()
 		logPath := writeSyncFakeDoltProcesslist(t, binDir, "printf 'Id,Time,db\\n"+strings.ReplaceAll(row, `"`, `\"`)+"\\n' ; exit 0")

--- a/examples/bd/dolt/sync_ffclassify_test.go
+++ b/examples/bd/dolt/sync_ffclassify_test.go
@@ -641,12 +641,12 @@ func TestSyncFetchInFlightSkipsNeverFetches(t *testing.T) {
 	if !strings.Contains(log, "LOWER(db) = LOWER('app')") {
 		t.Fatalf("the single-flight check must be scoped to this database, case-insensitively.\nlog:\n%s", log)
 	}
-	// The predicate is a REGEXP on the statement text (whitespace, comments,
-	// case, backticks, a db qualifier), not a LIKE prefix: `CALL  DOLT_FETCH`,
-	// `/* x */ CALL DOLT_PULL(`, `call dolt_fetch(`, `CALL \`dolt_fetch\`(` and
-	// `CALL app.DOLT_FETCH(` are all in flight (verified on Dolt 2.1.10).
-	if !strings.Contains(log, "UPPER(Info) REGEXP '") || !strings.Contains(log, "`?DOLT_(FETCH|PULL)`?") {
-		t.Fatalf("the in-flight predicate must be the REGEXP on UPPER(Info).\nlog:\n%s", log)
+	// The predicate is the whole-identifier token test on the statement text,
+	// not a LIKE prefix and not a grammar of spellings: any statement naming
+	// DOLT_FETCH or DOLT_PULL counts — bare `CALL DOLT_FETCH`, `CALL\`dolt_fetch\`()`,
+	// comments, qualifiers, any case (verified on Dolt 2.1.10, evidence 04f).
+	if !strings.Contains(log, "UPPER(Info) REGEXP '(^|[^A-Z0-9_])DOLT_(FETCH|PULL)([^A-Z0-9_]|$)'") {
+		t.Fatalf("the in-flight predicate must be the whole-identifier REGEXP on UPPER(Info).\nlog:\n%s", log)
 	}
 }
 

--- a/examples/bd/dolt/sync_test.go
+++ b/examples/bd/dolt/sync_test.go
@@ -94,6 +94,10 @@ func writeSyncFakeDolt(t *testing.T, dir string) string {
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    exit 0
+    ;;
   *"SELECT name, url FROM dolt_remotes"*)
     printf 'name,url\norigin,file:///example.invalid/repo\n'
     ;;
@@ -121,6 +125,10 @@ func writeSyncFakeDoltActiveBranch(t *testing.T, dir, activeBranch string) strin
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    exit 0
+    ;;
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,file:///example.invalid/repo\n'
     ;;
@@ -151,6 +159,10 @@ func writeSyncFakeDoltInvalidActiveBranch(t *testing.T, dir string) string {
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    exit 0
+    ;;
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,file:///example.invalid/repo\n'
     ;;
@@ -183,6 +195,10 @@ func writeSyncFakeDoltRemoteLookupFailure(t *testing.T, dir string) string {
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    exit 0
+    ;;
   *"SELECT name, url FROM dolt_remotes"*)
     printf 'sql lookup failed\n' >&2
     exit 7
@@ -216,6 +232,10 @@ func writeSyncFakeDoltPushFails(t *testing.T, dir string, exitCode int, stderr s
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    exit 0
+    ;;
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,file:///example.invalid/repo\n'
     exit 0
@@ -258,6 +278,10 @@ func writeSyncFakeDoltPushFailsNoTrailingNewline(t *testing.T, dir string, exitC
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    exit 0
+    ;;
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,file:///example.invalid/repo\n'
     exit 0
@@ -298,6 +322,10 @@ func writeSyncFakeDoltCLIPushFails(t *testing.T, dir string, exitCode int) {
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    exit 0
+    ;;
   *"push "*)
     printf 'remote rejected push\n' >&2
     exit ` + strconv.Itoa(exitCode) + `
@@ -349,6 +377,10 @@ func writeSyncFakeDoltPushEchoesArgs(t *testing.T, dir string) {
 	body := `#!/bin/sh
 printf '%s\n' "$*" >> "` + logPath + `"
 case "$*" in
+  *"information_schema.processlist"*)
+    printf 'Id,Time,db\n'
+    exit 0
+    ;;
   *"SELECT name, url FROM dolt_remotes ORDER BY name"*)
     printf 'name,url\norigin,file:///example.invalid/repo\n'
     exit 0


### PR DESCRIPTION
----
> **DRAFT — upstream twin of aphexcx/gascity `fix/gp-f2yq-dolt-fetch-single-flight` (https://github.com/aphexcx/gascity/pull/16).** Cherry-picks of the fork's sixteen round-1 commits onto `main` 48d68d13a plus one twin-only test fixup (1b2e8adeb) = round-1 head 7b0bf958e; round 2 (bead gp-anyw) adds the fork's six round-2 commits cherry-picked in order, **head eab7fd72b** (= fork 162b59eb4; the *Round 2* section below); round 3 (bead gp-rm5v) re-cuts the same commits onto upstream `main` 1b991d75c, no conflict, **head 0fadded86** (the fork's round-3 head is 00871edae: its one reconciliation commit is fork-only; the *Round 3* section below).

## What broke

A `CALL DOLT_FETCH` / `CALL DOLT_PULL` issued through the dolt CLI runs **inside the sql-server**. `gc dolt sync` bounds the *client* (`run_bounded`, exit 124 after `GC_DOLT_SYNC_FETCH_TIMEOUT_SECS`, default 60 s) and moves on with "fetch timed out … skipped (NOT pushed)". The server-side procedure keeps running. Nothing asked the server whether a fetch for the database was already in flight before issuing another, so the 15-minute `dolt-remotes-patrol` stacked one more per run. Boomtown measured it on 2026-09-11 (their bead hq-v5paz): 169 of 178 sql-server connections in `CALL DOLT_FETCH('origin','main')`, ages 19 s to 2.0 days, 28 git children, dolt at 114–180 % CPU, `hw`'s `.beads/last_pull` from 2026-07-07 — their sync had effectively not run for two months. They disabled the order by hand and `KILL`ed the 169 sessions (CPU 180 → 26 % within minutes). Citadel does not reproduce it (local bare-repo hub); jadegate fetches the same hub over the tailnet and can.

## The fix

**One rule, shared by sync, pull and health** (`examples/bd/dolt/assets/scripts/runtime.sh`, "Server-side remote operations"):

- **The single-flight operand is the server's own session lock, re-proven inside the statements that act.** The fetch / pull batch is `USE db; SELECT CONNECTION_ID() AS id; SELECT IF(GET_LOCK(CONCAT('gc_remote_op:', LOWER('db')), 0) = 1 AND GET_LOCK('gc_remote_op_run:db:<16 random hex>', 0) = 1, 1, JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS gate; CALL DOLT_FETCH|DOLT_PULL(IF(IS_USED_LOCK('gc_remote_op_run:db:<nonce>') = CONNECTION_ID(), '<remote>', JSON_EXTRACT('gc-remote-op-lost', '$')), …)`, run with `--use-db db`. Both locks are session-scoped and released only when the session ends (the CALL finished and the client left, or `KILL`); when another session holds the database lock the `IF`'s else branch raises Error 3141 and the CLI stops the batch there, so the CALL is never sent ("already in flight — the server refused a second one, skipped (NOT pushed)"). Dolt evaluates expressions in CALL arguments, so a client that reconnected between the gate and the CALL fails with `gc-remote-op-lost` before the procedure runs instead of fetching on a lockless session. The run nonce is 64 random bits; without random bytes the script refuses to run before any database is touched. Verified on a real Dolt 2.1.10 (evidence 04c, 04i, 04j).
- `remote_op_sessions DB TIMEOUT ERRFILE` is the informative pre-check and the health count: the live `information_schema.processlist` sessions whose `Info` names `DOLT_FETCH` or `DOLT_PULL` as a whole identifier (`UPPER(Info) REGEXP '(^|[^A-Z0-9_])DOLT_(FETCH|PULL)([^A-Z0-9_]|$)'` — a token test, not a grammar of CALL spellings; over-inclusive by design, fail closed), **server-wide**: the processlist `DB` column is the connection's `--use-db`, not the statement's target (a client on `--use-db other` running `USE app; CALL DOLT_FETCH` is attributed to `other`), so no per-database filter is applied to it — every in-flight remote operation on the server blocks every database's run for that pass (one skipped run for a database while another's operation runs; the pack's own runs are serialized by the locks anyway). The query text is **constant** (no database name in it), so no store name can make it match itself. The answer must start with exactly the `Id,Time,db` header and every row must be `digits,digits,<one CSV field>`: anything else is **not** a processlist answer and is a failure. Fail closed on every non-zero return.
- The CLI prints each statement's result before running the next, so the session's own id is on disk before the procedure starts and survives the client's death; `--use-db` fills the processlist `DB` column (a `USE` inside the query does not).
- `kill_remote_op_session LABEL DB ID` ends the recorded session on the bound's expiry (exit 124, or 137 when GNU timeout escalated to SIGKILL) with ONE batch — `PREPARE gc_kill FROM 'KILL <id>'; SELECT IF(IS_USED_LOCK('<run lock>') = <id>, 1, JSON_EXTRACT('gc-remote-op-not-owner', '$')) AS own; EXECUTE gc_kill; DEALLOCATE PREPARE gc_kill` — so the KILL runs only while the id still holds THIS run's lock (a restarted server that handed the number to someone else is never asked to kill them; KILL takes only a literal, so the check cannot sit inside it, and the session-local prepared handle closes the window between the check and the KILL: a client that reconnected in between has no handle to execute), and **proves it ended** with a processlist read after (Dolt 2.1.10 answers `KILL` of any id, gone or not, with exit 0 and no text — KILL's exit code proves nothing). A session still listed is reported as NOT killed, or as not ours when the guard stopped the batch. With no captured id (the client died before the server answered) **nothing is killed**: ownership of a listed session cannot be proven, the in-flight sessions are named for the operator, and the abandoned session keeps the database's lock so every later run is refused by the gate until it ends or is killed by hand; health names it.

**sync** (`commands/sync/run.sh`, `sync_database_sql`): before `CALL DOLT_FETCH`, the single-flight check — one in flight anywhere on the server prints `<db>: fetch already in flight for <N>s (session <Id>) — skipped (NOT pushed)`, returns 1, issues no fetch. A processlist query that fails prints the error with dolt's stderr replayed and skips the same way. On exit 124/137 the recorded session is `KILL`ed and the outcome reported on its own line (`server-side fetch killed (session N no longer in flight)` / `NOT killed (… still in flight after KILL)` / `already ended`); the bound's verdict outranks any text the dying client printed. **The push path, the fast-forward classification, the refspec resolution and the CLI fallback are untouched**, and so is the order (`orders/dolt-remotes-patrol.toml`): a run that finds a fetch in flight returns at once.

**pull** (`commands/pull/run.sh`, `pull_database_sql`): the same two guards around `CALL DOLT_PULL`, and its own bound **`GC_DOLT_PULL_TIMEOUT_SECS`** (default 120 s, the prior fixed ceiling) validated the way the sync bounds are (empty / non-numeric / all-zero → exit 2 before any database is touched), named in the header and `--help`.

**health** (`commands/health/run.sh`): one read-only, server-wide probe under the same 5 s bound as the other probes. **`WARN: N server-side DOLT_FETCH/DOLT_PULL sessions in flight (oldest …, more than M)`** when the count is *more than* **`GC_DOLT_HEALTH_MAX_FETCH_SESSIONS`** (default 2, same validation). The JSON report carries `fetch_sessions: {probed, count, oldest_age_sec, warn_above, warn}` (schema updated) so `gc dolt health-check` can fail on it if the pack chooses; a failed probe is `probed=false, count=0`, never a fabricated zero. Informational — never the exit code.

**Judgment calls vs the bead text.** (0) The bead's per-database scope for the pre-check became server-wide (round 9): the processlist `DB` column is the connection's, not the statement's, so filtering on it let an operator's fetch through; the cost is one skipped pass for a database while another's remote operation runs. (1) The bead asked to "record the count before the fetch so the new one is the one to kill; prefer the youngest". A count is an operand the adversary can move (a concurrent runner or an operator between the two reads). The session's own `CONNECTION_ID()`, printed by the statement about itself, cannot be moved; with no id, nothing is killed. (2) The bead's single-flight was a processlist read; two reads race, so the correctness operand became the server lock (round 2 → 3) and the processlist read is the status line and the health count. (3) "Info starts with CALL DOLT_FETCH" became a whole-identifier token test after five rounds of valid spellings the grammar missed (round 5).

## Contract, probed on a real Dolt 2.1.10 sql-server (throwaway, evidence 04–04k2)

- Client under a 3 s bound running `SELECT CONNECTION_ID() AS id; SELECT SLEEP(120)` with `--use-db probe`: client exit 124, stdout `id / 2`.
- Processlist after the client died: `2,3,probe,SELECT SLEEP(120)` — the server-side statement lives on, attributed to the database.
- `KILL 99999` (no such id): exit 0, no text. `KILL 2`: exit 0, no text. Processlist after: header only.
- The same statement with `USE probe;` inside and no `--use-db`: `db` column empty.
- A second session's batch ends at the `GET_LOCK` gate with Error 3141 and its CALL never runs; the abandoned session keeps the lock; `IS_USED_LOCK` names it; after `KILL` the gate passes (04c).
- The token predicate: 15 spellings hit (bare `CALL DOLT_FETCH`, `` CALL`dolt_fetch`() ``, tab/newline/comment separators, backticked and qualified names, any case), 6 decoys miss (`DOLT_PUSH`, `DOLT_FETCHX`, `CALLDOLT_FETCH`, `dolt_fetch_log`, `my_dolt_fetch`, `SELECT SLEEP`), the pre-check query does not match itself (04f).
- A store named `dolt_fetch`: the previous query (with `LOWER('dolt_fetch')` in it) listed itself; the constant query does not (04g 1b–1d). `PREPARE s FROM 'CALL DOLT_FETCH()'; EXECUTE s` shows `Info = EXECUTE s`; a wrapper procedure shows `CALL fetch_wrapper()`; neither holds the pack lock (04g 2a–2d).
- `--use-db probe/main` attributes the session as `probe/main`, a commit hash as `probe/<hash>`; a `USE` inside the batch does not change the column; a slash is refused in a database name (04h).
- Dolt evaluates expressions in CALL arguments; a guarded CALL without the run lock raises Error 3141 before the fetch, with it the fetch runs; the exact runtime strings behave the same (04i, 04j). KILL takes only a literal; the prepared-handle batch kills on the true path, stops at the guard on the false path, and a fresh session has no handle to EXECUTE (04k, 04k2).

## Tests (fake dolt; `examples/bd/dolt`, `go test ./...` — green on every fork head, last 54 (478bc14cd, 295 s; the census refactor after it: sync/pull tests 56 s + the census test) and every twin head, last 55 (8f9d6440b, 328 s; then 7b0bf958e's sync/pull tests 191 s + census); each round's new tests RED on the previous head and GREEN after, with mutation proofs where a test could pass on a broken script — evidence 19/22/22b/27/31/31b/35/35b/39/39b/43/49/49b/52/53)

sync (`sync_ffclassify_test.go`): the in-flight cases (skip, other database counts too, case, revision-qualified, unattributed), the processlist failure / header-less / malformed-row / malformed-header cases, the timeout-kill cases (kill proven, kill not confirmed, kill verdict on a malformed answer, kill guarded by the run lock, no id kills nothing, exit 137, the bound outranks first-push text, the configured bound reaches the fetch), the gate-refused and lost-run-lock cases, the marker-collision case, the self-identifying batch (complete gate + ownership argument with one nonce), and the no-nonce refusal. pull (`pull_test.go`): the same in-flight, processlist-failure, timeout-kill, gate, lost-lock, marker-collision and bound cases, and the invalid-bound rejection. health (`health_test.go`): the fetch_sessions block, WARN above the threshold, silence below, the override, invalid thresholds, probe failure. health (`health_test.go`): `TestHealthScriptReportsFetchSessionsInJSON`, `…BelowThresholdDoesNotWarn`, `…WarnLineHumanMode`, `…ThresholdOverride`, `TestHealthScriptRejectsInvalidFetchSessionsThreshold`, `…ProbeFailureIsReported`. Existing fakes gain an idle processlist arm (`Id,Time,db` header, no rows). The `fetched` / pull detectors match `CALL DOLT_FETCH(` / `CALL DOLT_PULL(`, not the bare procedure name the processlist query's LIKE pattern also carries (that false positive was the RED→GREEN gap on the first run). Red-before-implementation log in evidence 02; the round-6 tests RED against the round-5 head in evidence 19.

`shellcheck -s sh` on the four scripts: no new findings (every warning is on a pre-existing line).

## Docs

`examples/bd/dolt/docs/remote-sync-single-flight.md` (the rule, the kill on expiry, the health line, the env bounds) plus a pointer in `docs/troubleshooting/dolt-bloat-recovery.md`.

## Roll

The dolt pack on each city is the `gc import` cache copy; the fix reaches a city with its next `gc import` refresh plus `gc roll`, each in its own window (boomtown's two-step path; their `[[orders.overrides]]` disable lifts on their side when this ships). Leftover sessions from runs older than this guard need one manual `KILL <Id>` each — the health line names them.

## Evidence

`/Users/tailor512/city/assets/pr-evidence/gp-f2yq/` — `00-README.md` indexes all 96 files: the baseline, every round's RED / GREEN / mutation logs, the full package suite on every fork and twin head, the eleven real-dolt probes (04–04k2, scripts + transcripts), and the fifteen codex rulings (07–07o).

## Review

Codex (gpt-6-astra, read-only sandbox, adversarial prompt naming every prior round's findings), seven rounds:

| round | head | verdict | what it found → what changed |
|---|---|---|---|
| 1 | bdf05bdb5 | BLOCK 5 | check/CALL race → per-db runner lock; CALL spellings → REGEXP; exit 137 → `bound_expired`; malformed rows → whole answer refused; leading zeros → canonical |
| 2 | a2568e89a | BLOCK 4 | runner lock racy / TMPDIR-keyed → **replaced by the server's `GET_LOCK` gate in the CALL's own batch**; `/***/` comments; health `mktemp` under `set -e` |
| 3 | 2372c57db | BLOCK 4 | lock name case → `LOWER` on the server; backticked/qualified names; no-id fallback could kill a foreign session → **kills nothing without a proven id**; CSV quoting |
| 4 | 035813d70 | BLOCK 2 | first-push stderr text outranked the timeout → bound first; hyphenated qualifier, `#` comment |
| 5 | c078329f4 | BLOCK 1 | `CALL DOLT_FETCH` (no parens), `` CALL`dolt_fetch`() `` → **the grammar is gone; whole-identifier token test** |
| 6 | b2e11858c | BLOCK 2 | #1 a store named `dolt_fetch` made the query match itself → **constant query text**; #2 indirect execution (`EXECUTE s`, wrapper procedure) invisible → the documented limit (below) |
| 7 | 3fb972f9c | BLOCK 2 | a four-column row read as "another database" → the db column must be ONE CSV field; the pull bound never proven → recording `gtimeout` |
| 8 | a5248d51d | BLOCK 2 | `--use-db app/main` attribution; the gate marker echoed in an ordinary error → Error 3141 + quoted marker |
| 9 | 697043646 | BLOCK 2 | **attribution is not proof of the target** (`--use-db other; USE app; CALL …`) → no per-database filter at all; the gate assertion pins the complete expression |
| 10 | 93a872d29 | BLOCK 2 minor | exact KILL id; every failure path asserts a non-zero exit |
| 11 | d7fd88452 | BLOCK 2 minor | the header is exactly three fields; pull's processlist-failure tests |
| 12 | a825cd518 | BLOCK 2 | reconnect between gate and CALL; restart reuses the id → **a per-run lock; the CALL's argument and the KILL batch re-prove ownership** |
| 13 | e663787e1 / f669b62f2 | BLOCK 3 | reconnect inside the KILL batch → **PREPARE / guard / EXECUTE**; pid-epoch nonce → 64 random bits; the guard pin |
| 14 | 8773b2c5b | BLOCK 2 | the silent nonce fallback → no random bytes, no run; the complete SELECT pin |
| 15 | 478bc14cd | **CLEAN** | — |
| — | 1b4b4964d | (test-only) | the sync/pull test runners share one `exec.Command` site so the repository's resource census stays at its baseline; no script changed |

**Documented limit (round 6 #2, unchanged since).** A fetch an operator runs indirectly — `PREPARE s FROM 'CALL DOLT_FETCH()'; EXECUTE s` (Info `EXECUTE s`), a stored procedure wrapping the call (Info `CALL fetch_wrapper()`), an event — is invisible to the processlist text, to the pre-check line and to the health count, and holds no pack lock (reproduced, evidence 04g). No text predicate can see it. The only wider predicates (any `EXECUTE`; any `CALL` naming no `DOLT_` procedure) either bring back a grammar the reviewer can keep moving (a comment naming `DOLT_COMMIT` inside the wrapper call defeats the exclusion) or make sync skip whenever bd is inside a `CALL DOLT_COMMIT` — the beads store's every write. The pack's own runs never need that visibility (the server locks serialize them) and the herd's shape was direct CALLs. Stated as a limit in `runtime.sh` and the docs page; rounds 7–15 judged it and did not re-report it. Afik's call whether that stands.

## Twin-only hunks

The conflict resolutions keep upstream's pull remote-selection policy (`GC_DOLT_REMOTE_<DB>`, `GC_DOLT_PULL_ALLOW_REMOTE_<DB>`) next to the new bound and guards. Upstream's pull remote-selection fakes (`pull_remote_selection_test.go`) and `writeSyncFakeDolt` gain the idle processlist arm — an answer without the `Id,Time,db` header is fail-closed by design, so a fake that answers nothing would now skip the pull. `runPull` opts in with `GC_DOLT_PULL_ALLOW_REMOTE_APP=1` because its fake remote is `https://`. Full package suite on every twin head: green (last: evidence 55, 8f9d6440b, 328 s; 7b0bf958e adds the test-only census refactor, its sync/pull tests and the census test green). Twin-only: upstream's `pull_remote_selection_test.go` and `TestPullUsesLiveSQLWhenManagedServerReachable` pinned `CALL DOLT_PULL('<remote>', 'main')` literally; they now pin the ownership-checked first argument with the same remote name — the selection policy is untouched.

## Round 2 (bead gp-anyw): the id the KILL targets comes from the statement that takes the locks

**The mayor's codex gate r1 on 1b4b4964d — BLOCK 1 MAJOR, verbatim:** "Reconnect before lock acquisition leaves timed-out operations running. sync/run.sh:447 and pull/run.sh:179 record `CONNECTION_ID()` before acquiring the locks. If the pooled client reconnects between those statements, the new session acquires both locks and runs the operation, but timeout cleanup targets the old ID. Cleanup then reports "already ended" while the actual operation remains running, blocking subsequent sync/pull runs server-wide. An in-memory simulation confirmed this false-success path. Return the ID from the lock-acquisition statement and cover reconnects before the gate."

**The fix (b57419b3b; then 420893d52, bedb4513a, 3efd8970d, 8f61945c6 for codex round-2 r1–r4):**

- `remote_op_gate_sql` answers with the session's own `CONNECTION_ID()` in the SAME statement that takes the two locks: `SELECT IF(GET_LOCK(db, 0) = 1 AND GET_LOCK(run, 0) = 1, CONNECTION_ID(), JSON_EXTRACT('gc-remote-op-lock-held', '$')) AS id`. The id and the locks are one statement, so the recorded id is the lock holder by construction. Both runners' batches are `USE db; <gate>; CALL …`; the standalone `SELECT CONNECTION_ID() AS id` is gone. `remote_op_session_id` still reads the `id` column.
- `kill_remote_op_session` reads, after the KILL attempt and the processlist read, who holds THIS run's lock — `SELECT COALESCE(IS_USED_LOCK(run lock), 0) AS holder` (`remote_op_run_lock_holder`, strict parse: the `holder` header and exactly one all-digit row; 0 = free) — and **never returns 0 while any session holds it**. A gone id is "already ended" / "killed" only when the lock is free; the recorded id still holding the lock while not listed as a remote operation (the bound expired between the gate and the CALL) is NOT killed, named; a live holder other than the recorded id is NOT killed, named for the operator; an unreadable holder answer refuses to confirm. **The no-id path never confirms a cleanup** (codex round-2 r3): with the id inside the gate, no id no longer proves the gate never ran — a gate still pending on the server takes this run's lock after any "free" read, and a session lock cannot fence it — so nothing listed + lock free is "cleanup NOT confirmed", return 1, nothing killed. Every one of those paths returns 1.
- Docs: `remote-sync-single-flight.md` describes the one-statement shape and the holder read.

**Tests (RED on 1b4b4964d — evidence 58; every round's rows RED on the previous head — 62, 66, 70, 74; GREEN — 59/63/67/71/75, full package suite on every fork head, last 79 (162b59eb4), and every twin head, last 80):** `assertGateBeforeCall` pins the gate's `CONNECTION_ID()` true branch and refuses any standalone `SELECT CONNECTION_ID()`; `TestSyncFetchIDIsTheGateStatement` / `TestPullIDIsTheGateStatement` pin `USE; gate; CALL` adjacency; `TestKillRemoteOpSessionNeverReturnsZeroWhileTheRunLockIsHeld` is the helper's return-code table (twelve rows, the helper run alone through a wrapper script against a fake dolt: killed/guarded × gone/listed/not-listed × lock free/held by the id/held by another, the three unreadable-holder answers, and the two no-id rows — both exit 1); `TestSyncFetchTimeoutKillRefusesWhenAnotherSessionHoldsTheRunLock` and `TestPullTimeoutKillRefusesWhenAnotherSessionHoldsTheRunLock` are the runner paths. Fixture change, stated: every fake dolt whose KILL arm is reached now answers the holder query with 0 (`fakeDoltRunLockFreeArm`, `writePullFakeDolt`'s default) — the helper refuses to confirm without that answer, so the fixtures must say "free" to keep testing what they tested.

**Real Dolt 2.1.10 (evidence 04l, throwaway server):** the gate prints `id` / N; `IS_USED_LOCK` names N (`remote_op_run_lock_holder` → N, equal); a second session's gate raises 3141 with no id row; the helper with a stale id returns 1 naming the live holder; with the recorded id returns 0 (killed, gone); the free lock prints 0; the helper again returns 0 (already ended).

**Codex, round 2 (evidence 07p–07t):** r1 on b57419b3b — 0 MAJOR 1 MINOR (the fold blamed the recorded id when it was itself the holder while not listed; return code already 1) → 420893d52; r2 — 0 MAJOR 1 MINOR (the no-id line promised health names an idle holder) → bedb4513a; r3 — **1 MAJOR** (a gate still pending can take the run lock after the no-id path's "free" read: the path printed already ended and returned 0) 1 MINOR (the different-holder line's health promise) → 3efd8970d; r4 — 0 MAJOR 1 MINOR (health reports counts and ages, never ids: no line may promise it names a session) → 8f61945c6; r5 on 8f61945c6 — **CLEAN** ("the gate records its lock holder, and cleanup refuses confirmation for held or unreadable locks and every no-ID path"; 1,215 simulated cleanup cases across dash/bash/zsh). 162b59eb4 after it is test-only: the kill-helper table test runs through `packScriptCmd` so the repository's resource census stays at its baseline (evidence 78), the 1b4b4964d precedent.

**Open design call for Afik (not a defect, codex r4/r5 agreed it is a boundary):** the no-id path finds a holder of this run's lock only through the nonce, which nobody else knows — that session is ours by construction and could be KILLed with the same guarded batch. This round leaves it for the operator (the no-id path kills nothing, round 1's rule). Extending the guarded KILL to the nonce holder is a one-line change if wanted.

**Twin, round 2:** the five round-2 commits cherry-picked in order (b57419b3b, 420893d52, bedb4513a, 3efd8970d, 8f61945c6, 162b59eb4 → twin head eab7fd72b), no conflicts; the census and the full package suite green on every twin head (evidence 61, 65, 69, 73, 77, 80). The whole-repo pre-push suite ran on the fork head 162b59eb4 (evidence 82: `examples/bd/dolt` 263 s green; one `cmd/gc` detached-probe deadline test failed under load and passes alone 3/3, evidence 82a/82b; `cmd/gc` is outside this diff), so this branch too was pushed with the hook bypassed on that evidence, the round-1 precedent.

## Round 3 (bead gp-rm5v): the twin re-cut from upstream `main`

The fork PR aphexcx/gascity#16 was rebased onto the fork's `integration` after aphexcx/gascity#13 landed there (gp-c04p part B: `gc dolt pull` resolves `row_lock`/`updated_at`-only conflicts in bd `issues` inside one fail-closed transaction; both PRs edit `examples/bd/dolt/commands/pull/run.sh`, one content conflict). Upstream `main` (1b991d75c) has no #13 — its twin, gastownhall/gascity#6252, is a draft — so this branch was rebased onto upstream `main` without conflict: the round-2 commits replay unchanged (twin head 0fadded86), and the fork's one round-3 commit (00871edae: #13's conflict-resolving retry of the pull runs behind the same gate, bound and KILL as the first pull) is fork-only, because there is no retry here to gate. When #6252 lands upstream, that commit is the reconciliation to cherry-pick. Both PRs touch 12 files (this one's twelfth is upstream's pre-existing `pull_remote_selection_test.go`; the fork's is #13's `pull_conflicts_test.go`). Twin head 0fadded86: build, vet, the dolt pack suite — 355 tests + 92 subtests, 0 FAIL, 183 s (round3/19, 19a). No conflict markers (evidence round3/16). Codex round 3 reviewed the fork head (round3/18): r1 on 00871edae — 0 MAJOR 0 MINOR, **VERDICT: CLEAN** ("both sides' behavior is preserved; the resolving retry uses the gate, ownership-checked argument, database attribution, configured bound, and guarded timeout cleanup; failure ordering, stderr parsing, temp-file cleanup, and per-database variable resets are consistent; CLI behavior matches integration; by inspection both new failure tests distinguish the mechanical union").

Bead: gp-f2yq (round 2: gp-anyw; round 3: gp-rm5v)
Codex-Reviewed-By: gpt-6-astra (codex 0.153.4) on the fork branch: round 1 rounds 1–15 (r15 CLEAN on fork 478bc14cd); the mayor's gate r1 BLOCK 1 MAJOR on fork 1b4b4964d; round 2 rounds 1–5, r5 CLEAN on fork 8f61945c6 (= twin 6a2d5cda1; head eab7fd72b adds a test-only census fix); round 3 r1 CLEAN on fork 00871edae (the rebase + reconciliation; this twin = the same commits minus the fork-only reconciliation)
Fable-Reviewed-By: Claude Fable 5.1 — the citadel mayor's read-only read of fork 162b59eb4 (round 2) CLEAN, 0 MAJOR, 2 MINOR; pending on the round-3 heads
Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


