### PR TITLE
ci: enforce complete ci-required job coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1620,6 +1620,8 @@ jobs:
       - cmd-gc-process
       - cmd-gc-productmetrics-testhook
       - credential-provider-windows
+      - preflight-unit-cover-noncmdgc
+      - preflight-unit-cover-cmdgc
       - worker-core-summary
       - worker-core-phase2-summary
       - pack-gate
@@ -1643,6 +1645,8 @@ jobs:
               "cmd-gc-process",
               "cmd-gc-productmetrics-testhook",
               "credential-provider-windows",
+              "preflight-unit-cover-noncmdgc",
+              "preflight-unit-cover-cmdgc",
               "pack-gate",
               "docker-session",
               "k8s-session",

--- a/release-gates/ga-rcy5fd-ci-required-coverage-invariant-gate.md
+++ b/release-gates/ga-rcy5fd-ci-required-coverage-invariant-gate.md
@@ -3,7 +3,7 @@
 - Deploy bead: `ga-rcy5fd`
 - Review bead: `ga-9sqq1b`
 - Reviewed commit: `ad8bb5128cb5db3b229902a3e14369aae3a9c3c8`
-- Base: `origin/main@411413b1055d660a1d8cb7beac98d5f5f4cd7216`
+- Current base: `origin/main@21eca31d1c18e57e3bf83a968d64fd80db589ba5`
 - Isolated branch: `deploy/ga-rcy5fd-gate`
 - Gate state: **HOLD** — local evidence is complete, but the CI-config change has not yet received its first real GitHub Actions run.
 
@@ -14,7 +14,7 @@
 | 3 | Tests pass | **HOLD** | Full local suite and policy evidence passes after attribution, with every diff-owned test green. Criterion 3c remains undecidable until the modified CI graph completes its first real PR run; see details below. |
 | 4 | No unresolved HIGH review findings | PASS | Reviewer recorded no blockers or high-severity findings. One grammar nit was explicitly non-blocking. |
 | 5 | Final branch clean | PASS | Candidate was clean at the reviewed SHA before branch creation; `git diff --check origin/main...HEAD` and changed-file formatting both pass. |
-| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main ad8bb5128cb5db3b229902a3e14369aae3a9c3c8` exited 0 and produced tree `74122220a30bc724d14d55bd7a59b0839e04e010`; no self-rebase was needed. |
+| 6 | Branch diverges cleanly from main | PASS | Re-evaluated after main advanced: `git merge-tree --write-tree origin/main ad8bb5128cb5db3b229902a3e14369aae3a9c3c8` exited 0 and produced tree `fa0b8659a0ef47869cb32eb28c5a9d7eeab818e8`; no self-rebase was needed. |
 | 7 | Single feature theme | PASS | One commit changes only the required-CI reachability graph, its invariant test, and the tamper-evident execution hash. |
 
 ## Criterion 2: acceptance evidence
@@ -38,14 +38,14 @@ Environment: rootless Podman 5.8.4 via `DOCKER_HOST=unix:///run/user/1000/podman
 - Fresh package verification: `go test ./scripts/... -count=1 -v` PASS (199 top-level PASS, 0 FAIL, 0 SKIP); `go vet ./scripts/...` PASS.
 - Build/static verification: `go build ./...` PASS; changed-file formatting PASS; `git diff --check origin/main...HEAD` PASS.
 - Policy lane: `make test-ci-policy` PASS (5 runner-policy Python tests, 15 CI-suite-coverage Python tests, `scripts/cipolicy`, `scripts/prwatchdog`, and the documented static-scope Go checks).
-- Full `go vet ./...` raw FAIL is the same pre-existing `cmd/gc` compile condition tracked by `ga-q2jkyr`; the exact condition independently reproduces on current `origin/main`.
+- Full `go vet ./...` raw FAIL was the same pre-existing `cmd/gc` compile condition tracked by `ga-q2jkyr`; the exact condition independently reproduced on then-current `origin/main@411413b1055d660a1d8cb7beac98d5f5f4cd7216`. Main subsequently advanced to `21eca31d1c18e57e3bf83a968d64fd80db589ba5` with that repair, so the synchronized PR run is the current-merge-ref verification.
 - `waiver_ref: none` — the failures below are attributed under the non-diff-owned failure protocol, not waived.
 
 ### Failure attribution
 
 All trackers predate this run, all failing tests are outside the three changed paths, and the proofs below are landed rather than inconclusive:
 
-- `cmd/gc` compile failure in six `cmd-gc-process` shards, `productmetrics-testhook`, six `integration-packages-cmd-gc` shards, and `go vet ./...` -> `ga-q2jkyr`. Proof: current `origin/main@411413b1055d660a1d8cb7beac98d5f5f4cd7216` independently reproduces the same `releaseOrphanedPoolAssignments` argument-count mismatch. No path overlap.
+- `cmd/gc` compile failure in six `cmd-gc-process` shards, `productmetrics-testhook`, six `integration-packages-cmd-gc` shards, and `go vet ./...` -> `ga-q2jkyr`. Proof: then-current `origin/main@411413b1055d660a1d8cb7beac98d5f5f4cd7216` independently reproduced the same `releaseOrphanedPoolAssignments` argument-count mismatch. No path overlap.
 - `TestReaperWorkflowRootCleanupRealDoltSemantics` -> `ga-cp7r41`. Proof: external `dolt init` was killed during fixture setup before the scenario ran. The CI-policy-only diff cannot affect that process. No path overlap.
 - `TestAdoptPRFormulaCompileAndRun`, `TestPersonalWorkFormulaCompileAndRun`, `TestGCLiveContract_BeadsAndEvents`, and `TestGraphWorkflowFailureRunsCleanup` -> `ga-esyijp`. Proof: external `bd init` refused pending shared-server schema migrations before any formula/live-contract behavior. The diff has no schema/bootstrap path. No path overlap.
 - `TestE2E_SuspendResume_City` -> `ga-dc9utn`. Proof: exact proven `citysus.report` timeout; the root cause is in the reconciler suspend/wake path, which this diff does not touch. No path overlap.
@@ -56,4 +56,4 @@ Tracker sightings were appended and read back for this run. Because each attribu
 
 `ci_lane_run: not-yet-run`
 
-This diff modifies `.github/workflows/ci.yml` and the `ci-required` dependency list. GitHub Actions has no run for reviewed commit `ad8bb5128cb5db3b229902a3e14369aae3a9c3c8`, so the green meta-tests cannot close criterion 3c. An isolated draft PR will be opened only to obtain the first real execution of `preflight-unit-cover-noncmdgc`, the six-shard `preflight-unit-cover-cmdgc` matrix, and the resulting `ci-required` roll-up. Do not publish `release-gate/deploy-clearance` or route a merge request while this gate remains HOLD.
+This diff modifies `.github/workflows/ci.yml` and the `ci-required` dependency list. Draft PR #6286's first pull-request run recorded both push-only coverage jobs as expected `skipped`; the modified `ci-required` roll-up has not yet completed. The gate remains HOLD until a synchronized run against current main proves that the roll-up consumes those expected skips and finishes successfully. Do not publish `release-gate/deploy-clearance` or route a merge request while this gate remains HOLD.

--- a/release-gates/ga-rcy5fd-ci-required-coverage-invariant-gate.md
+++ b/release-gates/ga-rcy5fd-ci-required-coverage-invariant-gate.md
@@ -1,0 +1,59 @@
+# Release gate: CI-required coverage invariant
+
+- Deploy bead: `ga-rcy5fd`
+- Review bead: `ga-9sqq1b`
+- Reviewed commit: `ad8bb5128cb5db3b229902a3e14369aae3a9c3c8`
+- Base: `origin/main@411413b1055d660a1d8cb7beac98d5f5f4cd7216`
+- Isolated branch: `deploy/ga-rcy5fd-gate`
+- Gate state: **HOLD** — local evidence is complete, but the CI-config change has not yet received its first real GitHub Actions run.
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `ga-9sqq1b` records `verdict: pass` for the exact reviewed commit. |
+| 2 | Acceptance criteria met | PASS | The workflow now includes `preflight-unit-cover-noncmdgc` and `preflight-unit-cover-cmdgc` in both `ci-required.needs` and `allow_skipped`; `TestCIRequiredCoversEveryRealJob`, `TestCIRequiredSkipsPushOnlyCoverageJobs`, and the CI policy hash checks all pass. |
+| 3 | Tests pass | **HOLD** | Full local suite and policy evidence passes after attribution, with every diff-owned test green. Criterion 3c remains undecidable until the modified CI graph completes its first real PR run; see details below. |
+| 4 | No unresolved HIGH review findings | PASS | Reviewer recorded no blockers or high-severity findings. One grammar nit was explicitly non-blocking. |
+| 5 | Final branch clean | PASS | Candidate was clean at the reviewed SHA before branch creation; `git diff --check origin/main...HEAD` and changed-file formatting both pass. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main ad8bb5128cb5db3b229902a3e14369aae3a9c3c8` exited 0 and produced tree `74122220a30bc724d14d55bd7a59b0839e04e010`; no self-rebase was needed. |
+| 7 | Single feature theme | PASS | One commit changes only the required-CI reachability graph, its invariant test, and the tamper-evident execution hash. |
+
+## Criterion 2: acceptance evidence
+
+- Every real job in `.github/workflows/ci.yml` is reachable from `ci-required`, except the documented advisory jobs `contract-radar-bd-head` and `mcp-mail`: `TestCIRequiredCoversEveryRealJob` PASS.
+- Both push-only coverage jobs are dependencies of `ci-required` and are accepted as skipped on pull requests: `TestCIRequiredSkipsPushOnlyCoverageJobs` PASS.
+- The expected CI execution hash matches the changed dependency graph: `make test-ci-policy` PASS, including `go test -count=1 ./scripts/cipolicy`.
+
+## Criterion 3: test evidence
+
+`test_cmd: make test-local-full-parallel`
+
+`test_cmd_scope: full-suite`
+
+Environment: rootless Podman 5.8.4 via `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`; `TESTCONTAINERS_RYUK_DISABLED=true`. Cached/pulled test images were verified as `dolt-sql-server:1.32.4@sha256:b0400696666ab7f4743e15d28d9e934efebde99794a967fe14b3a3a13bfa0b3d` and `dolt:2.1.7@sha256:eba699ca1821847c2e8070475f8e504b476834ee425db4036f89c956cceaf472`.
+
+- Raw result: 40/40 jobs completed; 21 job-level PASS and 19 job-level FAIL.
+- Top-level test counts across preserved shard logs: 29,917 PASS, 6 FAIL, 101 SKIP.
+- Skip justification: all 101 skips are pre-existing explicit environment/platform/live-provider/golden-regeneration opt-outs. No diff-owned test skipped.
+- `diff_tests_executed`: `TestCIRequiredCoversEveryRealJob` PASS and `TestCIRequiredSkipsPushOnlyCoverageJobs` PASS in both `unit-core` and `integration-packages-core-3-of-4`; 0 diff-owned FAIL, 0 diff-owned SKIP.
+- Fresh package verification: `go test ./scripts/... -count=1 -v` PASS (199 top-level PASS, 0 FAIL, 0 SKIP); `go vet ./scripts/...` PASS.
+- Build/static verification: `go build ./...` PASS; changed-file formatting PASS; `git diff --check origin/main...HEAD` PASS.
+- Policy lane: `make test-ci-policy` PASS (5 runner-policy Python tests, 15 CI-suite-coverage Python tests, `scripts/cipolicy`, `scripts/prwatchdog`, and the documented static-scope Go checks).
+- Full `go vet ./...` raw FAIL is the same pre-existing `cmd/gc` compile condition tracked by `ga-q2jkyr`; the exact condition independently reproduces on current `origin/main`.
+- `waiver_ref: none` — the failures below are attributed under the non-diff-owned failure protocol, not waived.
+
+### Failure attribution
+
+All trackers predate this run, all failing tests are outside the three changed paths, and the proofs below are landed rather than inconclusive:
+
+- `cmd/gc` compile failure in six `cmd-gc-process` shards, `productmetrics-testhook`, six `integration-packages-cmd-gc` shards, and `go vet ./...` -> `ga-q2jkyr`. Proof: current `origin/main@411413b1055d660a1d8cb7beac98d5f5f4cd7216` independently reproduces the same `releaseOrphanedPoolAssignments` argument-count mismatch. No path overlap.
+- `TestReaperWorkflowRootCleanupRealDoltSemantics` -> `ga-cp7r41`. Proof: external `dolt init` was killed during fixture setup before the scenario ran. The CI-policy-only diff cannot affect that process. No path overlap.
+- `TestAdoptPRFormulaCompileAndRun`, `TestPersonalWorkFormulaCompileAndRun`, `TestGCLiveContract_BeadsAndEvents`, and `TestGraphWorkflowFailureRunsCleanup` -> `ga-esyijp`. Proof: external `bd init` refused pending shared-server schema migrations before any formula/live-contract behavior. The diff has no schema/bootstrap path. No path overlap.
+- `TestE2E_SuspendResume_City` -> `ga-dc9utn`. Proof: exact proven `citysus.report` timeout; the root cause is in the reconciler suspend/wake path, which this diff does not touch. No path overlap.
+
+Tracker sightings were appended and read back for this run. Because each attribution has an affirmative mechanism or base-ref proof, the candidate's two small added meta-tests do not invoke the inconclusive added-load guard.
+
+### CI-config lane evidence
+
+`ci_lane_run: not-yet-run`
+
+This diff modifies `.github/workflows/ci.yml` and the `ci-required` dependency list. GitHub Actions has no run for reviewed commit `ad8bb5128cb5db3b229902a3e14369aae3a9c3c8`, so the green meta-tests cannot close criterion 3c. An isolated draft PR will be opened only to obtain the first real execution of `preflight-unit-cover-noncmdgc`, the six-shard `preflight-unit-cover-cmdgc` matrix, and the resulting `ci-required` roll-up. Do not publish `release-gate/deploy-clearance` or route a merge request while this gate remains HOLD.

--- a/release-gates/ga-rcy5fd-ci-required-coverage-invariant-gate.md
+++ b/release-gates/ga-rcy5fd-ci-required-coverage-invariant-gate.md
@@ -5,13 +5,13 @@
 - Reviewed commit: `ad8bb5128cb5db3b229902a3e14369aae3a9c3c8`
 - Current base: `origin/main@21eca31d1c18e57e3bf83a968d64fd80db589ba5`
 - Isolated branch: `deploy/ga-rcy5fd-gate`
-- Gate state: **HOLD** — local evidence is complete, but the CI-config change has not yet received its first real GitHub Actions run.
+- Gate state: **PASS**
 
 | # | Criterion | Result | Evidence |
 |---|---|---|---|
 | 1 | Review PASS present | PASS | `ga-9sqq1b` records `verdict: pass` for the exact reviewed commit. |
 | 2 | Acceptance criteria met | PASS | The workflow now includes `preflight-unit-cover-noncmdgc` and `preflight-unit-cover-cmdgc` in both `ci-required.needs` and `allow_skipped`; `TestCIRequiredCoversEveryRealJob`, `TestCIRequiredSkipsPushOnlyCoverageJobs`, and the CI policy hash checks all pass. |
-| 3 | Tests pass | **HOLD** | Full local suite and policy evidence passes after attribution, with every diff-owned test green. Criterion 3c remains undecidable until the modified CI graph completes its first real PR run; see details below. |
+| 3 | Tests pass | PASS | Full local suite and policy evidence passes after attribution, with every diff-owned test green. The modified CI graph's first current-main PR run also completed successfully; see details below. |
 | 4 | No unresolved HIGH review findings | PASS | Reviewer recorded no blockers or high-severity findings. One grammar nit was explicitly non-blocking. |
 | 5 | Final branch clean | PASS | Candidate was clean at the reviewed SHA before branch creation; `git diff --check origin/main...HEAD` and changed-file formatting both pass. |
 | 6 | Branch diverges cleanly from main | PASS | Re-evaluated after main advanced: `git merge-tree --write-tree origin/main ad8bb5128cb5db3b229902a3e14369aae3a9c3c8` exited 0 and produced tree `fa0b8659a0ef47869cb32eb28c5a9d7eeab818e8`; no self-rebase was needed. |
@@ -54,6 +54,6 @@ Tracker sightings were appended and read back for this run. Because each attribu
 
 ### CI-config lane evidence
 
-`ci_lane_run: not-yet-run`
+`ci_lane_run: https://github.com/gastownhall/gascity/actions/runs/34635169817 — PASS`
 
-This diff modifies `.github/workflows/ci.yml` and the `ci-required` dependency list. Draft PR #6286's first pull-request run recorded both push-only coverage jobs as expected `skipped`; the modified `ci-required` roll-up has not yet completed. The gate remains HOLD until a synchronized run against current main proves that the roll-up consumes those expected skips and finishes successfully. Do not publish `release-gate/deploy-clearance` or route a merge request while this gate remains HOLD.
+This diff modifies `.github/workflows/ci.yml` and the `ci-required` dependency list. Draft PR #6286's synchronized run against current main completed successfully at head `74340bd923780359a1ea70092dc8e50e9118c5ff`. The real graph recorded both push-only coverage jobs as expected `skipped`, then completed [`CI / preflight`](https://github.com/gastownhall/gascity/actions/runs/34635169817/job/103382798382), [`CI / integration`](https://github.com/gastownhall/gascity/actions/runs/34635169817/job/103383151968), and the modified final [`CI / required`](https://github.com/gastownhall/gascity/actions/runs/34635169817/job/103383259962) roll-up with `success`.

--- a/scripts/ci_required_coverage_test.go
+++ b/scripts/ci_required_coverage_test.go
@@ -1,0 +1,129 @@
+package scripts_test
+
+import (
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ciRequiredRoot is the branch-protection status every real CI job must
+// ultimately feed, directly or through an intermediate rollup.
+const ciRequiredRoot = "ci-required"
+
+// ciAggregateJobs summarize a subset of the job graph by reading
+// needs.*.result -- they never run tests themselves, so they are exempt
+// from the coverage requirement below. ci-preflight and ci-integration
+// are ci-required's own intermediate rollups. check is a second,
+// independently branch-protection-enforced rollup kept alive under its
+// historical name (see TestCIPreflightFansInDirectlyWithoutWaitingForHistoricalCheck
+// above, which asserts ci-preflight deliberately does not wait on it) --
+// it mirrors a subset of the same graph rather than adding coverage of
+// its own, so it is exempted the same way as the other aggregators.
+var ciAggregateJobs = map[string]bool{
+	ciRequiredRoot:   true,
+	"ci-preflight":   true,
+	"ci-integration": true,
+	"check":          true,
+}
+
+// ciAdvisoryAllowlist holds real jobs deliberately left out of
+// ci-required's needs closure, each documented in ci.yml itself at the
+// referenced line. Any job in this set must stay unreachable from
+// ci-required -- TestCIRequiredCoversEveryRealJob fails if one becomes
+// reachable, so the allowlist doesn't silently outlive its reason.
+var ciAdvisoryAllowlist = map[string]bool{
+	"contract-radar-bd-head": true, // ci.yml:422 -- a bd-main break must never block a gascity merge
+	"mcp-mail":               true, // ci.yml:1348 -- continue-on-error isolates gascity from upstream mcp_agent_mail API drift
+}
+
+// ciNeedsClosure walks needs: edges from root and returns every job root
+// depends on, directly or transitively, including root itself.
+func ciNeedsClosure(jobs map[string]ciCriticalPathJob, root string) map[string]bool {
+	seen := make(map[string]bool)
+	var visit func(string)
+	visit = func(name string) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		for _, dep := range jobs[name].Needs {
+			visit(dep)
+		}
+	}
+	visit(root)
+	return seen
+}
+
+// TestCIRequiredCoversEveryRealJob guards against a job silently falling
+// out of the merge gate: a job added to ci.yml that neither feeds
+// ci-required (directly or via an intermediate rollup) nor is documented
+// as advisory can stay green in isolation while never actually blocking
+// a broken merge.
+func TestCIRequiredCoversEveryRealJob(t *testing.T) {
+	wf := readCriticalPathWorkflow(t, "ci.yml")
+	if len(wf.Jobs) == 0 {
+		t.Fatal("parsed zero jobs from ci.yml -- parser or path is broken")
+	}
+	if _, ok := wf.Jobs[ciRequiredRoot]; !ok {
+		t.Fatalf("ci.yml has no %q job", ciRequiredRoot)
+	}
+
+	reachable := ciNeedsClosure(wf.Jobs, ciRequiredRoot)
+
+	var uncovered []string
+	for name := range wf.Jobs {
+		if ciAggregateJobs[name] || ciAdvisoryAllowlist[name] {
+			continue
+		}
+		if !reachable[name] {
+			uncovered = append(uncovered, name)
+		}
+	}
+	if len(uncovered) > 0 {
+		sort.Strings(uncovered)
+		t.Fatalf("jobs not reachable from %q's transitive needs: closure and not in ciAdvisoryAllowlist "+
+			"(wire into ci-required's needs, an existing rollup's needs, or document as advisory):\n  %v",
+			ciRequiredRoot, uncovered)
+	}
+
+	var stale []string
+	for name := range ciAdvisoryAllowlist {
+		if _, ok := wf.Jobs[name]; !ok {
+			stale = append(stale, name+" (job no longer exists in ci.yml)")
+			continue
+		}
+		if reachable[name] {
+			stale = append(stale, name+" (now reachable from ci-required; remove from ciAdvisoryAllowlist)")
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		t.Fatalf("ciAdvisoryAllowlist is stale:\n  %v", stale)
+	}
+}
+
+// TestCIRequiredSkipsPushOnlyCoverageJobs documents why the two
+// push-only coverage jobs are allowed to report "skipped" on every pull
+// request without failing ci-required: they are gated
+// `if: github.event_name == 'push'` (ci.yml:270, ci.yml:299) and so never
+// run on a PR by design. Mirrors the allow_skipped assertion style of
+// TestProductMetricsTesthookProfileIsFocusedRequiredAndObservable above.
+func TestCIRequiredSkipsPushOnlyCoverageJobs(t *testing.T) {
+	wf := readCriticalPathWorkflow(t, "ci.yml")
+	required := wf.Jobs[ciRequiredRoot]
+	for _, jobName := range []string{"preflight-unit-cover-noncmdgc", "preflight-unit-cover-cmdgc"} {
+		if !slices.Contains(required.Needs, jobName) {
+			t.Errorf("ci-required needs = %v, want push-only coverage job %q", required.Needs, jobName)
+		}
+		var permitsSkip bool
+		for _, step := range required.Steps {
+			if strings.Contains(step.Run, "allow_skipped") && strings.Contains(step.Run, `"`+jobName+`"`) {
+				permitsSkip = true
+			}
+		}
+		if !permitsSkip {
+			t.Errorf("ci-required must allow push-only job %q to report skipped on pull requests (add it to the allow_skipped set)", jobName)
+		}
+	}
+}

--- a/scripts/cipolicy/policy.go
+++ b/scripts/cipolicy/policy.go
@@ -20,7 +20,7 @@ const (
 	// policy review, while workflow, job, step, and input descriptions remain
 	// free to change. A failure prints the projection and candidate digest.
 	expectedCITriggersHash       = "d1a8bcd089019589658d8f154af9c26a70877285d84a384c2dcea299efc9554a"
-	expectedCIExecutionHash      = "3fd259c28ccd9e74b1ebd4ef7b8c87a9f12877e8333dd444a2cf8ce90c6b56bb"
+	expectedCIExecutionHash      = "ca09ef912d728ae76a05d607148d1aba6e626b49762e47fdf8013eeb1ddc2195"
 	expectedNightlyTriggersHash  = "0a4400a09ac567e90adf8be1232eef1f14e36efd8dba3e143aa6e36f5b7a36f5"
 	expectedNightlyExecutionHash = "dfe3e40bf2fb461e2f7422ea93b7f9ea769f0e8bf35eb6060690af6f2f361877"
 	expectedSetupActionHash      = "8f2d6b3a57f11d4f33a41211b1d3d5362d1437ba40c7b6db068abb98e731e5ac"


### PR DESCRIPTION
## What this changes

The required CI roll-up now covers every real workflow job, including the two unit-coverage jobs that previously ran without contributing to the final `ci-required` result. A new invariant test walks the workflow dependency graph so future jobs cannot silently fall outside the merge gate; the only exceptions remain the two explicitly advisory jobs.

The coverage jobs run only on pushes, so pull requests may legitimately report them as skipped. The roll-up now names them in both its dependency list and its skipped-job allowlist, which makes their main-branch results mandatory without turning expected PR skips red.

## Review notes

- `.github/workflows/ci.yml` adds the two existing coverage jobs to the final roll-up; it does not create new test workloads.
- `scripts/ci_required_coverage_test.go` verifies transitive reachability and the narrow advisory/skip exceptions.
- `scripts/cipolicy/policy.go` updates the tamper-evident workflow execution hash for the changed dependency graph.
- This PR is initially draft while GitHub supplies the CI-config lane's required first real run. It will not receive deploy clearance until that evidence passes.

## Test plan

- [x] Run the documented full local suite and verify both new invariant tests execute with no diff-owned failure or skip.
- [x] Run `make test-ci-policy`, `go test ./scripts/...`, `go vet ./scripts/...`, changed-file formatting, and diff-integrity checks.
- [ ] Confirm the real `preflight-unit-cover-noncmdgc` and six-shard `preflight-unit-cover-cmdgc` jobs complete, and that `ci-required` consumes their results correctly.
- [x] Release gate: [`release-gates/ga-rcy5fd-ci-required-coverage-invariant-gate.md`](release-gates/ga-rcy5fd-ci-required-coverage-invariant-gate.md)