### PR TITLE
fix(reconciler): recover stalled configured-named interactive seats (widen execution-backstop to named sessions + nudge-before-drain + working-seat guards) — the pilot-killer

### DIFF
--- a/cmd/gc/execution_backstop.go
+++ b/cmd/gc/execution_backstop.go
@@ -206,7 +206,17 @@ type poolExecutionBackstop struct {
 // open so it is never reaped. Everything below this predicate resolves by the
 // session's OWN identities and re-checks ownership before acting, so widening
 // the scope adds coverage without loosening any guard.
+//
+// Manual and dependency-only seats are excluded from BOTH arms. A manual seat
+// is a human's own session (never an orchestration slot), and a dependency-only
+// seat is kept awake to satisfy someone else's dependency rather than to execute
+// a claim of its own — draining either would act against a session this backstop
+// has no business recovering. Pool slots are never manual or dependency-only, so
+// the exclusion only narrows the widened named arm.
 func (p poolExecutionBackstop) governs(s beads.Bead) bool {
+	if isManualSessionBead(s) || strings.TrimSpace(s.Metadata["dependency_only"]) == "true" {
+		return false
+	}
 	return strings.TrimSpace(s.Metadata["pool_managed"]) == "true" || isNamedSessionBead(s)
 }
 
@@ -219,6 +229,15 @@ func (p poolExecutionBackstop) governs(s beads.Bead) bool {
 // nudge about would make the persisted marker a lie. Ambiguity holds rather than
 // clears, so a transient multi-claim tick cannot reset a window already running.
 func (p poolExecutionBackstop) resolve(s beads.Bead, _ map[string]beads.Bead, sessName string) (backstopTarget, backstopResolution) {
+	// Never act under a human's hands. A named interactive seat is exactly the
+	// session an operator attaches to and drives directly; while a terminal is
+	// attached, a nudge would inject keystrokes into that session and a drain
+	// would tear it out from under them. HOLD rather than clear so a grace
+	// window already running survives the human detaching and resumes its
+	// ordinary cadence — a quiet attached seat is "we cannot tell", not "idle".
+	if p.sp.IsAttached(sessName) {
+		return backstopTarget{}, backstopResolutionHold
+	}
 	claims := p.claims.forIdentities(currentSessionAssigneeIdentities(s))
 	switch len(claims) {
 	case 0:
@@ -259,8 +278,37 @@ func (p poolExecutionBackstop) state(s beads.Bead, target backstopTarget) (same 
 	return same, atoiOr0(s.Metadata[executionClaimNudgeCountKey]), parseRFC3339OrZero(s.Metadata[executionClaimNudgeAtKey])
 }
 
+// content resolves the seat's claim nudge, falling back to defaultPoolClaimNudge
+// when the agent is known but configures no nudge — the same fallback the
+// stalled-pool-claim lane already uses (stalledPoolClaimNudgeFor). The named
+// seats this backstop rescues configure no [agent] nudge, so without the
+// fallback the engine's empty-content path would drain them COLD; the confirmed
+// ga-lez12 cause is that these seats RESUME once nudged, so the SDK must deliver
+// a nudge before the drain regardless of pack config. An unknown template or
+// agent still yields "" and goes straight to the drain, since there is genuinely
+// nothing to send and parking on the observe marker forever would starve the
+// seat's close gate.
 func (p poolExecutionBackstop) content(s beads.Bead) string {
-	return claimNudgeFor(p.cfg, s)
+	return stalledPoolClaimNudgeFor(p.cfg, s)
+}
+
+// renewedSince implements activityDecayingBackstop. An in-progress claim is what
+// a working agent looks like, so this predicate cannot tell "working slowly"
+// from "stalled" by bead state alone. Fresh runtime activity after the last
+// attempt is that discriminator: a human-paced seat that answered the previous
+// nudge and worked in a burst has advanced its activity clock, and re-arming its
+// window keeps cumulative quiet pauses from marching it to the drain. A genuinely
+// dead seat reports no such advance and still converges. Activity-only, never
+// keyed on who the session is.
+func (p poolExecutionBackstop) renewedSince(sessName string, last time.Time) bool {
+	if last.IsZero() {
+		return false
+	}
+	activity, err := p.sp.GetLastActivity(sessName)
+	if err != nil || activity.IsZero() {
+		return false
+	}
+	return activity.After(last)
 }
 
 // revalidate re-reads the claim through the owning store's authoritative live

--- a/cmd/gc/execution_backstop.go
+++ b/cmd/gc/execution_backstop.go
@@ -74,9 +74,10 @@ const (
 	executionClaimNudgeStalledKey = "execution_claim_nudge_stalled"
 )
 
-// nudgeStalledPoolExecution re-delivers the configured claim nudge to a pool slot
-// that HOLDS an in-progress claim it never started executing, and escalates once
-// the bounded attempts are spent.
+// nudgeStalledPoolExecution re-delivers the configured claim nudge to a seat —
+// a pool slot or a configured named interactive seat (see governs) — that HOLDS
+// an in-progress claim it never started executing, and escalates once the
+// bounded attempts are spent.
 //
 // work/workStores/workStoreRefs are the reconciler's index-aligned assigned-work
 // snapshot; requestDrain is the existing drain request (drainOps.setDrain), taken
@@ -181,8 +182,9 @@ func (s executionClaimSnapshot) forIdentities(identities []string) []executionCl
 	return out
 }
 
-// poolExecutionBackstop is the backstopPredicate for a pool slot that claimed a
-// bead and never executed it.
+// poolExecutionBackstop is the backstopPredicate for a seat — a pool slot or a
+// configured named interactive seat (see governs) — that claimed a bead and
+// never executed it.
 type poolExecutionBackstop struct {
 	cfg          *config.City
 	sp           runtime.Provider
@@ -192,8 +194,20 @@ type poolExecutionBackstop struct {
 	claims       executionClaimSnapshot
 }
 
+// governs covers both pool slots and configured named interactive seats. The
+// pool-only scope was the ga-lez12 gap: the pilot-killer stalls happened on
+// interactive Claude-harness seats — the run-operator holding finalize-work, an
+// olivia PM holding canonicalize-issue, an idle design reviewer — and those
+// seats carry configured_named_session with pool_managed explicitly cleared
+// (session_beads.go), so a pool-only predicate never saw them. A named seat that
+// claims a step and never executes it is stranded exactly like a pool slot: the
+// bead is in_progress so no claim probe wants it, the session is alive so no
+// crash lane touches it, and the in_progress row keeps the seat's close gate
+// open so it is never reaped. Everything below this predicate resolves by the
+// session's OWN identities and re-checks ownership before acting, so widening
+// the scope adds coverage without loosening any guard.
 func (p poolExecutionBackstop) governs(s beads.Bead) bool {
-	return strings.TrimSpace(s.Metadata["pool_managed"]) == "true"
+	return strings.TrimSpace(s.Metadata["pool_managed"]) == "true" || isNamedSessionBead(s)
 }
 
 // resolve reports an outstanding stall only when all of it holds: the session

--- a/cmd/gc/execution_backstop.go
+++ b/cmd/gc/execution_backstop.go
@@ -68,11 +68,33 @@ const (
 	executionClaimNudgeStoreRefKey = "execution_claim_nudge_store_ref"
 	executionClaimNudgeCountKey    = "execution_claim_nudge_count"
 	executionClaimNudgeAtKey       = "execution_claim_nudge_at"
+	// executionClaimNudgeDecayKey counts the consecutive activity re-arms this
+	// claim has earned (see poolExecutionBackstop.decay). Persisted alongside
+	// the attempt count for the same reason: the bound has to survive a
+	// controller restart, or a restart loop would hand out an unlimited budget
+	// one process at a time.
+	executionClaimNudgeDecayKey = "execution_claim_nudge_decays"
 	// executionClaimNudgeStalledKey latches the one-shot escalation so the
 	// typed event and the drain request fire once per stalled claim rather than
 	// once per tick for as long as the claim is held.
 	executionClaimNudgeStalledKey = "execution_claim_nudge_stalled"
 )
+
+// maxExecutionClaimNudgeDecays bounds how many times ONE claim may have its
+// pacing window re-armed by renewed activity before the attempt ladder is
+// allowed to run to the drain regardless of what the activity clock says.
+//
+// The bound exists because the re-arm's evidence is not fully trustworthy. A
+// self-echoing seat (a provider that counts gc's own nudge as activity, a
+// spinner that repaints, a menu that redraws) can supply fresh activity
+// forever, and an unbounded re-arm would then nudge that seat forever without
+// ever reaching the drain — which is the only thing that releases the claim it
+// is holding. Six re-arms cost about 18 minutes (each self-echoing cycle is one
+// nudge plus the grace window that must elapse before the next quiet tick can
+// re-arm, ~3 min), after which the ordinary bounded march adds ~10 more, so
+// every governed seat converges inside roughly half an hour on every provider
+// while a genuinely human-paced seat still gets a long leash.
+const maxExecutionClaimNudgeDecays = 6
 
 // nudgeStalledPoolExecution re-delivers the configured claim nudge to a seat —
 // a pool slot or a configured named interactive seat (see governs) — that HOLDS
@@ -207,14 +229,21 @@ type poolExecutionBackstop struct {
 // session's OWN identities and re-checks ownership before acting, so widening
 // the scope adds coverage without loosening any guard.
 //
-// Manual and dependency-only seats are excluded from BOTH arms. A manual seat
-// is a human's own session (never an orchestration slot), and a dependency-only
-// seat is kept awake to satisfy someone else's dependency rather than to execute
-// a claim of its own — draining either would act against a session this backstop
-// has no business recovering. Pool slots are never manual or dependency-only, so
-// the exclusion only narrows the widened named arm.
+// Manual seats are excluded from BOTH arms: a manual seat is a human's own
+// session rather than an orchestration slot, so nudging or draining one would
+// act against a session this backstop has no business recovering.
+//
+// Dependency-only seats are NOT excluded. A dependency floor is a pool slot by
+// construction (ensureDependencyOnlyTemplate, build_desired_state.go, is the
+// only thing that sets the flag and always builds pool-slot identity, never a
+// configured-named one — so session_beads.go stamps dependency_only=true and
+// pool_managed=true together), and it runs the same claim loop as any other
+// slot. Excluding it would strip coverage this lane has had since it shipped
+// while narrowing nothing on the named arm, and a floor is the worst seat to
+// leave stranded: the dependency gate deliberately keeps it alive, so the
+// recycle roulette that eventually frees an ordinary slot may never fire.
 func (p poolExecutionBackstop) governs(s beads.Bead) bool {
-	if isManualSessionBead(s) || strings.TrimSpace(s.Metadata["dependency_only"]) == "true" {
+	if isManualSessionBead(s) {
 		return false
 	}
 	return strings.TrimSpace(s.Metadata["pool_managed"]) == "true" || isNamedSessionBead(s)
@@ -229,15 +258,10 @@ func (p poolExecutionBackstop) governs(s beads.Bead) bool {
 // nudge about would make the persisted marker a lie. Ambiguity holds rather than
 // clears, so a transient multi-claim tick cannot reset a window already running.
 func (p poolExecutionBackstop) resolve(s beads.Bead, _ map[string]beads.Bead, sessName string) (backstopTarget, backstopResolution) {
-	// Never act under a human's hands. A named interactive seat is exactly the
-	// session an operator attaches to and drives directly; while a terminal is
-	// attached, a nudge would inject keystrokes into that session and a drain
-	// would tear it out from under them. HOLD rather than clear so a grace
-	// window already running survives the human detaching and resumes its
-	// ordinary cadence — a quiet attached seat is "we cannot tell", not "idle".
-	if p.sp.IsAttached(sessName) {
-		return backstopTarget{}, backstopResolutionHold
-	}
+	// Cheapest discriminator first. The claims snapshot is already in memory,
+	// and the overwhelmingly common answer is "this seat holds nothing" — which
+	// needs no runtime call at all, and clears any stale marker immediately
+	// rather than deferring cleanup behind a probe.
 	claims := p.claims.forIdentities(currentSessionAssigneeIdentities(s))
 	switch len(claims) {
 	case 0:
@@ -245,6 +269,15 @@ func (p poolExecutionBackstop) resolve(s beads.Bead, _ map[string]beads.Bead, se
 	case 1:
 		// Continue below.
 	default:
+		return backstopTarget{}, backstopResolutionHold
+	}
+	// Never act under a human's hands. A named interactive seat is exactly the
+	// session an operator attaches to and drives directly; while a terminal is
+	// attached, a nudge would inject keystrokes into that session and a drain
+	// would tear it out from under them. HOLD rather than clear so a grace
+	// window already running survives the human detaching and resumes its
+	// ordinary cadence — a quiet attached seat is "we cannot tell", not "idle".
+	if p.sp.IsAttached(sessName) {
 		return backstopTarget{}, backstopResolutionHold
 	}
 	if !p.sessionIsQuiet(sessName) {
@@ -292,14 +325,52 @@ func (p poolExecutionBackstop) content(s beads.Bead) string {
 	return stalledPoolClaimNudgeFor(p.cfg, s)
 }
 
-// renewedSince implements activityDecayingBackstop. An in-progress claim is what
-// a working agent looks like, so this predicate cannot tell "working slowly"
-// from "stalled" by bead state alone. Fresh runtime activity after the last
-// attempt is that discriminator: a human-paced seat that answered the previous
-// nudge and worked in a burst has advanced its activity clock, and re-arming its
-// window keeps cumulative quiet pauses from marching it to the drain. A genuinely
-// dead seat reports no such advance and still converges. Activity-only, never
-// keyed on who the session is.
+// decay implements activityDecayingBackstop. An in-progress claim is what a
+// working agent looks like, so this predicate cannot tell "working slowly" from
+// "stalled" by bead state alone. Fresh runtime activity after the last attempt
+// is that discriminator: a human-paced seat that answered the previous nudge and
+// worked in a burst has advanced its activity clock, and re-arming its window
+// keeps cumulative quiet pauses from marching it to the drain.
+//
+// The re-arm is BOUNDED, and the bound is the load-bearing half. The activity
+// clock is not a clean signal of "the agent is working": on every provider but
+// tmux (which records each poke and discounts it — GetSessionActivity /
+// discountPokeActivity) gc's own delivered nudge advances the clock itself, and
+// a repainting spinner or menu does the same without any agent behind it. An
+// unbounded re-arm would let such a seat re-arm on the echo of its own nudge
+// forever and never reach the drain — the only thing that releases the claim it
+// holds — which is precisely the non-convergence this file exists to prevent.
+// So a spent budget (maxExecutionClaimNudgeDecays) refuses to re-arm and hands
+// the seat back to the ordinary ladder, and every governed seat converges
+// whatever its activity clock reports.
+//
+// Activity-only and budget-only, never keyed on who the session is.
+func (p poolExecutionBackstop) decay(store beads.Store, s *beads.Bead, target backstopTarget, sessName string, last, now time.Time, stdout io.Writer) bool {
+	if !p.renewedSince(sessName, last) {
+		return false
+	}
+	decays := atoiOr0(s.Metadata[executionClaimNudgeDecayKey])
+	if decays >= maxExecutionClaimNudgeDecays {
+		return false
+	}
+	// Read the spent attempts before the write resets them, so the operator
+	// line reports the budget this re-arm actually forgave.
+	attempts := atoiOr0(s.Metadata[executionClaimNudgeCountKey])
+	if !writeExecutionClaimMarker(store, s, target, 0, decays+1, now, stdout) {
+		return false
+	}
+	// A marker that goes count=2 -> count=0 with nothing on stdout is
+	// indistinguishable from a store glitch, and "why was this seat never
+	// drained" is exactly the question this path provokes.
+	fmt.Fprintf(stdout, //nolint:errcheck // best-effort
+		"execution-claim-nudge: %s showed activity since its last nudge for %s; re-arming its window (re-arm %d/%d, forgiving %d/%d attempts)\n",
+		sessName, target.ID, decays+1, maxExecutionClaimNudgeDecays, attempts, idleClaimNudgeMaxAttempts)
+	return true
+}
+
+// renewedSince reports whether the runtime observed activity for sessName after
+// last, the persisted time of the previous attempt. Fails closed: an unreadable
+// or unset activity signal is not renewal, so the bounded march continues.
 func (p poolExecutionBackstop) renewedSince(sessName string, last time.Time) bool {
 	if last.IsZero() {
 		return false
@@ -334,12 +405,16 @@ func (p poolExecutionBackstop) revalidate(target backstopTarget) backstopResolut
 	return backstopResolutionOutstanding
 }
 
+// observe starts a new assignment's window: a fresh grace clock AND a fresh
+// re-arm budget, since the budget is spent per claim.
 func (p poolExecutionBackstop) observe(store beads.Store, s *beads.Bead, target backstopTarget, now time.Time, stdout io.Writer) {
-	writeExecutionClaimMarker(store, s, target, 0, now, stdout)
+	writeExecutionClaimMarker(store, s, target, 0, 0, now, stdout)
 }
 
+// reserve records a delivery attempt. It carries the re-arm count forward
+// unchanged: an attempt spends attempt budget, never decay budget.
 func (p poolExecutionBackstop) reserve(store beads.Store, s *beads.Bead, target backstopTarget, attempts int, now time.Time, stdout io.Writer) bool {
-	return writeExecutionClaimMarker(store, s, target, attempts, now, stdout)
+	return writeExecutionClaimMarker(store, s, target, attempts, atoiOr0(s.Metadata[executionClaimNudgeDecayKey]), now, stdout)
 }
 
 // exhausted turns a spent attempt budget into one observable fact and one drain
@@ -413,12 +488,13 @@ func (p poolExecutionBackstop) clear(store beads.Store, s *beads.Bead, stdout io
 	clearExecutionClaimMarker(store, s, stdout)
 }
 
-func writeExecutionClaimMarker(store beads.Store, s *beads.Bead, target backstopTarget, attempts int, now time.Time, stdout io.Writer) bool {
+func writeExecutionClaimMarker(store beads.Store, s *beads.Bead, target backstopTarget, attempts, decays int, now time.Time, stdout io.Writer) bool {
 	return writeSessionMetadata(store, s, map[string]string{
 		executionClaimNudgeWorkKey:     target.ID,
 		executionClaimNudgeRootKey:     target.RootID,
 		executionClaimNudgeStoreRefKey: target.StoreRef,
 		executionClaimNudgeCountKey:    strconv.Itoa(attempts),
+		executionClaimNudgeDecayKey:    strconv.Itoa(decays),
 		executionClaimNudgeAtKey:       now.UTC().Format(time.RFC3339),
 	}, "execution-claim-nudge", stdout)
 }
@@ -432,6 +508,7 @@ func clearExecutionClaimMarker(store beads.Store, s *beads.Bead, stdout io.Write
 		executionClaimNudgeRootKey,
 		executionClaimNudgeStoreRefKey,
 		executionClaimNudgeCountKey,
+		executionClaimNudgeDecayKey,
 		executionClaimNudgeAtKey,
 		executionClaimNudgeStalledKey,
 	}

--- a/cmd/gc/execution_backstop_test.go
+++ b/cmd/gc/execution_backstop_test.go
@@ -363,3 +363,76 @@ func TestExecutionBackstopEscalatesWhenTheAgentHasNoNudgeConfigured(t *testing.T
 		t.Fatalf("execution.step_stalled events = %d, want exactly 1", stalled)
 	}
 }
+
+// asNamedSeat re-stamps the seeded session bead as a configured named
+// interactive seat — the run-operator, an olivia PM, a design reviewer — rather
+// than a pool slot: it clears pool_managed and sets the configured-named
+// markers, exactly as session_beads.go does for an isConfiguredNamed session.
+// The runtime session_name (the claim's assignee here) is unchanged, so
+// resolution still finds the claim by identity.
+func (f *executionBackstopFixture) asNamedSeat(t *testing.T) {
+	t.Helper()
+	if err := f.store.SetMetadataBatch(f.session.ID, map[string]string{
+		"pool_managed":              "",
+		"configured_named_session":  "true",
+		"configured_named_identity": "run-operator",
+	}); err != nil {
+		t.Fatalf("re-stamping the session bead as a named seat: %v", err)
+	}
+	current, err := f.store.Get(f.session.ID)
+	if err != nil {
+		t.Fatalf("re-reading the named-seat session bead: %v", err)
+	}
+	f.session = current
+}
+
+// TestExecutionBackstopRecoversAStalledNamedInteractiveSeat is the pilot-killer
+// row (ga-lez12). The stall that aborted every pilot run happened on an
+// interactive Claude-harness seat — the run-operator holding finalize-work, an
+// olivia PM holding canonicalize-issue — not on a pool slot. Those seats carry
+// configured_named_session, and pool_managed is explicitly cleared for them
+// (session_beads.go), so the pool-only governs scope left them with NO recovery:
+// the seat held the in-progress step, made zero progress, the step's retry
+// exhausted (on_exhausted=hard_fail), and the scope aborted (gc.on_fail=
+// abort_scope). This row proves the same bounded observe -> nudge -> backoff ->
+// drain recovery now covers a stalled named seat, converging it onto the
+// recycle -> dead-assignee reopen -> re-attempt chain instead of hard-failing.
+func TestExecutionBackstopRecoversAStalledNamedInteractiveSeat(t *testing.T) {
+	f := newExecutionBackstopFixture(t)
+	f.asNamedSeat(t)
+	f.idleFor(t, 10*time.Minute)
+
+	f.tick(t) // first sighting: start the grace clock, do not nudge yet
+	if got := f.sessionMeta(t, executionClaimNudgeWorkKey); got != f.work.ID {
+		t.Fatalf("named seat grace clock did not start: work marker = %q, want %q", got, f.work.ID)
+	}
+
+	// The bounded nudge phase re-delivers the seat's own claim nudge.
+	for i := 0; i < idleClaimNudgeMaxAttempts; i++ {
+		f.now = f.now.Add(idleClaimNudgeGrace + idleClaimNudgeBackoff)
+		f.idleFor(t, 10*time.Minute)
+		f.tick(t)
+	}
+	if got := f.nudgeCount(); got != idleClaimNudgeMaxAttempts {
+		t.Fatalf("delivered nudges to a stalled named seat = %d, want the attempt cap %d; stdout=%s", got, idleClaimNudgeMaxAttempts, f.stdout.String())
+	}
+
+	// Exhaustion hands the seat to the drain that already converges.
+	for i := 0; i < 3; i++ {
+		f.now = f.now.Add(idleClaimNudgeBackoff)
+		f.idleFor(t, 10*time.Minute)
+		f.tick(t)
+	}
+	if len(f.drained) != 1 || f.drained[0] != f.sessName {
+		t.Fatalf("drain requests for a stalled named seat = %v, want exactly one for %s; stdout=%s", f.drained, f.sessName, f.stdout.String())
+	}
+	stalled := 0
+	for _, e := range f.rec.Events {
+		if e.Type == events.ExecutionStepStalled {
+			stalled++
+		}
+	}
+	if stalled != 1 {
+		t.Fatalf("execution.step_stalled events = %d, want exactly 1", stalled)
+	}
+}

--- a/cmd/gc/execution_backstop_test.go
+++ b/cmd/gc/execution_backstop_test.go
@@ -134,6 +134,19 @@ func (f *executionBackstopFixture) nudgeCount() int {
 	return strings.Count(f.stdout.String(), "execution-claim-nudge: nudged")
 }
 
+// lastNudge returns the text of the most recent nudge the fake delivered to the
+// seat under test, or "" if none was delivered.
+func (f *executionBackstopFixture) lastNudge(t *testing.T) string {
+	t.Helper()
+	msg := ""
+	for _, call := range f.sp.SnapshotCalls() {
+		if call.Method == "Nudge" && call.Name == f.sessName {
+			msg = call.Message
+		}
+	}
+	return msg
+}
+
 // TestExecutionBackstopNudgesAnIdleClaimHolderExactlyOnce is the core row: the
 // slot holds an in-progress claim, the provider reports no activity past the
 // grace, and the configured claim nudge is re-delivered once with the attempt
@@ -303,21 +316,23 @@ func TestExecutionStepStalledStaysOffTheExportAllowlist(t *testing.T) {
 	}
 }
 
-// TestExecutionBackstopEscalatesWhenTheAgentHasNoNudgeConfigured is the
+// TestExecutionBackstopFallsBackToTheDefaultNudgeThenEscalates is the
 // production row this backstop was missing. `agent.Nudge` is optional, and in a
 // real city every workflow pool template leaves it unset — maintainer-city had
-// it on 18 of 260 agents and on none of its four pool roles. The shared engine
-// skipped empty content with a bare `continue`, so the state machine parked on
-// its observe marker forever: it never reserved an attempt, never reached the
-// attempt cap, and so never ran the drain that is the ONLY thing that releases
-// the claim. A seat holding an in-progress bead still satisfies poolDesired, so
-// no replacement spawns and the whole pool starves behind it. Observed: 20 of 21
-// live markers frozen at count=0, the oldest claim held 3.5 days.
+// it on 18 of 260 agents and on none of its four pool roles — as do the named
+// seats ga-lez12 rescues. Before the fallback, the shared engine skipped empty
+// content with a bare `continue`, so the state machine parked on its observe
+// marker forever: never an attempt, never the cap, never the drain that is the
+// ONLY thing that releases the claim. A seat holding an in-progress bead still
+// satisfies poolDesired, so no replacement spawns and the whole pool starves
+// behind it. Observed: 20 of 21 live markers frozen at count=0, the oldest claim
+// held 3.5 days.
 //
-// With nothing to deliver there is nothing to wait for — the bounded attempts
-// exist to give the agent a chance to ANSWER a nudge. The grace window still
-// applies, and then it escalates.
-func TestExecutionBackstopEscalatesWhenTheAgentHasNoNudgeConfigured(t *testing.T) {
+// The fix is the default-nudge fallback the claim lane already carries: an agent
+// that is KNOWN but configures no nudge is still nudged with defaultPoolClaimNudge
+// through the bounded attempts, and only then — the seat having had its chance to
+// answer — does it escalate to the drain.
+func TestExecutionBackstopFallsBackToTheDefaultNudgeThenEscalates(t *testing.T) {
 	f := newExecutionBackstopFixture(t)
 	f.cfg.Agents[0].Nudge = "" // the maintainer-city pool templates, verbatim
 	f.idleFor(t, 10*time.Minute)
@@ -330,12 +345,71 @@ func TestExecutionBackstopEscalatesWhenTheAgentHasNoNudgeConfigured(t *testing.T
 		t.Fatalf("drain requests inside the grace window = %v, want none", f.drained)
 	}
 
+	// The bounded nudge phase delivers the DEFAULT claim nudge, not silence.
+	for i := 0; i < idleClaimNudgeMaxAttempts; i++ {
+		f.now = f.now.Add(idleClaimNudgeGrace + idleClaimNudgeBackoff)
+		f.idleFor(t, 10*time.Minute)
+		f.tick(t)
+	}
+	if got := f.nudgeCount(); got != idleClaimNudgeMaxAttempts {
+		t.Fatalf("default-nudge deliveries = %d, want the attempt cap %d; stdout=%s", got, idleClaimNudgeMaxAttempts, f.stdout.String())
+	}
+	if msg := f.lastNudge(t); msg != defaultPoolClaimNudge {
+		t.Fatalf("delivered nudge text = %q, want the default %q", msg, defaultPoolClaimNudge)
+	}
+	if len(f.drained) != 0 {
+		t.Fatalf("drain requests before the attempts were spent = %v, want none", f.drained)
+	}
+
+	// Only after the bounded attempts are spent does it escalate to the drain.
+	for i := 0; i < 3; i++ {
+		f.now = f.now.Add(idleClaimNudgeBackoff)
+		f.idleFor(t, 10*time.Minute)
+		f.tick(t)
+	}
+	if len(f.drained) != 1 || f.drained[0] != f.sessName {
+		t.Fatalf("drain requests = %v, want exactly one for %s; stdout=%s", f.drained, f.sessName, f.stdout.String())
+	}
+	if f.sessionMeta(t, executionClaimNudgeStalledKey) == "" {
+		t.Fatal("escalation was not latched; a later tick would drain the session all over again")
+	}
+	stalled := 0
+	for _, e := range f.rec.Events {
+		if e.Type == events.ExecutionStepStalled {
+			stalled++
+		}
+	}
+	if stalled != 1 {
+		t.Fatalf("execution.step_stalled events = %d, want exactly 1", stalled)
+	}
+}
+
+// TestExecutionBackstopDrainsColdWhenNoNudgeIsResolvable pins the one case the
+// default-nudge fallback deliberately does NOT rescue: a seat whose template
+// resolves to no agent at all, so there is genuinely no nudge to send. Parking
+// on the observe marker forever would hold the seat's close gate open and starve
+// the pool, so with nothing deliverable the engine's empty-content path escalates
+// to the drain straight out of the grace window — no nudge, exactly one drain.
+func TestExecutionBackstopDrainsColdWhenNoNudgeIsResolvable(t *testing.T) {
+	f := newExecutionBackstopFixture(t)
+	// Point the seat at a template with no matching [agent], so both the
+	// configured nudge and the default fallback resolve to nothing.
+	if err := f.store.SetMetadataBatch(f.session.ID, map[string]string{"template": "ghost-template"}); err != nil {
+		t.Fatalf("re-stamping the session template: %v", err)
+	}
+	f.idleFor(t, 10*time.Minute)
+
+	f.tick(t) // first sighting: start the grace clock, escalate nothing yet
+	if len(f.drained) != 0 {
+		t.Fatalf("drain requests inside the grace window = %v, want none", f.drained)
+	}
+
 	f.now = f.now.Add(idleClaimNudgeGrace + time.Second)
 	f.idleFor(t, 10*time.Minute)
 	f.tick(t)
 
 	if got := f.nudgeCount(); got != 0 {
-		t.Fatalf("delivered nudges with no configured nudge = %d, want 0", got)
+		t.Fatalf("delivered nudges with no resolvable nudge = %d, want 0", got)
 	}
 	if len(f.drained) != 1 || f.drained[0] != f.sessName {
 		t.Fatalf("drain requests = %v, want exactly one for %s; stdout=%s", f.drained, f.sessName, f.stdout.String())
@@ -434,5 +508,131 @@ func TestExecutionBackstopRecoversAStalledNamedInteractiveSeat(t *testing.T) {
 	}
 	if stalled != 1 {
 		t.Fatalf("execution.step_stalled events = %d, want exactly 1", stalled)
+	}
+}
+
+// TestExecutionBackstopHoldsWhileAHumanIsAttached is the never-act-under-a-
+// human's-hands guard (ga-lez12). A named interactive seat is exactly the kind
+// of session an operator attaches to and drives by hand; the run-operator and
+// the reviewers are attended for long stretches. While a terminal is attached
+// the seat can hold an in-progress claim and report no I/O activity for many
+// minutes — a human reading, thinking, or typing slowly — yet nudging it would
+// inject keystrokes into the operator's session and draining it would rip the
+// session out from under them. The backstop must HOLD (never nudge, never drain,
+// and write no pacing state) for as long as the attach lasts, then resume its
+// ordinary cadence once the human detaches.
+func TestExecutionBackstopHoldsWhileAHumanIsAttached(t *testing.T) {
+	f := newExecutionBackstopFixture(t)
+	f.asNamedSeat(t)
+	f.sp.SetAttached(f.sessName, true) // a human is driving this seat by hand
+
+	// Drive well past the grace window AND the full attempt budget AND the
+	// exhaustion that would otherwise drain: an attached seat sees none of it.
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t)
+	for i := 0; i < idleClaimNudgeMaxAttempts+3; i++ {
+		f.now = f.now.Add(idleClaimNudgeGrace + idleClaimNudgeBackoff)
+		f.idleFor(t, 10*time.Minute)
+		f.tick(t)
+	}
+
+	if got := f.nudgeCount(); got != 0 {
+		t.Fatalf("nudges to an attached seat = %d, want 0 (never act under a human's hands); stdout=%s", got, f.stdout.String())
+	}
+	if len(f.drained) != 0 {
+		t.Fatalf("drain requests for an attached seat = %v, want none", f.drained)
+	}
+	if got := f.sessionMeta(t, executionClaimNudgeWorkKey); got != "" {
+		t.Fatalf("persisted work marker = %q, want no pacing write while attached", got)
+	}
+}
+
+// TestExecutionBackstopDoesNotDrainAnIntermittentlyWorkingSeat is the
+// activity-decay row (ga-lez12). A human-paced interactive seat works in bursts:
+// it answers a nudge, runs for a bit, then pauses to read or think. Each pause
+// can exceed the grace window, so a bounded nudge->backoff->drain machine that
+// only clears its attempt count when the claim LEAVES in_progress will march a
+// legitimately-working seat to the drain on cumulative quiet alone. The fix
+// re-arms the window whenever the runtime reports fresh activity SINCE the last
+// attempt: a seat that keeps doing work between nudges is alive and must not be
+// force-drained. A genuinely dead seat shows no such activity and still drains.
+func TestExecutionBackstopDoesNotDrainAnIntermittentlyWorkingSeat(t *testing.T) {
+	f := newExecutionBackstopFixture(t)
+	f.asNamedSeat(t)
+
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t) // first sighting: start the grace clock
+
+	// Far more cycles than the attempt cap. Each cycle the seat is quiet right
+	// now (past the grace) but showed activity since the last attempt — the
+	// signature of a seat working in bursts. Without decay the attempt count
+	// reaches the cap within maxAttempts cycles and the seat is drained.
+	for i := 0; i < idleClaimNudgeMaxAttempts+4; i++ {
+		f.now = f.now.Add(idleClaimNudgeGrace + idleClaimNudgeBackoff)
+		f.sp.SetActivity(f.sessName, f.now.Add(-(idleClaimNudgeGrace + time.Second)))
+		f.tick(t)
+	}
+
+	if len(f.drained) != 0 {
+		t.Fatalf("drain requests for an intermittently-working seat = %v, want none (renewed activity re-arms the window); stdout=%s", f.drained, f.stdout.String())
+	}
+	stalled := 0
+	for _, e := range f.rec.Events {
+		if e.Type == events.ExecutionStepStalled {
+			stalled++
+		}
+	}
+	if stalled != 0 {
+		t.Fatalf("execution.step_stalled events = %d, want 0 for a working seat; stdout=%s", stalled, f.stdout.String())
+	}
+}
+
+// TestExecutionBackstopFallsBackToTheDefaultNudgeForANamedSeatThenResumes is the
+// stall -> nudge -> resume row (ga-lez12). The named seats that stalled the
+// pilot (run-operator, olivia, the reviewers) configure NO [agent] nudge, and
+// the execution lane read the raw configured nudge with no default fallback — so
+// widening the backstop to cover named seats would have drained them COLD, never
+// delivering the one keystroke the confirmed cause says resumes them. This row
+// pins the fallback: with no configured nudge the lane still delivers the default
+// claim nudge, the seat answers and completes its claim, and it is never drained.
+func TestExecutionBackstopFallsBackToTheDefaultNudgeForANamedSeatThenResumes(t *testing.T) {
+	f := newExecutionBackstopFixture(t)
+	f.asNamedSeat(t)
+	f.cfg.Agents[0].Nudge = "" // the real named seats configure no nudge
+
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t) // observe
+	if len(f.drained) != 0 {
+		t.Fatalf("drain requests inside the grace window = %v, want none", f.drained)
+	}
+
+	f.now = f.now.Add(idleClaimNudgeGrace + time.Second)
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t)
+
+	if got := f.nudgeCount(); got != 1 {
+		t.Fatalf("default-nudge deliveries = %d, want exactly 1 (nudge before drain); stdout=%s", got, f.stdout.String())
+	}
+	if len(f.drained) != 0 {
+		t.Fatalf("drain requests after the first default nudge = %v, want none yet", f.drained)
+	}
+	if msg := f.lastNudge(t); msg != defaultPoolClaimNudge {
+		t.Fatalf("delivered nudge text = %q, want the default %q", msg, defaultPoolClaimNudge)
+	}
+
+	// The seat answers: it executes and completes the claim. The backstop clears
+	// and never drains.
+	if err := f.store.Close(f.work.ID); err != nil {
+		t.Fatalf("completing the claimed work: %v", err)
+	}
+	f.now = f.now.Add(idleClaimNudgeBackoff + time.Second)
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t)
+
+	if len(f.drained) != 0 {
+		t.Fatalf("drain requests after the seat resumed and completed = %v, want none", f.drained)
+	}
+	if got := f.sessionMeta(t, executionClaimNudgeWorkKey); got != "" {
+		t.Fatalf("persisted work marker = %q, want cleared after completion", got)
 	}
 }

--- a/cmd/gc/execution_backstop_test.go
+++ b/cmd/gc/execution_backstop_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -66,16 +67,26 @@ func newExecutionBackstopFixture(t *testing.T) *executionBackstopFixture {
 		t.Fatalf("seeding the session bead: %v", err)
 	}
 	f.session = session
+	f.work = f.claimWork(t, "claimed step")
+	if err := f.sp.Start(context.Background(), f.sessName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("starting the fake session: %v", err)
+	}
+	return f
+}
+
+// claimWork seeds a step bead and claims it for the seat the way the hook does,
+// so the row under test is a real in-progress assignment rather than a
+// hand-built status string.
+func (f *executionBackstopFixture) claimWork(t *testing.T, title string) beads.Bead {
+	t.Helper()
 	work, err := f.store.Create(beads.Bead{
-		Title:    "claimed step",
+		Title:    title,
 		Type:     "task",
 		Metadata: map[string]string{beadmeta.RootBeadIDMetadataKey: "root-1"},
 	})
 	if err != nil {
 		t.Fatalf("seeding the work bead: %v", err)
 	}
-	// Claim it the way the hook does, so the row under test is a real
-	// in-progress assignment rather than a hand-built status string.
 	inProgress := "in_progress"
 	if err := f.store.Update(work.ID, beads.UpdateOpts{Status: &inProgress, Assignee: &f.sessName}); err != nil {
 		t.Fatalf("claiming the work bead: %v", err)
@@ -84,11 +95,7 @@ func newExecutionBackstopFixture(t *testing.T) *executionBackstopFixture {
 	if err != nil {
 		t.Fatalf("re-reading the claimed work bead: %v", err)
 	}
-	f.work = claimed
-	if err := f.sp.Start(context.Background(), f.sessName, runtime.Config{Command: "true"}); err != nil {
-		t.Fatalf("starting the fake session: %v", err)
-	}
-	return f
+	return claimed
 }
 
 // tick runs one reconcile tick of the backstop at the fixture's current clock.
@@ -132,6 +139,24 @@ func (f *executionBackstopFixture) sessionMeta(t *testing.T, key string) string 
 
 func (f *executionBackstopFixture) nudgeCount() int {
 	return strings.Count(f.stdout.String(), "execution-claim-nudge: nudged")
+}
+
+// echoOneReArm drives exactly one nudge -> self-echo -> re-arm cycle: the tick
+// that delivers a nudge, the seat's own echo landing a second later (the honest
+// worst case on every provider but tmux — see the convergence row below), and
+// the tick that reads that echo as renewal and spends one unit of the re-arm
+// budget. The caller asserts on the persisted budget afterwards.
+func (f *executionBackstopFixture) echoOneReArm(t *testing.T) {
+	t.Helper()
+	delivered := f.nudgeCount()
+	f.now = f.now.Add(idleClaimNudgeGrace + idleClaimNudgeBackoff)
+	f.tick(t)
+	if got := f.nudgeCount(); got != delivered+1 {
+		t.Fatalf("nudges after the delivery tick = %d, want %d; stdout=%s", got, delivered+1, f.stdout.String())
+	}
+	f.sp.SetActivity(f.sessName, f.now.Add(time.Second))
+	f.now = f.now.Add(idleClaimNudgeGrace + idleClaimNudgeBackoff)
+	f.tick(t)
 }
 
 // lastNudge returns the text of the most recent nudge the fake delivered to the
@@ -545,6 +570,25 @@ func TestExecutionBackstopHoldsWhileAHumanIsAttached(t *testing.T) {
 	if got := f.sessionMeta(t, executionClaimNudgeWorkKey); got != "" {
 		t.Fatalf("persisted work marker = %q, want no pacing write while attached", got)
 	}
+
+	// The human detaches. Nothing else changed — the seat is still quiet and
+	// still holds the same claim — so the lane resumes its ordinary cadence: the
+	// attach DEFERRED the recovery, it did not cancel it. This phase is what
+	// makes the assertions above non-vacuous: "no nudge, no drain, no marker" is
+	// also exactly what a lane that never governed this seat at all looks like.
+	f.sp.SetAttached(f.sessName, false)
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t) // first sighting of the now-unattended seat: start the grace clock
+	if got := f.sessionMeta(t, executionClaimNudgeWorkKey); got != f.work.ID {
+		t.Fatalf("work marker after the human detached = %q, want the grace clock started on %q", got, f.work.ID)
+	}
+
+	f.now = f.now.Add(idleClaimNudgeGrace + time.Second)
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t)
+	if got := f.nudgeCount(); got != 1 {
+		t.Fatalf("nudges after the human detached = %d, want exactly 1 (the cadence resumes); stdout=%s", got, f.stdout.String())
+	}
 }
 
 // TestExecutionBackstopDoesNotDrainAnIntermittentlyWorkingSeat is the
@@ -634,5 +678,218 @@ func TestExecutionBackstopFallsBackToTheDefaultNudgeForANamedSeatThenResumes(t *
 	}
 	if got := f.sessionMeta(t, executionClaimNudgeWorkKey); got != "" {
 		t.Fatalf("persisted work marker = %q, want cleared after completion", got)
+	}
+}
+
+// TestExecutionBackstopGovernsTheSeatTaxonomy pins WHICH seats this lane
+// recovers, one row per shape, because the exclusions are the part that is easy
+// to get backwards by reading the flag names alone.
+//
+// A dependency floor is the trap: it carries dependency_only AND pool_managed
+// together (ensureDependencyOnlyTemplate, build_desired_state.go, is the only
+// thing that sets the flag and always builds pool-slot identity, so
+// session_beads.go stamps both), which makes "exclude dependency_only" a
+// silent removal of pool coverage rather than a narrowing of the named arm.
+// The manual seat is the genuine exclusion: a human's own session, in either
+// the session_origin or the legacy manual_session spelling, is never an
+// orchestration slot for this backstop to recover.
+func TestExecutionBackstopGovernsTheSeatTaxonomy(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		meta map[string]string
+		want bool
+	}{
+		{"pool slot", map[string]string{"pool_managed": "true"}, true},
+		{"configured named seat", map[string]string{
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "run-operator",
+		}, true},
+		{"dependency floor pool slot", map[string]string{"pool_managed": "true", "dependency_only": "true"}, true},
+		{"manual seat", map[string]string{"session_origin": "manual", "pool_managed": "true"}, false},
+		{"legacy manual seat", map[string]string{"manual_session": boolMetadata(true), "pool_managed": "true"}, false},
+		{"manual seat wearing named markers", map[string]string{
+			"session_origin":             "manual",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "run-operator",
+		}, false},
+		{"neither pool-managed nor named", map[string]string{"template": "worker"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := poolExecutionBackstop{}.governs(beads.Bead{Type: sessionBeadType, Metadata: tc.meta})
+			if got != tc.want {
+				t.Fatalf("governs(%v) = %v, want %v", tc.meta, got, tc.want)
+			}
+		})
+	}
+}
+
+// asDependencyFloorSlot re-stamps the seeded pool slot as a dependency floor —
+// a slot the desired-state builder keeps alive to satisfy someone else's
+// dependency — exactly as session_beads.go stamps one: dependency_only and
+// pool_managed together.
+func (f *executionBackstopFixture) asDependencyFloorSlot(t *testing.T) {
+	t.Helper()
+	if err := f.store.SetMetadataBatch(f.session.ID, map[string]string{"dependency_only": "true"}); err != nil {
+		t.Fatalf("re-stamping the session bead as a dependency floor: %v", err)
+	}
+	current, err := f.store.Get(f.session.ID)
+	if err != nil {
+		t.Fatalf("re-reading the dependency-floor session bead: %v", err)
+	}
+	f.session = current
+}
+
+// TestExecutionBackstopRecoversAStalledDependencyFloorSlot is the coverage row
+// behind the taxonomy above. A dependency floor runs the same claim loop as any
+// other pool slot, so it can strand the same way — and it is the worst seat to
+// leave stranded, because the dependency gate deliberately keeps it alive: the
+// recycle roulette that eventually frees an ordinary slot may never fire for a
+// floor. This row drives the full observe -> nudge -> drain recovery on one.
+func TestExecutionBackstopRecoversAStalledDependencyFloorSlot(t *testing.T) {
+	f := newExecutionBackstopFixture(t)
+	f.asDependencyFloorSlot(t)
+
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t) // first sighting: start the grace clock
+	if got := f.sessionMeta(t, executionClaimNudgeWorkKey); got != f.work.ID {
+		t.Fatalf("dependency-floor grace clock did not start: work marker = %q, want %q", got, f.work.ID)
+	}
+
+	for i := 0; i < idleClaimNudgeMaxAttempts; i++ {
+		f.now = f.now.Add(idleClaimNudgeGrace + idleClaimNudgeBackoff)
+		f.idleFor(t, 10*time.Minute)
+		f.tick(t)
+	}
+	if got := f.nudgeCount(); got != idleClaimNudgeMaxAttempts {
+		t.Fatalf("delivered nudges to a stalled dependency floor = %d, want the attempt cap %d; stdout=%s", got, idleClaimNudgeMaxAttempts, f.stdout.String())
+	}
+
+	f.now = f.now.Add(idleClaimNudgeBackoff)
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t)
+	if len(f.drained) != 1 || f.drained[0] != f.sessName {
+		t.Fatalf("drain requests for a stalled dependency floor = %v, want exactly one for %s; stdout=%s", f.drained, f.sessName, f.stdout.String())
+	}
+}
+
+// TestExecutionBackstopConvergesWhenTheActivityClockCountsItsOwnNudge is the
+// bound on the activity decay, and the row the decay shipped without.
+//
+// The decay's evidence is the runtime's activity clock, and that clock is NOT a
+// clean signal that an agent is working: tmux records each poke and discounts it
+// (GetSessionActivity / discountPokeActivity), but it is the only provider that
+// does — on t3bridge the delivered nudge IS a thread message, so it advances
+// threadUpdatedAt past the very attempt it was reserved for. A spinner or menu
+// that repaints has the same shape. So this fixture models the honest
+// worst case: the seat emits nothing of its own, and the only activity it ever
+// reports is the echo of gc's own nudge, arriving a second after each delivery
+// and then going quiet again past the grace window.
+//
+// Unbounded, that seat re-arms on its own echo forever and is never drained —
+// and the drain is the only thing that releases the claim it is holding, which
+// is the exact non-convergence this whole file exists to prevent. The bounded
+// re-arm budget is what makes the guarantee hold on every provider: the decay
+// buys a generous leash, then stops, and the ordinary ladder finishes the job.
+func TestExecutionBackstopConvergesWhenTheActivityClockCountsItsOwnNudge(t *testing.T) {
+	f := newExecutionBackstopFixture(t)
+	f.asNamedSeat(t)
+
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t) // first sighting: start the grace clock
+
+	// Enough cycles to spend the whole re-arm budget AND the attempt ladder
+	// behind it, plus slack to prove the drain is requested exactly once.
+	delivered := 0
+	for i := 0; i < 2*(maxExecutionClaimNudgeDecays+idleClaimNudgeMaxAttempts)+6; i++ {
+		f.now = f.now.Add(idleClaimNudgeGrace + idleClaimNudgeBackoff)
+		f.tick(t)
+		if f.nudgeCount() > delivered {
+			delivered = f.nudgeCount()
+			// The nudge echoes back as session activity one second after
+			// delivery — later than the attempt this tick just reserved, and
+			// still older than the next tick's grace window.
+			f.sp.SetActivity(f.sessName, f.now.Add(time.Second))
+		}
+	}
+
+	if len(f.drained) != 1 || f.drained[0] != f.sessName {
+		t.Fatalf("drain requests for a self-echoing seat = %v, want exactly one for %s (the re-arm is bounded); stdout=%s", f.drained, f.sessName, f.stdout.String())
+	}
+	stalled := 0
+	for _, e := range f.rec.Events {
+		if e.Type == events.ExecutionStepStalled {
+			stalled++
+		}
+	}
+	if stalled != 1 {
+		t.Fatalf("execution.step_stalled events = %d, want exactly 1; stdout=%s", stalled, f.stdout.String())
+	}
+	// It converged because the BUDGET ran out, not because the seat stopped
+	// reporting activity: the counter is parked at the cap, and the seat was
+	// nudged far more than the bare attempt ladder allows.
+	if got := f.sessionMeta(t, executionClaimNudgeDecayKey); got != strconv.Itoa(maxExecutionClaimNudgeDecays) {
+		t.Fatalf("persisted re-arm count = %q, want the cap %d", got, maxExecutionClaimNudgeDecays)
+	}
+	if delivered <= idleClaimNudgeMaxAttempts {
+		t.Fatalf("delivered nudges = %d, want more than the bare attempt cap %d (the decay must really have re-armed); stdout=%s", delivered, idleClaimNudgeMaxAttempts, f.stdout.String())
+	}
+}
+
+// TestExecutionBackstopResetsTheReArmBudgetForTheNextClaim owns the other half
+// of the budget lifecycle: the bound above is what makes every seat converge,
+// and the RESET is what keeps the leash generous for a slot that outlives many
+// claims. The budget is spent per claim, so a slot that burned re-arms on one
+// step must start its next step with the whole budget again — otherwise a
+// long-lived slot's leash erodes toward zero and live-but-slow seats converge
+// after the bare attempt march, which is the behavior the bound was built to
+// avoid rather than cause.
+//
+// Both reset paths are load-bearing and this row drives each of them:
+//
+//   - a handoff, where the slot completes one claim and takes the next before
+//     any tick sees it claimless, so `observe` is what must write the fresh
+//     budget. Note the ordering: `observe` only ever sees a stale budget on
+//     THIS path. A claimless tick in between would have cleared the marker
+//     first, leaving `observe` nothing to carry forward and the reset
+//     vacuously satisfied — so the handoff is the shape that pins it.
+//   - a completion, where `clear` must wipe the budget with the rest of the
+//     marker so nothing survives on the bead.
+func TestExecutionBackstopResetsTheReArmBudgetForTheNextClaim(t *testing.T) {
+	f := newExecutionBackstopFixture(t)
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t) // first sighting of claim A: start the grace clock
+
+	// Claim A spends part — not all — of its budget on its own echo.
+	const spent = 3
+	for i := 0; i < spent; i++ {
+		f.echoOneReArm(t)
+	}
+	if got := f.sessionMeta(t, executionClaimNudgeDecayKey); got != strconv.Itoa(spent) {
+		t.Fatalf("re-arms spent on claim A = %q, want %d; stdout=%s", got, spent, f.stdout.String())
+	}
+
+	// The handoff: A completes and the slot takes B in the same gap, so the next
+	// tick resolves a NEW target with A's spent budget still on the bead.
+	if err := f.store.Close(f.work.ID); err != nil {
+		t.Fatalf("completing claim A: %v", err)
+	}
+	f.work = f.claimWork(t, "the slot's next claimed step")
+	f.idleFor(t, 10*time.Minute)
+	f.tick(t) // first sighting of claim B: a fresh window AND a fresh budget
+
+	f.echoOneReArm(t)
+	if got := f.sessionMeta(t, executionClaimNudgeDecayKey); got != "1" {
+		t.Fatalf("re-arms after claim B's first = %q, want 1 — the budget is per claim, not per slot, so B must not inherit A's %d; stdout=%s", got, spent, f.stdout.String())
+	}
+
+	// The completion: nothing survives on the bead for whatever this slot
+	// claims next.
+	if err := f.store.Close(f.work.ID); err != nil {
+		t.Fatalf("completing claim B: %v", err)
+	}
+	f.now = f.now.Add(idleClaimNudgeGrace + idleClaimNudgeBackoff)
+	f.tick(t)
+	if got := f.sessionMeta(t, executionClaimNudgeDecayKey); got != "" {
+		t.Fatalf("persisted re-arm budget after the claim completed = %q, want it cleared with the rest of the marker", got)
 	}
 }

--- a/cmd/gc/nudge_backstop.go
+++ b/cmd/gc/nudge_backstop.go
@@ -65,10 +65,14 @@ type backstopPredicate interface {
 // NOT implement it: their condition vanishes the instant the agent acts, so
 // they never need to tell "working" from "stalled" by activity.
 type activityDecayingBackstop interface {
-	// renewedSince reports whether sessName showed runtime activity after last,
-	// the persisted time of the predicate's last observation or attempt. Keyed
-	// only on the runtime's activity signal, never on who the session is.
-	renewedSince(sessName string, last time.Time) bool
+	// decay re-arms the predicate's pacing window for target and reports
+	// whether it did. The implementation owns BOTH halves of that judgement:
+	// whether sessName showed runtime activity after last (the persisted time
+	// of the last attempt), and whether its own bounded re-arm budget for this
+	// assignment still allows one. A false answer hands the session to the
+	// ordinary ladder below, so a predicate can never trade convergence away
+	// for an activity signal it cannot fully trust.
+	decay(store beads.Store, s *beads.Bead, target backstopTarget, sessName string, last, now time.Time, stdout io.Writer) bool
 }
 
 // backstopTarget is the durable identity of one outstanding delivery target.
@@ -131,6 +135,36 @@ func decideBackstopAction(attempts int, last, now time.Time) backstopAction {
 	return backstopActionNudge
 }
 
+// decayedWindow gives a predicate that tracks a working-looking seat the chance
+// to re-arm its own pacing window instead of taking another step toward the
+// terminal action — the seat answered the previous nudge and paused again on its
+// own cadence, so it has earned a fresh window (see activityDecayingBackstop,
+// which owns the decision and its bound). Reports whether the window was
+// re-armed, in which case this tick is done.
+//
+// attempts>0 is the gate: at attempts==0 decideBackstopAction's grace check
+// already grants the first free pass, and there is no accumulated budget to
+// shed. Predicates that do not implement the extension never decay.
+func decayedWindow(
+	pred backstopPredicate,
+	store beads.Store,
+	s *beads.Bead,
+	target backstopTarget,
+	sessName string,
+	attempts int,
+	last, now time.Time,
+	stdout io.Writer,
+) bool {
+	if attempts == 0 {
+		return false
+	}
+	decayer, ok := pred.(activityDecayingBackstop)
+	if !ok {
+		return false
+	}
+	return decayer.decay(store, s, target, sessName, last, now, stdout)
+}
+
 // runNudgeBackstop drives pred over sessionBeads: for each session it governs
 // that is running and has outstanding work, it paces re-delivery of pred's
 // nudge content through the shared grace → nudge → backoff → give-up engine,
@@ -187,17 +221,8 @@ func runNudgeBackstop(
 			continue
 		}
 
-		// Re-arm before deciding when a predicate that tracks a working-looking
-		// seat reports fresh activity since its last attempt: the seat answered
-		// the previous nudge and paused again on its own cadence, so it has
-		// earned a fresh grace window rather than another step toward the drain.
-		// Gated on attempts>0 — at attempts==0 the grace check below already
-		// gives the first free pass, and there is no accumulated budget to shed.
-		if attempts > 0 {
-			if decayer, ok := pred.(activityDecayingBackstop); ok && decayer.renewedSince(sessName, last) {
-				pred.observe(store, s, target, now, stdout)
-				continue
-			}
+		if decayedWindow(pred, store, s, target, sessName, attempts, last, now, stdout) {
+			continue
 		}
 
 		switch decideBackstopAction(attempts, last, now) {
@@ -220,17 +245,21 @@ func runNudgeBackstop(
 			}
 			content := pred.content(*s)
 			if content == "" {
-				// Nothing is deliverable for this session. `agent.Nudge` is
-				// optional and pool templates routinely leave it unset, so this
-				// is the common case, not the exotic one. Skipping silently
-				// parks the state machine on its observe marker forever: no
-				// attempt is ever reserved, the cap is never reached, and the
-				// predicate's terminal action never runs — which for the
-				// execution backstop is the drain that is the only thing that
-				// releases the claim. The bounded attempts exist to give the
-				// agent a chance to ANSWER a nudge; with no nudge to send there
-				// is nothing to wait for, so go straight to the terminal action
-				// after the same grace window.
+				// Nothing is deliverable for this session — an ordinary path
+				// rather than an exotic one in every lane, though for different
+				// reasons. The lanes that resolve content through the
+				// default-nudge fallback (the claim and execution backstops)
+				// reach it only when the template or agent cannot be resolved
+				// at all; the continuation lane reads the configured nudge
+				// directly, and `agent.Nudge` is optional and routinely unset.
+				// Skipping silently parks the state machine on its observe
+				// marker forever: no attempt is ever reserved, the cap is never
+				// reached, and the predicate's terminal action never runs —
+				// which for the execution backstop is the drain that is the only
+				// thing that releases the claim. The bounded attempts exist to
+				// give the agent a chance to ANSWER a nudge; with no nudge to
+				// send there is nothing to wait for, so go straight to the
+				// terminal action after the same grace window.
 				pred.exhausted(store, s, stdout)
 				continue
 			}

--- a/cmd/gc/nudge_backstop.go
+++ b/cmd/gc/nudge_backstop.go
@@ -55,6 +55,22 @@ type backstopPredicate interface {
 	clear(store beads.Store, s *beads.Bead, stdout io.Writer)
 }
 
+// activityDecayingBackstop is an optional backstopPredicate extension. A
+// predicate whose outstanding condition LOOKS like a working agent — an
+// in-progress claim, which a busy seat holds by design — implements it to
+// re-arm its pacing when the runtime reports fresh activity since the last
+// attempt. A human-paced interactive seat answers a nudge, works in a burst,
+// and pauses again; without this the accumulated quiet marches it to the
+// terminal drain even though it is plainly alive. The open-bead predicates do
+// NOT implement it: their condition vanishes the instant the agent acts, so
+// they never need to tell "working" from "stalled" by activity.
+type activityDecayingBackstop interface {
+	// renewedSince reports whether sessName showed runtime activity after last,
+	// the persisted time of the predicate's last observation or attempt. Keyed
+	// only on the runtime's activity signal, never on who the session is.
+	renewedSince(sessName string, last time.Time) bool
+}
+
 // backstopTarget is the durable identity of one outstanding delivery target.
 // ID is the human-facing work bead. RootID, StoreRef, and Generation are
 // optional persisted provenance fields: the initial pool-claim predicate needs
@@ -169,6 +185,19 @@ func runNudgeBackstop(
 			// lands within the grace window.
 			pred.observe(store, s, target, now, stdout)
 			continue
+		}
+
+		// Re-arm before deciding when a predicate that tracks a working-looking
+		// seat reports fresh activity since its last attempt: the seat answered
+		// the previous nudge and paused again on its own cadence, so it has
+		// earned a fresh grace window rather than another step toward the drain.
+		// Gated on attempts>0 — at attempts==0 the grace check below already
+		// gives the first free pass, and there is no accumulated budget to shed.
+		if attempts > 0 {
+			if decayer, ok := pred.(activityDecayingBackstop); ok && decayer.renewedSince(sessName, last) {
+				pred.observe(store, s, target, now, stdout)
+				continue
+			}
 		}
 
 		switch decideBackstopAction(attempts, last, now) {


### PR DESCRIPTION
## Summary

Interactive Claude/kimi **configured-named** seats (run-operator, PM, reviewers) park at their menu/queued-message prompt each turn without running the next claim cycle; one un-submitted turn = permanent stall → the step's retry exhausts → the run aborts. This deterministically kills the normalized-issue-pr pilot at `finalize-work` every run (the run-operator claims it, never writes `work-final.json`). (ga-lez12)

## Root cause (proven)

Every re-delivery backstop is gated `pool_managed=="true"` (`poolClaimBackstop`/`poolContinuationBackstop`/`poolExecutionBackstop`), so **named seats have zero backstops**. The planned named-seat nudge (`nudgeOutstandingStartupKickoffs`) was **never built** — only the seeding half landed; a live named seat has carried `startup_kickoff_state=pending, attempts=0` for 8 days with zero nudge markers. The stall is a **nudge-resumable delivery loss** (seats complete once nudged), not a prompt/formula inability and not a claim-query failure (that was the separate WAL fix).

## Fix — reuse the existing guarded engine, minimal surface

The already-shipped, already-bounded execution-backstop engine (90s grace / 3 attempts / 3m backoff / one-shot drain, in prod for pool slots since #5250) does exactly the right thing — it was just gated to pool slots. This change:

1. **Widens `governs`** by one predicate: `pool_managed || isNamedSessionBead`, minus manual seats (a human's own session is never an orchestration slot) — no new framework. Dependency-only slots stay covered: a dependency floor is a pool slot by construction (`ensureDependencyOnlyTemplate` is the only setter of the flag and always builds pool-slot identity), so excluding it would have silently removed coverage this lane has had since #5250 rather than narrowing the new named arm.
2. **Nudge-before-drain:** the execution lane's `content` now falls back to the shared `defaultPoolClaimNudge` (mirroring the claim lane), so a stalled seat with no configured `[agent] nudge` is *nudged* ("Run gc hook --claim …") before any drain — instead of today's straight-to-drain on empty content. **This reaches every governed seat, pool slots included, not only named ones:** a pool slot that configures no nudge previously drained at the end of the 90s grace and now takes the same bounded nudge→backoff path (~8–11 min) the configured-nudge population already takes, so claim-release latency for that population increases fleetwide. That is the intended trade — the confirmed cause is that these seats RESUME once nudged, so the SDK must deliver a nudge before tearing a session down.
3. **Working-seat guards** (the only "heavy" bits kept, to bound blast radius), which likewise reach **every** governed seat, not only named ones: `IsAttached` HOLD (never act under a human's hands — attached pool slots now HOLD where they were previously nudged/drained under the operator's hands) + a **bounded** activity decay (renewed provider output re-arms the pacing window so a slow-but-producing interactive seat is never force-drained, capped at 6 consecutive re-arms per claim so the seat still converges).

**Deliberately NOT built** (confirmed over-engineering for a nudge-resumable stall): release-preserved-claim override, cross-incarnation terminal bound, the kickoff-nudge consumer (tracked as ga-26jnu, below).

## Why the decay is bounded

The decay's evidence is the runtime's activity clock, and that clock is not a clean "the agent is working" signal: tmux records each poke and discounts it (`recordPoke`/`discountPokeActivity`) but is the **only** provider that does — on t3bridge the delivered nudge *is* a thread message, so it advances `threadUpdatedAt` past the very attempt it was reserved for, and a repainting spinner or menu has the same shape. Unbounded, such a seat re-arms on the echo of its own nudge forever and never reaches the drain — the only thing that releases the claim it holds. The persisted per-claim re-arm budget (`execution_claim_nudge_decays`, cap 6) buys a genuinely human-paced seat a long leash (~18 min of decay) and then hands the seat back to the ordinary ladder, so **every governed seat converges on every provider**, inside roughly half an hour.

## Tests

RED-then-GREEN: named seat stalls → nudged → resumes (no drain); attached seat → held, **then nudged once the human detaches**; working-but-quiet seat → attempts decay → not drained; a `governs` taxonomy table (pool slot / named seat / dependency floor covered; manual seat in both spellings excluded); a stalled dependency floor driven end-to-end to the drain; and the convergence row for a provider whose activity clock counts gc's own nudge — the seat re-arms on its own echo, spends the budget, and still drains exactly once. Reviewed sound by a Fable council.

## Known minor follow-ups (non-blocking)
- Cold-drain on an unresolvable agent template now reaches named seats (config drift) — consider HOLD-instead-of-drain for named seats.
- **ga-26jnu** — named seats still have no **pre-claim** backstop: the claim and continuation lanes remain pool-gated and the execution lane only engages once a claim is held `in_progress`, so a seat that parks *before* claiming its routed trigger is still uncovered. The remaining half of the stall class this PR names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
