### PR TITLE
fix(gc): handoff responder hardening and GC_BIN retry assertion (stacked on #6273)

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -1035,7 +1035,7 @@ var recoverManagedBDCommand = func(cityPath string) error {
 	overrides := cityRuntimeEnvMapForCity(cityPath)
 	gcBin, err := resolveProviderLifecycleGCBinary()
 	if err != nil {
-		return fmt.Errorf("resolve invoking gc executable: %w", err)
+		return err
 	}
 	if gcBin != "" {
 		overrides["GC_BIN"] = gcBin

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -130,7 +130,11 @@ func TestBdCommandRunnerForCityCompleteStorageBindingSkipsManagedRetry(t *testin
 	}
 }
 
-func TestBdContextCommandRunnerForCityPinsCanonicalGCBinary(t *testing.T) {
+// TestBdCommandRunnerForCityCompleteBindingPinsCanonicalGCBinary drives
+// bdCommandRunnerForCity's complete-binding arm, which delegates to
+// bdContextCommandRunnerForCity. The managed-retry arm is covered by
+// TestBdCommandRunnerWithManagedRetryPinsCanonicalGCBinaryOnBothEnvArms.
+func TestBdCommandRunnerForCityCompleteBindingPinsCanonicalGCBinary(t *testing.T) {
 	t.Setenv("GC_BIN", "/tmp/stale-gc")
 	cityPath := t.TempDir()
 	bdPath := filepath.Join(t.TempDir(), "bd")
@@ -190,6 +194,95 @@ func TestBeadsCommandRunnerWithContextPinsCanonicalGCBinary(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(out)); got != want {
 		t.Fatalf("child GC_BIN = %q, want canonical %q", got, want)
+	}
+}
+
+// TestBdCommandRunnerWithManagedRetryPinsCanonicalGCBinaryOnBothEnvArms covers
+// the managed-retry arm — the default path for cities without a complete
+// storage binding — which pins GC_BIN twice: once on the initial env and again
+// on the retry env rebuilt after recovery. A real bd shim records the child's
+// GC_BIN on each attempt, so deleting either pin leaves the ambient
+// GC_BIN=/tmp/stale-gc in that attempt's child and reddens this test.
+func TestBdCommandRunnerWithManagedRetryPinsCanonicalGCBinaryOnBothEnvArms(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BIN", "/tmp/stale-gc")
+
+	captured := filepath.Join(t.TempDir(), "gc-bin-per-attempt")
+	bdPath := filepath.Join(t.TempDir(), "bd")
+	// Fail the first attempt the way an unreachable managed server fails,
+	// because that is the only failure shape bdTransportRetryableError matches;
+	// anything else leaves the retry env arm unreached and its assertion vacuous.
+	shim := fmt.Sprintf("#!/bin/sh\n"+
+		"printf '%%s\\n' \"$GC_BIN\" >> %[1]q\n"+
+		"if [ \"$(wc -l < %[1]q)\" -eq 1 ]; then\n"+
+		"echo 'server unreachable at 127.0.0.1:3307' >&2\n"+
+		"exit 17\n"+
+		"fi\n"+
+		"echo ok\n", captured)
+	if err := os.WriteFile(bdPath, []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	gcBin := filepath.Join(t.TempDir(), "gc")
+	if err := os.WriteFile(gcBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	origResolve := resolveInvokingExecutable
+	origRecover := recoverManagedBDCommand
+	origSleep := bdCommandRetrySleep
+	t.Cleanup(func() {
+		resolveInvokingExecutable = origResolve
+		recoverManagedBDCommand = origRecover
+		bdCommandRetrySleep = origSleep
+	})
+	resolveInvokingExecutable = func() (string, error) { return gcBin, nil }
+	recoverCalls := 0
+	recoverManagedBDCommand = func(_ string) error {
+		recoverCalls++
+		return nil
+	}
+	bdCommandRetrySleep = func(time.Duration) {}
+
+	want, err := filepath.EvalSymlinks(gcBin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No scope metadata is written, so scopeHasCompleteStorageBinding is false
+	// and bdCommandRunnerForCity would route here rather than to the
+	// complete-binding delegation.
+	cityPath := t.TempDir()
+	runner := bdCommandRunnerWithManagedRetryErr(cityPath, func(_ string) (map[string]string, error) {
+		return map[string]string{"BD_BIN": bdPath}, nil
+	})
+
+	out, err := runner(cityPath, "bd", "list", "--json")
+	if err != nil {
+		t.Fatalf("managed-retry runner error = %v, want nil after successful retry", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "ok" {
+		t.Fatalf("runner output = %q, want %q", got, "ok")
+	}
+	if recoverCalls != 1 {
+		t.Fatalf("recoverCalls = %d, want 1: the retry env arm must be reached", recoverCalls)
+	}
+
+	data, err := os.ReadFile(captured)
+	if err != nil {
+		t.Fatalf("read captured GC_BIN: %v", err)
+	}
+	attempts := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(attempts) != 2 {
+		t.Fatalf("bd attempts = %d (%q), want 2 (initial env then retry env)", len(attempts), attempts)
+	}
+	for i, got := range attempts {
+		arm := "initial env"
+		if i == 1 {
+			arm = "retry env"
+		}
+		if got != want {
+			t.Errorf("attempt %d (%s) child GC_BIN = %q, want canonical %q", i+1, arm, got, want)
+		}
 	}
 }
 

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -3193,7 +3193,7 @@ func providerLifecycleProcessEnvFromBase(cityPath, provider string, env []string
 	}
 	gcBin, err := resolveProviderLifecycleGCBinary()
 	if err != nil {
-		return nil, fmt.Errorf("resolve invoking gc executable: %w", err)
+		return nil, err
 	}
 	if gcBin != "" {
 		env = pinInvokingGCBinary(env, gcBin)

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -199,6 +199,11 @@ func resolveBdInvokingGCBinary() (string, error) {
 
 // pinBdGCEnvironment replaces ambient GC_BIN with the physical invoking
 // executable before the beads runner merges the child environment.
+//
+// Unlike resolveProviderLifecycleGCBinary this deliberately has no isTestBinary
+// carve-out: production callers of these paths must always pin, and tests
+// reaching them stub resolveInvokingExecutable rather than injecting a fake
+// GC_BIN into the child environment.
 func pinBdGCEnvironment(env map[string]string) error {
 	gcBin, err := resolveBdInvokingGCBinary()
 	if err != nil {

--- a/cmd/gc/cmd_bd_store_bridge.go
+++ b/cmd/gc/cmd_bd_store_bridge.go
@@ -144,7 +144,7 @@ func runBdStoreBridge(op string, args []string, dir, host, port, user string, st
 	// those callbacks to this exact executable so an ambient GC_BIN cannot
 	// cross the city boundary or select a different gc installation.
 	if err := pinBdGCEnvironment(env); err != nil {
-		return fmt.Errorf("resolve invoking gc executable: %w", err)
+		return err
 	}
 	store := beads.NewBdStore(dir, beads.ExecCommandRunnerWithEnv(env))
 	switch op {

--- a/cmd/gc/dolt_handoff_guard_test.go
+++ b/cmd/gc/dolt_handoff_guard_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -184,5 +189,112 @@ func TestCommittedBeadsHandoffOwnsScopeOnlyAfterCommit(t *testing.T) {
 	write("committed", "bd", true)
 	if got, err := committedBeadsHandoffOwnsScope(city); err != nil || !got {
 		t.Fatalf("committed projection = %t, %v", got, err)
+	}
+}
+
+// writeCommittedHandoffJournal writes the durable artifact bd leaves behind
+// once `bd migrate ownership-handoff` commits: the scope's Dolt endpoint now
+// belongs to bd, and every legacy managed-Dolt lifecycle path must refuse it.
+func writeCommittedHandoffJournal(t *testing.T, city string) {
+	t.Helper()
+	var journal handoffProjectionJournal
+	journal.Request.CityRoot, journal.Request.Root = city, city
+	journal.Request.Database, journal.Request.Workspace = "beads", "test"
+	journal.Request.Endpoint.Host, journal.Request.Endpoint.Port = "127.0.0.1", 3307
+	journal.Request.Owner = "legacy-gc"
+	journal.Phase, journal.Owner = "committed", "bd"
+	journal.SnapshotCaptured, journal.MutationOccurred, journal.CommitHookRan = true, true, true
+	setProjectionEligibleSnapshot(t, &journal)
+	journal.Snapshot.TargetPID, journal.Snapshot.TargetBirth = 42, "birth"
+	journal.Snapshot.TargetDataDir = filepath.Join(city, ".beads", "dolt")
+	journal.Snapshot.TargetLaunchID = "0123456789abcdef0123456789abcdef"
+	journal.Snapshot.TargetLaunchConfig = filepath.Join(city, ".beads", "dolt-handoff-"+journal.Snapshot.TargetLaunchID+".yaml")
+	journal.Snapshot.TargetLaunchExecutable = "/usr/local/bin/dolt"
+	body, err := json.Marshal(journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(city, ".beads", "ownership-handoff.json"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// scopeTreeSnapshot lists every path under root with its mode and size. A
+// refusal that "mutates nothing" must leave this identical: no lock file, no
+// runtime state, no repaired publication.
+func scopeTreeSnapshot(t *testing.T, root string) []string {
+	t.Helper()
+	var entries []string
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		entries = append(entries, fmt.Sprintf("%s mode=%v size=%d", rel, info.Mode(), info.Size()))
+		return nil
+	}); err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(entries)
+	return entries
+}
+
+// TestCommittedHandoffRefusesManagedDoltLifecycleWithoutMutation is the
+// responder-side contract bd depends on: once its handoff journal is
+// committed, gc must not start or recover a second managed Dolt for the same
+// scope, and the refusal must not touch the scope on its way out. The other
+// guard tests call the predicates directly; this one goes through the real
+// `gc dolt-state start-managed` front door and the recovery entry point, and
+// proves the whole scope tree is byte-identical afterwards.
+func TestCommittedHandoffRefusesManagedDoltLifecycleWithoutMutation(t *testing.T) {
+	city := handoffGuardTestCity(t)
+	if err := os.Mkdir(filepath.Join(city, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCommittedHandoffJournal(t, city)
+	before := scopeTreeSnapshot(t, city)
+
+	t.Run("start-managed", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := run([]string{"dolt-state", "start-managed", "--city", city, "--host", "127.0.0.1", "--port", "3307", "--user", "root"}, &stdout, &stderr)
+		if code == 0 {
+			t.Fatalf("start-managed exit = 0, want refusal; stdout = %q", stdout.String())
+		}
+		// A committed handoff is provider ownership, so the fence answers with
+		// the canonical refusal rather than a handoff-specific one.
+		if !strings.Contains(stderr.String(), "provider scope ownership") {
+			t.Fatalf("start-managed stderr = %q, want a typed provider-ownership refusal", stderr.String())
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("start-managed stdout = %q, want no lifecycle report", stdout.String())
+		}
+	})
+
+	t.Run("recover-managed", func(t *testing.T) {
+		probed := false
+		_, err := recoverManagedDoltProcessWithOps(city, "127.0.0.1", "3307", "root", "warning", time.Second, managedDoltRecoveryOps{
+			queryProbe: func(string, string, string) error { probed = true; return nil },
+			start: func(string, string, string, string, string, time.Duration) (managedDoltStartReport, error) {
+				t.Error("recovery started managed Dolt on a committed handoff scope")
+				return managedDoltStartReport{}, nil
+			},
+		})
+		if err == nil || !strings.Contains(err.Error(), "provider scope ownership") {
+			t.Fatalf("recover error = %v, want a typed provider-ownership refusal", err)
+		}
+		if probed {
+			t.Fatal("recovery probed the endpoint on a committed handoff scope")
+		}
+	})
+
+	if after := scopeTreeSnapshot(t, city); !slices.Equal(before, after) {
+		t.Fatalf("refusal mutated the scope:\nbefore = %v\nafter  = %v", before, after)
 	}
 }

--- a/cmd/gc/dolt_handoff_test.go
+++ b/cmd/gc/dolt_handoff_test.go
@@ -41,6 +41,32 @@ func TestHandoffStartTimeTicksRejectsSignedOverflow(t *testing.T) {
 	}
 }
 
+// TestHandoffPhysicalExistingPathRetainsEvalSymlinksSpelling pins the one
+// place handoff identity must not use normalizePathForCompare: that helper
+// collapses host aliases, and bd validates the identity paths against its own
+// strict request root, which is the physical spelling.
+func TestHandoffPhysicalExistingPathRetainsEvalSymlinksSpelling(t *testing.T) {
+	physical := t.TempDir()
+	link := filepath.Join(t.TempDir(), "city")
+	if err := os.Symlink(physical, link); err != nil {
+		t.Fatal(err)
+	}
+	got, err := handoffPhysicalExistingPath(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Clean(want) {
+		t.Fatalf("physical handoff path = %q, want EvalSymlinks spelling %q", got, want)
+	}
+	if _, err := handoffPhysicalExistingPath(filepath.Join(physical, "absent")); err == nil {
+		t.Fatal("missing path resolved; want an error so identity never names a path that is not there")
+	}
+}
+
 func handoffTestArgs(operation, city string) []string {
 	return []string{
 		"dolt-state", operation, "--json", "--city", city, "--scope-root", city,

--- a/cmd/gc/store_target_exec.go
+++ b/cmd/gc/store_target_exec.go
@@ -83,7 +83,7 @@ func gcExecStoreEnv(cityPath string, target execStoreTarget, provider string) (m
 	if execProviderUsesCanonicalBdScopeFiles(provider) {
 		gcBin, err := resolveProviderLifecycleGCBinary()
 		if err != nil {
-			return nil, fmt.Errorf("resolve invoking gc executable: %w", err)
+			return nil, err
 		}
 		if gcBin != "" {
 			env["GC_BIN"] = gcBin


### PR DESCRIPTION
Stacked on #6273 (`feat/beads-proxied-default-rc2`). Three commits, +241/-5, all in `cmd/gc`.

## Inert on rc.2

Nothing here changes runtime behaviour for a user on the pinned beads v1.3.0-rc.2.

- `bd migrate ownership-handoff` (beads #6281/#6297) is **not** in rc.2, so nothing writes `.beads/ownership-handoff.json` and the managed-Dolt handoff fence never fires in practice.
- The GC responder (`gc dolt-state handoff-inspect|handoff-stop`) is hidden, and this PR does not change it.
- The only non-test production change is an error-message narrowing (four sites stop double-prefixing `resolve invoking gc executable:`).

## What it adds

### 1. `cb5b3345dd` from #6041, cherry-picked with `-x`

The maintainer-review fixups for #6041 that never made it onto the consolidated branch (only its first commit, `d7637d1f35`, did).

- `TestBdCommandRunnerWithManagedRetryPinsCanonicalGCBinaryOnBothEnvArms`. The only existing `GC_BIN` pin assertion drove `bdCommandRunnerForCity`'s complete-binding arm, so **both** `pinBdGCEnvironment` calls in `bdCommandRunnerWithManagedRetryErr` — the default path for a city without a complete storage binding — could be deleted with nothing turning red. The new test drives a real bd shim that records the child's `GC_BIN` on each attempt and fails attempt 1 the way an unreachable managed server does, so the retry env arm is actually reached. Original commit verified it by overlay mutation probe (delete either pin, the matching attempt reddens).
- Four call sites re-wrapped `resolve invoking gc executable:` over a resolver that already prefixes it, producing a doubled prefix on the most common failure branch. They return the error bare now, matching the five pin sites that already did.
- Documents why `pinBdGCEnvironment` deliberately has no `isTestBinary` carve-out (the asymmetry with its sibling `resolveProviderLifecycleGCBinary`).

**Conflict:** `cmd/gc/beads_provider_lifecycle.go`. `providerLifecycleProcessEnvFromBase` moved and a socket-target block was inserted into a same-shaped sibling, so git landed the un-wrap hunk on the wrong function ~900 lines away. Resolved by keeping this branch's socket block verbatim and applying the un-wrap at the real `resolveProviderLifecycleGCBinary` call site; the resolution is recorded in the commit message.

### 2. A unit test for `handoffPhysicalExistingPath`

That helper is the deliberate exception to `dolt_handoff.go`'s `normalizePathForCompare` rule: bd validates the identity's `data_dir` and `config_file` against its own strict request root, so those two fields must keep the `EvalSymlinks` spelling rather than a comparison-normalized host alias. It was only exercised indirectly, through `inspectHandoffIdentity`. The test covers the spelling and the missing-path arm. Mutation probe: swapping `EvalSymlinks` for `normalizePathForCompare` reddens it.

### 3. The committed-handoff fence, proved through the real front door

`73f2d7caa8` on #6273 already moved `admitLegacyManagedDoltLifecycle` onto the R1 classification and tests it directly with an un-journaled proxied city. This adds the case bd actually produces — a **committed** `.beads/ownership-handoff.json` — driven through `gc dolt-state start-managed` (via `run()`) and `recoverManagedDoltProcessWithOps`, plus the assertion the responder contract turns on: **the refusal mutates nothing.** A walk of the whole scope tree (path, mode, size) is byte-identical before and after, so the refusal leaves no lock file, no runtime state and no republished endpoint for bd to trip over when it takes the scope.

## Independent finding, deliberately not fixed here

After `73f2d7caa8`, the trailing `return handoffJournalBlocksManagedDoltStart(cityPath)` in `admitLegacyManagedDoltLifecycle` is unreachable-with-effect: `cityScopeProviderOwned` → `providerOwnedScopeState` already consults `committedBeadsHandoffOwnsScope`, so a committed handoff returns `owned=true` (generic message) and a pending/corrupt one returns an error, both before the trailing call.

Consequence: an operator blocked by a committed handoff is pointed at `.gc/scope-ownership.json` and `.beads/metadata.json`, neither of which is the artifact that blocks. Left alone rather than re-opening a council-reviewed decision — worth a follow-up that either names the handoff journal in the refusal or drops the dead call.

## Slice-3 scope note

Slice 3 was scoped as "consolidate #6042 + #6041 + the handoff-guard branch". The guard branch is **already consolidated** on #6273: the whole `codex/terra-gc-handoff-guard` lineage, including WIP `21da4bbd61`, is on the head in a later and better form (its projection file even fixes a `%!w(<nil>)` wrap bug the WIP still carries, and its guard wiring is wider — all seven managed `dolt-state` subcommands plus all three recovery sites). The only content unique to that branch was item 2 above. `codex/terra-gc-handoff-guard` can be retired once this merges.

## Validation

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./cmd/gc/...` | pass |
| `gofmt -l cmd/gc` | clean |
| `go test ./cmd/gc -run 'Handoff\|DoltState\|RecoverManaged\|GCBin\|GC_BIN\|Executable' -count=1` | pass, 16.4s |
| `TestDoltStateHandoffInspectAndStopOwnedProcess` with real `dolt` (2.1.8) on PATH | pass, 4.7s, 3 subtests — **ran, did not skip** |
| `go test ./cmd/gc -count=1 -timeout 35m` | pass, 621.4s |
| `.githooks/pre-commit` per commit | ran, no `--no-verify` |
| `.githooks/pre-push` (all fast jobs, incl. `unit-cmd-gc-{1..6}-of-6` and `unit-core`) | pass |
