### PR TITLE
fix(cmd/gc): restore the cmd/gc test build after two merged signature changes

### DIFF
--- a/cmd/gc/pool_session_name_route_assignee_liveness_test.go
+++ b/cmd/gc/pool_session_name_route_assignee_liveness_test.go
@@ -60,6 +60,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeSkippedWhenSessionLive(t
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 0 {
@@ -85,6 +86,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeReleasedWhenNoLiveSessio
 		"",
 		nil,
 		[]beads.Bead{work},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -125,6 +127,7 @@ func TestReleaseOrphanedPoolAssignments_DeadNamedAssigneeReleasedDespiteLiveTemp
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 1 || released[0].ID != work.ID {
@@ -156,6 +159,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeReleasedWhenOnlyNamedSes
 		"",
 		openSessions,
 		[]beads.Bead{work},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -211,6 +215,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeSkippedWhenSessionLiveIn
 		[]string{"repo"}, // store-ref aware: the work lives in the agent's own rig
 		nil,
 		nil,
+		nil,
 	)
 
 	if len(released) != 0 {
@@ -241,6 +246,7 @@ func TestReleaseOrphanedPoolAssignments_TemplateAssigneeReleasedWhenLiveSessionS
 		[]beads.Bead{work},
 		nil,
 		[]string{"other-repo"}, // store-ref aware: the work lives outside the agent's rig
+		nil,
 		nil,
 		nil,
 	)


### PR DESCRIPTION
## Problem

The `cmd/gc` test binary does not compile on `main`. At 411413b105:

```
$ go vet ./cmd/gc/
vet: cmd/gc/pool_session_name_route_assignee_liveness_test.go:63:2: not enough
arguments in call to releaseOrphanedPoolAssignments
```

A test binary that fails to build fails nothing a reader will notice. The package
reports `[build failed]`, and every test in `cmd/gc` stops running, including the
reconciler tests that guard the paths the two changes below touch.

## Cause

Two changes that are each correct against their own base, merged within an hour of
each other:

- #6261 added a `recordPhase` argument to `releaseOrphanedPoolAssignments` so the
  reconciler can trace its release sweep.
- #6265 added `cmd/gc/pool_session_name_route_assignee_liveness_test.go`, whose six
  calls were written against the previous ten-argument signature.

Neither pull request saw the other's tree, and no per-change gate sees a merge
result. `AGENTS.md` describes this shape: one change alters a signature, the other
adds a caller against the older base.

## Fix

Each of the six calls passes the trailing argument as `nil`. That is what every other
test call site in the package passes, and `releaseOrphanedPoolAssignments` already
guards the parameter with `if recordPhase != nil` before recording. No test behavior
changes, and no production code is touched.

## Test plan

- `go build ./...` clean.
- `go vet ./...` clean, against a failure on `main` before the change.
- `go test ./cmd/gc -count=1` green.
- The six tests that could not run are running again:
  `TestReleaseOrphanedPoolAssignments_TemplateAssigneeSkippedWhenSessionLive`,
  `_TemplateAssigneeReleasedWhenNoLiveSession`,
  `_DeadNamedAssigneeReleasedDespiteLiveTemplateSession`,
  `_TemplateAssigneeReleasedWhenOnlyNamedSessionLive`,
  `_TemplateAssigneeSkippedWhenSessionLiveInSameStoreScope`,
  `_TemplateAssigneeReleasedWhenLiveSessionServesAnotherStore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcPXz8AxpyCCoDcK7Bu5W
