### PR TITLE
fix(test): pass the trace callback at the six releaseOrphanedPoolAssignments call sites #6265 added (ga-b84w3)

### DIFF
--- a/cmd/gc/pool_session_name_route_assignee_liveness_test.go
+++ b/cmd/gc/pool_session_name_route_assignee_liveness_test.go
@@ -60,6 +60,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeSkippedWhenSessionLive(t
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 0 {
@@ -85,6 +86,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeReleasedWhenNoLiveSessio
 		"",
 		nil,
 		[]beads.Bead{work},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -125,6 +127,7 @@ func TestReleaseOrphanedPoolAssignments_DeadNamedAssigneeReleasedDespiteLiveTemp
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 1 || released[0].ID != work.ID {
@@ -156,6 +159,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeReleasedWhenOnlyNamedSes
 		"",
 		openSessions,
 		[]beads.Bead{work},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -211,6 +215,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeSkippedWhenSessionLiveIn
 		[]string{"repo"}, // store-ref aware: the work lives in the agent's own rig
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 0 {
@@ -241,6 +246,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeReleasedWhenLiveSessionS
 		[]beads.Bead{work},
 		nil,
 		[]string{"other-repo"}, // store-ref aware: the work lives outside the agent's rig
+		nil,
 		nil,
 		nil,
 	)


### PR DESCRIPTION
## What

Pass `nil` as the trailing `recordPhase` argument at the six `releaseOrphanedPoolAssignments` call sites in `cmd/gc/pool_session_name_route_assignee_liveness_test.go`. Test-only; the production build was never affected.

## Why main is red

Two PRs interleaved:

- #6265 (30ed29b976, merged 2026-09-11T14:46Z) added the test file with ten-argument calls.
- #6261 (3d268c5849, merged 15:34Z, reviewed against an older base) added the eleventh parameter `func(TraceSiteCode, string, time.Time, map[string]any)` and updated the call sites it could see, including `split_topology_conformance_test.go`, but never saw #6265's file.

Since 15:34Z `go vet ./cmd/gc/...` and every cmd/gc test shard fail to type-check at lines 62, 91, 127, 162, 213 and 245 (`not enough arguments in call to releaseOrphanedPoolAssignments`). Same shape as ga-7hyp6 (#5544 vs #6216).

Found by the pre-push fast lane while rebasing #5634 onto main; that PR touches neither file. Bead: ga-b84w3.

## Verification

- `go vet ./cmd/gc/` clean on this branch.
- `go test ./cmd/gc -run TestReleaseOrphanedPoolAssignments -count=1` passes (package compiles again).
- Pre-push fast lane (six cmd/gc unit shards plus core) passed on push.

Pre-push note: the first push attempt was refused by an unrelated fast-lane flake, TestGoTestShardManifestFailsClosed/invalid_regex_syntax hitting ETXTBSY on its fake go binary (filed ga-ln9ct); the test passes alone and the retried push ran the whole fast lane green.
