### PR TITLE
fix(cmd/gc): resolve claim-time work_branch from the worker checkout, not the shared store

### DIFF
--- a/cmd/gc/cmd_hook_claim.go
+++ b/cmd/gc/cmd_hook_claim.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/executionevent"
+	"github.com/gastownhall/gascity/internal/git"
 )
 
 const hookClaimCommandName = "hook"
@@ -202,11 +204,19 @@ type hookClaimOps struct {
 	// EmitClaimRejected publishes a bead.claim_rejected event when a claim is
 	// lost to a different live claimant (ADR-0009). Best-effort.
 	EmitClaimRejected hookEmitClaimRejectedFunc
-	// ResolveWorkBranch returns the git branch of the worker's worktree (dir),
-	// stamped onto the bead as gc.work_branch at claim time. Empty result (no
-	// repo / detached HEAD) omits the branch key — the session back-reference is
-	// still stamped.
+	// ResolveWorkBranch returns the git branch of the worker's worktree, stamped
+	// onto the bead as gc.work_branch at claim time. It is handed a tree that
+	// already carries the repository it resolved to, so the branch comes from the
+	// repository the store exclusion was decided against. Empty result (no repo /
+	// detached HEAD) omits the branch key — the session back-reference is still
+	// stamped.
 	ResolveWorkBranch hookResolveWorkBranchFunc
+	// ResolveSessionWorkDir returns the checkout the CLAIMING session is running
+	// in, used only as the fallback when the bead records no checkout of its own
+	// (gc-2n4c: a pool-routed bead cannot record one, because no slot is chosen
+	// until this claim). Empty result means nothing is knowable and nothing is
+	// stamped.
+	ResolveSessionWorkDir hookResolveSessionWorkDirFunc
 	// StampWorkMeta writes the claim-time execution-identity metadata patch
 	// (gc.work_branch and/or the durable session back-reference gc.session_id /
 	// gc.session_name) onto the claimed bead in ONE update. Best-effort.
@@ -251,17 +261,18 @@ type hookClaimOps struct {
 }
 
 type (
-	hookClaimFunc              func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
-	hookListContinuationFunc   func(context.Context, string, []string, string, string) ([]beads.Bead, error)
-	hookAssignContinuationFunc func(context.Context, string, []string, string, string) error
-	hookDrainAckFunc           func(io.Writer) error
-	hookDrainPendingFunc       func(sessionID string) (bool, error)
-	hookEmitClaimRejectedFunc  func(beadID, existingClaimant, attemptedClaimant string)
-	hookResolveWorkBranchFunc  func(dir string) string
-	hookStampWorkMetaFunc      func(ctx context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error
-	hookStampSessionClaimFunc  func(sessionID, beadID string) error
-	hookPublishRunMapFunc      func(runID, beadID string, sessionKeys ...string) error
-	hookClaimReleaseFunc       func(ctx context.Context, dir string, env []string, beadID, assignee string) (bool, error)
+	hookClaimFunc                 func(context.Context, string, []string, string, string) (beads.Bead, bool, error)
+	hookListContinuationFunc      func(context.Context, string, []string, string, string) ([]beads.Bead, error)
+	hookAssignContinuationFunc    func(context.Context, string, []string, string, string) error
+	hookDrainAckFunc              func(io.Writer) error
+	hookDrainPendingFunc          func(sessionID string) (bool, error)
+	hookEmitClaimRejectedFunc     func(beadID, existingClaimant, attemptedClaimant string)
+	hookResolveWorkBranchFunc     func(tree hookClaimWorkTree) string
+	hookResolveSessionWorkDirFunc func(sessionID string) string
+	hookStampWorkMetaFunc         func(ctx context.Context, dir string, env []string, beadID, assignee string, patch map[string]string) error
+	hookStampSessionClaimFunc     func(sessionID, beadID string) error
+	hookPublishRunMapFunc         func(runID, beadID string, sessionKeys ...string) error
+	hookClaimReleaseFunc          func(ctx context.Context, dir string, env []string, beadID, assignee string) (bool, error)
 )
 
 type hookClaimJSONResult struct {
@@ -473,6 +484,9 @@ func (ops *hookClaimOps) applyDefaults() {
 	}
 	if ops.ResolveWorkBranch == nil {
 		ops.ResolveWorkBranch = hookResolveWorkBranch
+	}
+	if ops.ResolveSessionWorkDir == nil {
+		ops.ResolveSessionWorkDir = hookResolveSessionWorkDir
 	}
 	if ops.StampWorkMeta == nil {
 		ops.StampWorkMeta = hookStampWorkMetaWithBdStore
@@ -1386,28 +1400,69 @@ func hookClaimLifecycleCandidate(bead beads.Bead, opts hookClaimOptions) bool {
 // (ApplyGraphControlRouteBinding), even when a control-dispatcher session claims one
 // through this same hook path.
 //
-// gc.claimed_at (OBS-001) is a fourth, differently-shaped entry: unlike the three
-// keys above, it is WRITE-ONCE, stamped only when absent from the bead's current
-// metadata and never touched again. A naive claimed_at = now() would differ from
+// It also carries gc.work_dir, but only for a bead that records no checkout under
+// either key and only from the claiming session's own checkout, which is the one
+// case where the bead has named no workspace for the branch to come from. A bead
+// that records a checkout keeps it, even an unusable one, because overwriting the
+// canonical key while the legacy key disagrees is a state worktreeSpecForBead
+// refuses outright.
+//
+// gc.claimed_at (OBS-001) is differently shaped from all of those: it is
+// WRITE-ONCE, stamped only when absent from the bead's current metadata and never
+// touched again. A naive claimed_at = now() would differ from
 // the stored value on every tick by construction and defeat the compare-and-skip
 // protection the rest of this function relies on (see stampHookClaimIdentity's doc
 // comment on the flood-class risk). It is also unconditional across control and
 // non-control beads alike: a claim timestamp answers "when was this claimed",
 // which is meaningful regardless of session identity, so it is not gated on
 // IsControlKind, GC_SESSION_ID, or a resolvable worktree branch the way the other
-// three keys are.
+// keys are.
 //
 // An empty result means every key is already current, so the caller issues no
 // write.
 func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClaimOps, dir string) map[string]string {
 	patch := map[string]string{}
-	if branch := strings.TrimSpace(ops.ResolveWorkBranch(dir)); branch != "" &&
+	sessionID := hookClaimSessionID(opts.Env)
+	isControl := beadmeta.IsControlKind(strings.TrimSpace(bead.Metadata[beadmeta.KindMetadataKey]))
+
+	storeHead := hookClaimResolveStoreHead(dir)
+	trees := hookClaimWorkerTrees(bead, storeHead)
+	// A pool-routed bead records no checkout at all, so fall back to the checkout
+	// of the claiming session (gc-2n4c). Only as a fallback: a recorded value is
+	// the declared intent of the bead and the tree the close gate resolves from,
+	// while the session dir is at best the same tree reached another way. The seam
+	// is nil when a test constructs hookClaimOps directly instead of going through
+	// applyDefaults; like every other identity source here, an unavailable one
+	// stamps nothing rather than guessing a path. The store-dir refusal applies
+	// here too: a rig-scoped session can legitimately be running IN the shared rig
+	// checkout, and that tree is no more the workspace of this bead than it was
+	// when the branch was read from it directly.
+	//
+	// The precondition is hookClaimRecordsNoWorkDir, NOT an empty dirs: those are
+	// different states and only the first one is this fallback's case. A bead whose
+	// recorded checkouts were all EXCLUDED as the store also yields an empty dirs,
+	// and stamping the session dir there would write a canonical gc.work_dir while
+	// the legacy key keeps the store path. worktreeSpecForBead
+	// (pool_desired_state.go) treats a canonical/legacy disagreement as a hard
+	// error, so that write would starve the bead of a session rather than help it;
+	// workDirStampWouldClobberEvidence (pool_slot_workdir.go) refuses the same
+	// manufactured conflict on the reconciler side for the same reason. A bead that
+	// recorded the store under both keys is therefore left alone: it is stamped with
+	// no branch, which is the honest outcome, not repointed at a tree it never named.
+	if hookClaimRecordsNoWorkDir(bead) && sessionID != "" && !isControl && ops.ResolveSessionWorkDir != nil {
+		if sessionDir := strings.TrimSpace(ops.ResolveSessionWorkDir(sessionID)); sessionDir != "" {
+			if tree, admitted := storeHead.Admit(sessionDir); admitted {
+				patch[beadmeta.WorkDirMetadataKey] = sessionDir
+				trees = []hookClaimWorkTree{tree}
+			}
+		}
+	}
+	if branch := hookClaimWorkerBranch(trees, ops.ResolveWorkBranch); branch != "" &&
 		strings.TrimSpace(bead.Metadata[beadmeta.WorkBranchMetadataKey]) != branch &&
 		hookClaimWorktreeEvidenceIsWholeOrAbsent(bead) {
 		patch[beadmeta.WorkBranchMetadataKey] = branch
 	}
-	if sessionID := hookClaimSessionID(opts.Env); sessionID != "" &&
-		!beadmeta.IsControlKind(strings.TrimSpace(bead.Metadata[beadmeta.KindMetadataKey])) {
+	if sessionID != "" && !isControl {
 		if strings.TrimSpace(bead.Metadata[beadmeta.SessionIDMetadataKey]) != sessionID {
 			patch[beadmeta.SessionIDMetadataKey] = sessionID
 		}
@@ -1420,6 +1475,422 @@ func hookClaimIdentityPatch(bead beads.Bead, opts hookClaimOptions, ops hookClai
 		patch[beadmeta.ClaimedAtMetadataKey] = time.Now().UTC().Format(time.RFC3339)
 	}
 	return patch
+}
+
+// hookClaimRecordsNoWorkDir reports whether bead names no work checkout at all,
+// under either the canonical or the legacy key. This is deliberately the RAW
+// question, asked before the store-dir exclusion: a bead that recorded the store
+// HAS named a checkout, it just named an unusable one, and the session fallback
+// must not treat the two cases alike. Stamping a canonical value over a legacy
+// one that disagrees manufactures the conflict worktreeSpecForBead fails closed
+// on.
+func hookClaimRecordsNoWorkDir(bead beads.Bead) bool {
+	for _, key := range []string{beadmeta.WorkDirMetadataKey, beadmeta.LegacyWorkDirMetadataKey} {
+		if strings.TrimSpace(bead.Metadata[key]) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+// hookClaimProbe is what came back from one git query on the claim path. The
+// distinction that matters is not success versus failure but ANSWERED versus NOT
+// ASKED: git reporting that a directory holds no repository is information the
+// exclusion can act on, while a query that never completed is not, and reading the
+// second as the first admits the shared checkout whenever a probe times out or git
+// cannot be run.
+type hookClaimProbe int
+
+const (
+	// hookClaimProbeAnswered means git ran and returned a value.
+	hookClaimProbeAnswered hookClaimProbe = iota
+	// hookClaimProbeAbsent means git ran and reported there is nothing here, which
+	// for repository discovery means no repository covers the directory.
+	hookClaimProbeAbsent
+	// hookClaimProbeUnavailable means the query did not complete, so nothing was
+	// learned either way.
+	hookClaimProbeUnavailable
+)
+
+// hookClaimStoreHead identifies the repository whose HEAD the store checkout would
+// answer a branch read with. It is resolved once per claim so a candidate list does
+// not re-probe the store for every entry.
+//
+// The branch is read by running git inside a candidate, and git answers that read
+// from the repository it discovers, not from the candidate's own path. So the
+// question the exclusion has to ask is whether the candidate would be answered by
+// the STORE's repository. Every earlier shape of this filter asked something about
+// paths instead, and each one left a different way in: a symlinked, relative or
+// bind-mounted spelling of the store; a ".." folded across a symlink, which Clean
+// resolves wrongly; a plain subdirectory of the checkout, which is a different
+// directory by device and inode and still answers with the checkout's branch; and
+// the checkout's own .git directory, which is not under its worktree at all.
+// hookClaimWorkTree is a checkout a branch can be stamped from, together with the
+// repository that answered for it. The pair travels as one value because the two
+// halves have to be the same observation: the exclusion is decided against RepoDir,
+// and resolving the path a second time at the branch read would let the path be
+// repointed in between and stamp a branch out of a repository the exclusion never
+// saw. RepoDir is empty when nothing identified the tree's repository, and a tree
+// with no repository yields no branch.
+type hookClaimWorkTree struct {
+	Dir     string
+	RepoDir string
+}
+
+type hookClaimStoreHead struct {
+	dir string
+	// repoDir is the absolute git directory the store resolves to, and probe says
+	// whether the query that produced it actually answered.
+	repoDir string
+	probe   hookClaimProbe
+}
+
+// hookClaimResolveStoreHead probes storeDir once and returns its identity.
+func hookClaimResolveStoreHead(storeDir string) hookClaimStoreHead {
+	store := strings.TrimSpace(storeDir)
+	head := hookClaimStoreHead{dir: store, probe: hookClaimProbeAbsent}
+	if store == "" {
+		return head
+	}
+	head.repoDir, head.probe = hookClaimHeadRepoDir(store)
+	return head
+}
+
+// Covers reports whether candidate's branch would be read out of the store's
+// repository, which makes it useless as evidence of where this bead's work happened.
+func (s hookClaimStoreHead) Covers(candidate string) bool {
+	_, admitted := s.Admit(candidate)
+	return !admitted
+}
+
+// Admit resolves candidate to the work tree a branch can be read from, and reports
+// whether it is admissible as evidence of this bead's work. A candidate the store
+// covers is refused; an admitted one carries the repository that answered for it, so
+// the branch read later happens against the identity this decision was made
+// against rather than against a path that is resolved a second time.
+func (s hookClaimStoreHead) Admit(candidate string) (hookClaimWorkTree, bool) {
+	cand := strings.TrimSpace(candidate)
+	if cand == "" {
+		return hookClaimWorkTree{}, false
+	}
+	if s.dir == "" {
+		// No store was named, so there is nothing to exclude. The candidate still
+		// has to be identified, because the branch is read from the repository that
+		// answers for it rather than from the path a second time.
+		repo, probe := hookClaimHeadRepoDir(cand)
+		if probe != hookClaimProbeAnswered {
+			return hookClaimWorkTree{Dir: cand}, true
+		}
+		return hookClaimWorkTree{Dir: cand, RepoDir: repo}, true
+	}
+
+	// Two names that clean alike are the same path, which settles the case without
+	// running anything, and settles it for a recorded path that no longer exists
+	// where git can answer nothing at all. It holds only when neither name folds a
+	// "..": filepath.Clean removes a ".." by folding the element before it away,
+	// which names the same directory only when that element is not a symlink, so
+	// "<root>/link/../shared" cleans to "<root>/shared" while actually naming
+	// whatever sits beside the link's target.
+	foldsDotDot := hookClaimPathFoldsDotDot(cand) || hookClaimPathFoldsDotDot(s.dir)
+	if !foldsDotDot && filepath.Clean(cand) == filepath.Clean(s.dir) {
+		return hookClaimWorkTree{}, false
+	}
+
+	candRepo, candProbe := hookClaimHeadRepoDir(cand)
+	switch candProbe {
+	case hookClaimProbeAbsent:
+		// git ran and reported that no repository covers this candidate. Usually
+		// there is nothing to exclude, because the branch read is the same discovery
+		// and will find none either.
+		//
+		// Usually, not always: git declines some questions with the same exit status
+		// it uses for "no repository here". A shared checkout owned by another user
+		// is refused for dubious ownership, an unreadable config is fatal, and in
+		// both cases the store IS a repository that the claiming session simply
+		// cannot ask about. Refusing a candidate that lies inside the store's own
+		// directory covers that, and it is the one comparison that needs no
+		// cooperation from git. It is a refusal only: a directory that answers for
+		// itself never reaches here, so a nested independent checkout and a linked
+		// worktree keep their own identity.
+		//
+		// Both halves of that refusal have to be positive, because this arm ADMITS on
+		// its own judgement and a stamp it hands out is never checked again. A store
+		// whose own repository was never identified clears nothing: there is no
+		// identity to compare against, and a candidate reached from outside the store
+		// directory can still name the store's repository through a .git file or an
+		// administrative directory, which no comparison of paths can see. And
+		// containment has to be SHOWN, not merely not-disproved, so every name this
+		// cannot decide is refused rather than stamped.
+		if s.probe != hookClaimProbeAnswered && hookClaimDirLooksLikeRepo(s.dir) {
+			return hookClaimWorkTree{}, false
+		}
+		if !hookClaimPathOutside(cand, s.dir) {
+			return hookClaimWorkTree{}, false
+		}
+		return hookClaimWorkTree{Dir: cand}, true
+	case hookClaimProbeUnavailable:
+		// The question could not be asked, so which repository answers for this
+		// candidate is unknown while a later branch read may still succeed. Refuse
+		// it. The premise of this change is that the store's branch is worse than no
+		// branch, and that ordering has to hold when the answer is unknown, not only
+		// when it is known.
+		return hookClaimWorkTree{}, false
+	}
+	if s.probe != hookClaimProbeAnswered {
+		// The store's own repository was never identified, so there is nothing to
+		// compare the candidate against, and the same ordering applies. A store that
+		// genuinely holds no repository hands out no branch, so this costs only the
+		// claim-time convenience stamp; the closer still supplies the branch with its
+		// own metadata.
+		return hookClaimWorkTree{}, false
+	}
+	if hookClaimSameDir(candRepo, s.repoDir) {
+		return hookClaimWorkTree{}, false
+	}
+	return hookClaimWorkTree{Dir: cand, RepoDir: candRepo}, true
+}
+
+// hookClaimDirLooksLikeRepo reports whether dir carries a repository on disk, asked
+// without git. It separates the two readings that share one exit status: a directory
+// that holds no repository at all, and a repository git declined to answer for.
+//
+// Only the second one is dangerous. When the store holds a repository that refused to
+// identify itself -- another user owns it, or its config is unreadable -- then every
+// candidate reaching that same repository refuses identically, whether it sits inside
+// the store directory or outside it behind a .git file or an administrative path, and
+// no comparison of paths separates them. Nothing can be cleared in that state. When
+// the store holds no repository, there is no branch to leak and the path comparison
+// is the whole question.
+//
+// A worktree carries .git as a directory or as a file; a bare repository carries HEAD
+// beside objects/.
+func hookClaimDirLooksLikeRepo(dir string) bool {
+	if strings.TrimSpace(dir) == "" {
+		return false
+	}
+	if _, err := os.Lstat(filepath.Join(dir, ".git")); err == nil {
+		return true
+	}
+	if _, err := os.Stat(filepath.Join(dir, "HEAD")); err != nil {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(dir, "objects"))
+	return err == nil && info.IsDir()
+}
+
+// hookClaimPathOutside reports whether child can be SHOWN to name a directory that
+// is neither parent nor inside it. Symlinks are resolved on both sides so an aliased
+// spelling is compared as the directory it reaches; when a name cannot be resolved --
+// a recorded path that no longer exists -- the cleaned names are compared instead.
+//
+// Every reading it cannot establish is false, because the caller admits on true. A
+// relative name is refused because it means nothing without the process directory it
+// was written against, and two names resolved against different directories compare
+// as unrelated, which would read as "outside". A name that folds a ".." is refused
+// because Clean's output does not name the same directory once a symlink precedes
+// the "..", so its comparison would be about a path nobody can reach.
+func hookClaimPathOutside(child, parent string) bool {
+	if !filepath.IsAbs(child) || !filepath.IsAbs(parent) {
+		return false
+	}
+	if hookClaimPathFoldsDotDot(child) || hookClaimPathFoldsDotDot(parent) {
+		return false
+	}
+	resolve := func(path string) string {
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			return resolved
+		}
+		return filepath.Clean(path)
+	}
+	childPath, parentPath := resolve(child), resolve(parent)
+	if childPath == parentPath {
+		return false
+	}
+	rel, err := filepath.Rel(parentPath, childPath)
+	if err != nil {
+		return false
+	}
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// hookClaimHeadRepoDir returns the absolute git directory whose HEAD a branch read
+// inside dir would report, with the probe outcome that produced it.
+//
+// This is hookResolveWorkBranch's own repository discovery asked directly. git
+// climbs to a repository from any depth, resolves symlinked and bind-mounted
+// spellings on the way, gives a LINKED worktree its own directory under the main
+// repository's worktrees/ (so a per-bead worktree cut from the rig checkout keeps
+// its own identity, which this fork depends on), and resolves a .git directory, or
+// anything inside one, to the repository it belongs to. A bare repository resolves
+// to itself and does report a branch, which is why the question is about the
+// repository rather than about the worktree: a worktree comparison misses both the
+// bare case and the .git directory, neither of which is under any worktree.
+func hookClaimHeadRepoDir(dir string) (string, hookClaimProbe) {
+	return hookClaimRunGit(dir, "rev-parse", "--absolute-git-dir")
+}
+
+// hookClaimGitProbeTimeout bounds each git query the claim path runs. Repository
+// discovery reads the filesystem and can block on an unresponsive mount, and no
+// caller deadline covers it: the claim's delivery window is checked before the
+// identity patch is built, and the metadata-write timeout is created after it. It
+// does not bound the claim as a whole, only each query.
+const hookClaimGitProbeTimeout = 5 * time.Second
+
+// hookClaimRunGit runs one git query in dir and returns its single-line output.
+//
+// Both the branch read and the repository probe go through here so the two cannot
+// drift in the environment they run under or the deadline they respect, and they
+// have to agree: the exclusion compares what this answers for a candidate against
+// what it answers for the store. git.SanitizedEnv is the reason the environment
+// matters. git reads GIT_DIR and GIT_WORK_TREE ahead of its own -C argument, a
+// pre-commit hook or nested worktree tooling exports both, and a leaked pair would
+// otherwise point every query in this file at the leaking repository.
+func hookClaimRunGit(dir string, args ...string) (string, hookClaimProbe) {
+	return hookClaimRunGitArgs(append([]string{"-C", dir}, args...))
+}
+
+// hookClaimRunGitDirAt runs one git query against the repository at repoDir by name,
+// from dir. This is how the branch read reaches the repository the exclusion already
+// identified.
+//
+// Both arguments are load-bearing and they do different jobs. --git-dir pins WHICH
+// repository answers, so the read cannot be redirected to a repository the exclusion
+// never saw. -C supplies the directory git runs FROM, because a relative path in the
+// environment -- GIT_CONFIG_GLOBAL is the one that survives the sanitizer -- is
+// resolved against the process directory, and dropping -C silently moved that
+// resolution from the checkout being read to whatever directory the claiming process
+// happened to sit in. git applies -C first and --git-dir second, so the directory
+// never overrides the pin.
+func hookClaimRunGitDirAt(dir, repoDir string, args ...string) (string, hookClaimProbe) {
+	return hookClaimRunGitArgs(append([]string{"-C", dir, "--git-dir=" + repoDir}, args...))
+}
+
+func hookClaimRunGitArgs(args []string) (string, hookClaimProbe) {
+	ctx, cancel := context.WithTimeout(context.Background(), hookClaimGitProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = git.SanitizedEnv()
+	out, err := cmd.Output()
+	return hookClaimClassifyGitOutput(ctx.Err(), err, string(out))
+}
+
+// hookClaimClassifyGitOutput decides what one git query actually established, from
+// the deadline state, the run error, and the output.
+//
+// A nonzero EXIT from a git that ran IS an answer for the queries here: "not a git
+// repository" and "cannot change to <dir>" both mean no repository covers the
+// directory. Exiting is the part that makes it an answer, so the status has to be a
+// real exit status: a process killed by a signal also surfaces as an ExitError while
+// having established nothing, and so does one the context killed, which is why the
+// deadline is checked first and on its own. Anything else, a git that could not be
+// started or output that cannot be used, established nothing either.
+func hookClaimClassifyGitOutput(ctxErr, runErr error, out string) (string, hookClaimProbe) {
+	if ctxErr != nil {
+		return "", hookClaimProbeUnavailable
+	}
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) && exitErr.Exited() {
+			return "", hookClaimProbeAbsent
+		}
+		return "", hookClaimProbeUnavailable
+	}
+	value := strings.TrimSpace(out)
+	if value == "" {
+		return "", hookClaimProbeUnavailable
+	}
+	return value, hookClaimProbeAnswered
+}
+
+// hookClaimSameDir reports whether a and b are one directory. Both are git
+// directories here, so both normally exist and the kernel settles it through device
+// and inode; the name comparison is the answer when one has gone away between
+// resolving it and inspecting it.
+func hookClaimSameDir(a, b string) bool {
+	aInfo, aErr := os.Stat(a)
+	bInfo, bErr := os.Stat(b)
+	if aErr != nil || bErr != nil {
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+	return os.SameFile(aInfo, bInfo)
+}
+
+// hookClaimPathFoldsDotDot reports whether path contains a ".." element, which is
+// what makes filepath.Clean's output unusable as evidence of identity: Clean
+// removes the element by folding the preceding one away, and the result names the
+// same directory only when that preceding element is not a symlink.
+func hookClaimPathFoldsDotDot(path string) bool {
+	for _, element := range strings.Split(filepath.ToSlash(path), "/") {
+		if element == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+// hookClaimWorkerBranch returns the branch of the first tree in trees that resolves
+// to one, or "" when none does. An unusable tree (missing path, no repo, detached
+// HEAD) is skipped like any other, so the order of trees is the authority order.
+func hookClaimWorkerBranch(trees []hookClaimWorkTree, resolve hookResolveWorkBranchFunc) string {
+	if resolve == nil {
+		return ""
+	}
+	for _, tree := range trees {
+		if branch := strings.TrimSpace(resolve(tree)); branch != "" {
+			return branch
+		}
+	}
+	return ""
+}
+
+// hookClaimWorkerTrees returns the checkouts bead records for its own work, most
+// authoritative first: the canonical gc.work_dir, then the legacy work_dir.
+//
+// These are deliberately NOT storeDir, the directory the work query was answered
+// from. Store and workspace are independent inputs a federated claim routinely
+// disagrees on: for a rig-scoped worker the store is the shared rig checkout, a
+// tree the worker never commits to and which sits on whatever branch someone last
+// left it on.
+//
+// The canonical key comes first because it is the one the work-record close gate
+// resolves its repo from (work_record_gate.go), so the branch stamped at claim
+// time and the branch a commit is validated against at close time name the same
+// tree. The legacy key follows because it is not reliably dead data here: this
+// fork's provisioner writes gc.work_dir as the per-bead worktree path it INTENDS,
+// which may never be created, while work_dir still records the tree the worker
+// actually used.
+//
+// store is passed in only to be EXCLUDED, and that exclusion is the whole reason it
+// stays a parameter. It arrives already resolved so the list costs one probe of the
+// store rather than one per candidate. Resolving a branch proves a candidate is
+// WELL-FORMED, not that it is the right tree: skipping candidates that fail to
+// resolve (missing path, detached HEAD, a legacy value written under the old
+// artifact-dir semantics) cannot reject a candidate that is a perfectly good repo
+// which merely IS the store. That case is not hypothetical -- a bead whose
+// gc.work_dir was itself stamped from the shared checkout carries the store path
+// under the canonical key, and without this filter the chain resolves it happily
+// and re-stamps the shared branch. The refusal compares the REPOSITORY a branch
+// read would be answered by rather than the path, so an alias, a plain subdirectory
+// and the checkout's own .git directory are all refused with it, while an
+// independently nested checkout and a linked worktree cut from the same repository,
+// both of which report a branch of their own, are not.
+func hookClaimWorkerTrees(bead beads.Bead, store hookClaimStoreHead) []hookClaimWorkTree {
+	var trees []hookClaimWorkTree
+	for _, key := range []string{beadmeta.WorkDirMetadataKey, beadmeta.LegacyWorkDirMetadataKey} {
+		candidate := strings.TrimSpace(bead.Metadata[key])
+		if candidate == "" {
+			continue
+		}
+		tree, admitted := store.Admit(candidate)
+		if !admitted {
+			continue
+		}
+		if slices.ContainsFunc(trees, func(have hookClaimWorkTree) bool { return have.Dir == tree.Dir }) {
+			continue
+		}
+		trees = append(trees, tree)
+	}
+	return trees
 }
 
 // worktreeOwnershipEvidenceKeys are the eight worktree-ownership metadata
@@ -2047,18 +2518,25 @@ func hookClaimSessionName(env []string) string {
 	return strings.TrimSpace(sessionName)
 }
 
-// hookResolveWorkBranch returns the current git branch of dir, or "" when dir
-// is not a worktree or HEAD is detached (no meaningful branch to stamp).
-func hookResolveWorkBranch(dir string) string {
-	if strings.TrimSpace(dir) == "" {
+// hookResolveWorkBranch returns the current git branch of the work tree, or "" when
+// no repository was identified for it or HEAD is detached (no meaningful branch to
+// stamp).
+//
+// It reads HEAD out of the repository the tree already resolved to, by name, rather
+// than discovering a repository from the path again. The exclusion that admitted
+// this tree was decided against that repository; rediscovering it here would be a
+// second answer to the same question, and a path repointed between the two answers
+// would stamp a branch out of a repository nothing checked.
+//
+// It shares one runner with the repository probe, which keeps both queries under one
+// environment and one deadline.
+func hookResolveWorkBranch(tree hookClaimWorkTree) string {
+	repoDir := strings.TrimSpace(tree.RepoDir)
+	if repoDir == "" {
 		return ""
 	}
-	out, err := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
-	if err != nil {
-		return ""
-	}
-	branch := strings.TrimSpace(string(out))
-	if branch == "HEAD" { // detached HEAD
+	branch, probe := hookClaimRunGitDirAt(tree.Dir, repoDir, "rev-parse", "--abbrev-ref", "HEAD")
+	if probe != hookClaimProbeAnswered || branch == "HEAD" { // unresolvable, or detached
 		return ""
 	}
 	return branch

--- a/cmd/gc/cmd_hook_claim_claimed_at_test.go
+++ b/cmd/gc/cmd_hook_claim_claimed_at_test.go
@@ -12,7 +12,7 @@ import (
 // hookClaimIdentityPatch directly: no worktree, no session-identity plumbing
 // beyond what the patch function itself reads.
 func claimedAtNoWorktreeOps() hookClaimOps {
-	return hookClaimOps{ResolveWorkBranch: func(string) string { return "" }}
+	return hookClaimOps{ResolveWorkBranch: func(hookClaimWorkTree) string { return "" }}
 }
 
 // requireRecentRFC3339 fails the test unless raw parses as RFC3339 and lands
@@ -135,13 +135,14 @@ func TestHookClaimIdentityPatchClaimedAtWithoutSessionOrWorktree(t *testing.T) {
 func TestHookClaimIdentityPatchClaimedAtDoesNotDisturbExistingKeys(t *testing.T) {
 	bead := beads.Bead{ID: "hw-mixed", Status: "open", Metadata: map[string]string{
 		beadmeta.KindMetadataKey:        "worker",
+		beadmeta.WorkDirMetadataKey:     poolClaimWorkerDir,
 		beadmeta.WorkBranchMetadataKey:  "bd-old",
 		beadmeta.SessionIDMetadataKey:   "mc-sess1",
 		beadmeta.SessionNameMetadataKey: "gc__role-mc-sess1",
 		beadmeta.ClaimedAtMetadataKey:   "2026-01-01T00:00:00Z",
 	}}
 	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1", "GC_SESSION_NAME=gc__role-mc-sess1"}}
-	ops := hookClaimOps{ResolveWorkBranch: func(string) string { return "bd-new" }}
+	ops := hookClaimOps{ResolveWorkBranch: func(hookClaimWorkTree) string { return "bd-new" }}
 
 	patch := hookClaimIdentityPatch(bead, opts, ops, "/tmp/work")
 

--- a/cmd/gc/cmd_hook_claim_runid_test.go
+++ b/cmd/gc/cmd_hook_claim_runid_test.go
@@ -36,7 +36,7 @@ func claimOpsForRunMap(beadID string, claimedMeta map[string]string, spy *publis
 		Claim: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, bool, error) {
 			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Metadata: claimedMeta}, true, nil
 		},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		StampWorkMeta:     noopStampWorkMeta,
 		ReadWorkMeta: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, error) {
 			meta := map[string]string{}

--- a/cmd/gc/cmd_hook_claim_stamp_test.go
+++ b/cmd/gc/cmd_hook_claim_stamp_test.go
@@ -101,16 +101,29 @@ func popClaimedAt(t *testing.T, patch map[string]string) map[string]string {
 	return rest
 }
 
+// poolClaimWorkerDir is the checkout a pool slot's bead records as its own. It
+// is deliberately NOT the store dir these tests pass to doHookClaim ("/tmp/work"):
+// gc.work_branch is resolved from the checkouts the bead records, never from the
+// directory the work query was answered from (gc-j4sr), so a bead with no
+// recorded checkout is stamped with no branch at all.
+const poolClaimWorkerDir = "/worktrees/pool-worker"
+
 // poolClaimOps builds the seam for a pool slot claiming an unassigned,
 // route-matched candidate: the runner yields it, Claim returns it owned by us,
 // the branch resolver returns branch, and StampWorkMeta is captured by spy.
+//
+// The claimed bead is given poolClaimWorkerDir as its gc.work_dir unless the
+// caller set one, so the branch resolver has a worker checkout to answer for.
 func poolClaimOps(runner string, claimedMeta map[string]string, branch string, spy *stampMetaSpy) hookClaimOps {
+	if _, ok := claimedMeta[beadmeta.WorkDirMetadataKey]; !ok {
+		claimedMeta[beadmeta.WorkDirMetadataKey] = poolClaimWorkerDir
+	}
 	return hookClaimOps{
 		Runner: func(string, string) (string, error) { return runner, nil },
 		Claim: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, bool, error) {
 			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Metadata: claimedMeta}, true, nil
 		},
-		ResolveWorkBranch: func(string) string { return branch },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return branch },
 		StampWorkMeta:     spy.fn,
 		ReadWorkMeta: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, error) {
 			meta := map[string]string{}
@@ -187,7 +200,7 @@ func TestDoHookClaimStampsSessionIdentityOnAdoption(t *testing.T) {
 			t.Error("Claim must not be called on the existing-assignment path")
 			return beads.Bead{}, false, nil
 		},
-		ResolveWorkBranch: func(string) string { return "" }, // no worktree
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" }, // no worktree
 		StampWorkMeta:     spy.fn,
 		PublishRunMap:     noopPublishRunMap,
 		StampSessionClaim: noopStampSessionClaim,
@@ -410,7 +423,7 @@ func TestHookClaimIdentityPatchWorkBranchPartialEvidenceGuard(t *testing.T) {
 		beadmeta.WorktreeLifecycleMetadataKey,
 	}
 	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1", "GC_SESSION_NAME=gc__role-mc-sess1"}}
-	ops := hookClaimOps{ResolveWorkBranch: func(string) string { return "bd-new-branch" }}
+	ops := hookClaimOps{ResolveWorkBranch: func(hookClaimWorkTree) string { return "bd-new-branch" }}
 
 	for _, tc := range []struct {
 		name         string
@@ -423,7 +436,10 @@ func TestHookClaimIdentityPatchWorkBranchPartialEvidenceGuard(t *testing.T) {
 		{name: "all_eight_present", presentCount: 8, wantStamped: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			meta := map[string]string{beadmeta.KindMetadataKey: "worker"}
+			meta := map[string]string{
+				beadmeta.KindMetadataKey:    "worker",
+				beadmeta.WorkDirMetadataKey: poolClaimWorkerDir,
+			}
 			for i := 0; i < tc.presentCount; i++ {
 				meta[otherEightKeys[i]] = "present"
 			}
@@ -483,7 +499,7 @@ func TestDoHookClaimAdoptionReconcilesDurableStartedFact(t *testing.T) {
 		Runner: func(string, string) (string, error) {
 			return `[{"id":"gcg-attempt","status":"in_progress","assignee":"gc__role-mc-sess1","metadata":{"gc.routed_to":"worker","gc.root_bead_id":"gcg-run","gc.step_id":"build","gc.session_id":"mc-sess1","gc.session_name":"gc__role-mc-sess1","gc.claimed_at":"2026-01-01T00:00:00Z"}}]`, nil
 		},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		StampWorkMeta:     spy.fn,
 		ReadWorkMeta: func(_ context.Context, _ string, _ []string, id, assignee string) (beads.Bead, error) {
 			return beads.Bead{ID: id, Status: "in_progress", Assignee: assignee, Metadata: meta}, nil
@@ -559,7 +575,7 @@ func TestDoHookClaimStampsCurrentClaimOnAdoption(t *testing.T) {
 						Metadata: map[string]string{"gc.routed_to": "worker"},
 					}, true, nil
 				},
-				ResolveWorkBranch: func(string) string { return "" },
+				ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 				StampWorkMeta:     noopStampWorkMeta,
 				PublishRunMap:     noopPublishRunMap,
 				StampSessionClaim: sessSpy.fn,

--- a/cmd/gc/cmd_hook_claim_turnbound_test.go
+++ b/cmd/gc/cmd_hook_claim_turnbound_test.go
@@ -64,7 +64,7 @@ func (r *turnBoundClaimRecorder) ops(t *testing.T, output string) hookClaimOps {
 		// fences under test never depend on it.
 		PublishRunMap:     func(string, string, ...string) error { return nil },
 		StampWorkMeta:     func(context.Context, string, []string, string, string, map[string]string) error { return nil },
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 	}
 }
 

--- a/cmd/gc/cmd_hook_claim_work_branch_test.go
+++ b/cmd/gc/cmd_hook_claim_work_branch_test.go
@@ -1,0 +1,1147 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beadmeta"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// hookClaimWorkBranchStoreDir is the directory a federated work query was
+// answered from. For a rig-scoped worker this is the SHARED rig checkout, which
+// sits on whatever branch someone last left it on and which the worker never
+// commits to.
+const hookClaimWorkBranchStoreDir = "/rigs/shared-checkout"
+
+// hookClaimBranchByDir builds a ResolveWorkBranch seam that answers per
+// directory, so a case can put the store and the worker checkout on different
+// branches without running git. A directory absent from the map resolves to no
+// branch, which is how a missing path or a detached HEAD presents.
+// hookClaimTreeFor resolves dir the way the claim path does, with no store to
+// exclude, so a case can hand the production resolver the same tree the production
+// caller would hand it. The resolver reads HEAD out of the repository the tree
+// carries, so a case that only had the path would be testing nothing.
+func hookClaimTreeFor(t *testing.T, dir string) hookClaimWorkTree {
+	t.Helper()
+	tree, admitted := (hookClaimStoreHead{}).Admit(dir)
+	if !admitted {
+		t.Fatalf("Admit(%s) refused the directory with no store to exclude", dir)
+	}
+	if tree.RepoDir == "" {
+		t.Fatalf("Admit(%s) identified no repository; the fixture is not a checkout", dir)
+	}
+	return tree
+}
+
+func hookClaimBranchByDir(branches map[string]string) hookResolveWorkBranchFunc {
+	return func(tree hookClaimWorkTree) string { return branches[tree.Dir] }
+}
+
+// TestHookClaimIdentityPatchResolvesWorkerBranchNotStoreBranch pins the rule
+// that gc.work_branch names the tree the WORKER used, never the store directory
+// the claim was answered from (gc-j4sr).
+//
+// The cases deliberately include two where the recorded checkout is a perfectly
+// valid repo that merely happens to BE the store: a chain that only rejects
+// MALFORMED candidates (missing path, detached HEAD) passes those while still
+// stamping the shared branch, which is the live gc-ber59 shape.
+func TestHookClaimIdentityPatchResolvesWorkerBranchNotStoreBranch(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		metadata map[string]string
+		branches map[string]string
+		want     string // expected gc.work_branch; "" means the key must be absent
+	}{
+		{
+			name:     "worker checkout on its own branch is stamped, not the store branch",
+			metadata: map[string]string{beadmeta.WorkDirMetadataKey: "/worktrees/worker-1"},
+			branches: map[string]string{
+				hookClaimWorkBranchStoreDir: "someone-elses-branch",
+				"/worktrees/worker-1":       "bd-gc-worker",
+			},
+			want: "bd-gc-worker",
+		},
+		{
+			name:     "no recorded checkout leaves the key unset rather than inferring from the store",
+			metadata: map[string]string{},
+			branches: map[string]string{hookClaimWorkBranchStoreDir: "someone-elses-branch"},
+			want:     "",
+		},
+		{
+			name:     "canonical work dir that IS the store dir is refused",
+			metadata: map[string]string{beadmeta.WorkDirMetadataKey: hookClaimWorkBranchStoreDir},
+			branches: map[string]string{hookClaimWorkBranchStoreDir: "someone-elses-branch"},
+			want:     "",
+		},
+		{
+			name: "legacy work dir recovers the branch when the canonical key does not resolve",
+			metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       "/worktrees/never-created",
+				beadmeta.LegacyWorkDirMetadataKey: "/worktrees/worker-2",
+			},
+			branches: map[string]string{
+				hookClaimWorkBranchStoreDir: "someone-elses-branch",
+				"/worktrees/worker-2":       "bd-gc-legacy",
+			},
+			want: "bd-gc-legacy",
+		},
+		{
+			name: "legacy work dir that IS the store dir is refused too",
+			metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:       "/worktrees/never-created",
+				beadmeta.LegacyWorkDirMetadataKey: hookClaimWorkBranchStoreDir,
+			},
+			branches: map[string]string{hookClaimWorkBranchStoreDir: "someone-elses-branch"},
+			want:     "",
+		},
+		{
+			name: "a trailing separator does not smuggle the store dir past the refusal",
+			metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey: hookClaimWorkBranchStoreDir + "/",
+			},
+			branches: map[string]string{
+				hookClaimWorkBranchStoreDir:       "someone-elses-branch",
+				hookClaimWorkBranchStoreDir + "/": "someone-elses-branch",
+			},
+			want: "",
+		},
+		{
+			name: "a branch already current issues no write",
+			metadata: map[string]string{
+				beadmeta.WorkDirMetadataKey:    "/worktrees/worker-1",
+				beadmeta.WorkBranchMetadataKey: "bd-gc-worker",
+			},
+			branches: map[string]string{"/worktrees/worker-1": "bd-gc-worker"},
+			want:     "",
+		},
+	} {
+		// Every case runs twice. "session fallback unwired" is the isolated
+		// predicate. "session fallback wired" is PRODUCTION: applyDefaults always
+		// installs ResolveSessionWorkDir and a claiming session always exports
+		// GC_SESSION_ID, so a case that leaves both unset cannot reach the fallback
+		// at all and therefore cannot say anything about the shipped path.
+		//
+		// What the wired arm adds here is reachability, not discrimination. Only the
+		// no-recorded-checkout case actually enters the fallback, and the
+		// store-excluded cases do not fail under a wrong precondition through this
+		// table, because their branch fixtures hold no entry for the session dir and
+		// their legacy key is empty. The two shapes that do discriminate have their
+		// own tests below: TestHookClaimIdentityPatchDoesNotManufactureWorkDirConflict
+		// for a bead recording the store under both keys, and
+		// TestHookClaimIdentityPatchLeavesACanonicalOnlyStoreAlone for the canonical
+		// key alone. Keep both; this table does not cover them.
+		for _, arm := range []struct {
+			name string
+			opts hookClaimOptions
+			ops  func(hookClaimOps) hookClaimOps
+		}{
+			{
+				name: "session fallback unwired",
+				opts: hookClaimOptions{},
+				ops:  func(o hookClaimOps) hookClaimOps { return o },
+			},
+			{
+				name: "session fallback wired (production shape)",
+				opts: hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1"}},
+				ops: func(o hookClaimOps) hookClaimOps {
+					o.ResolveSessionWorkDir = func(string) string { return hookClaimWorkBranchSessionDir }
+					return o
+				},
+			},
+		} {
+			t.Run(tc.name+"/"+arm.name, func(t *testing.T) {
+				bead := beads.Bead{ID: "gc-work-1", Metadata: beads.StringMap{}}
+				for k, v := range tc.metadata {
+					bead.Metadata[k] = v
+				}
+				ops := arm.ops(hookClaimOps{ResolveWorkBranch: hookClaimBranchByDir(tc.branches)})
+
+				patch := hookClaimIdentityPatch(bead, arm.opts, ops, hookClaimWorkBranchStoreDir)
+
+				// The branch verdict must not depend on whether the fallback is
+				// available: the fallback exists for a bead that recorded NO
+				// checkout, and every case here records one.
+				got, ok := patch[beadmeta.WorkBranchMetadataKey]
+				switch {
+				case tc.want == "" && ok:
+					t.Errorf("stamped gc.work_branch=%q; expected no stamp. A branch resolved from %q is the shared rig checkout, not this worker's tree, and stamping it makes the close gate validate unrelated commits.",
+						got, hookClaimWorkBranchStoreDir)
+				case tc.want != "" && !ok:
+					t.Errorf("no gc.work_branch stamped; expected %q resolved from the bead's own recorded checkout", tc.want)
+				case tc.want != "" && got != tc.want:
+					t.Errorf("gc.work_branch = %q; want %q", got, tc.want)
+				}
+
+				// And it must never manufacture a canonical/legacy disagreement:
+				// worktreeSpecForBead treats that as a hard error and the bead is
+				// then starved of a session entirely.
+				assertNoWorkDirConflict(t, bead, patch)
+			})
+		}
+	}
+}
+
+// hookClaimWorkBranchSessionDir is the checkout the claiming session reports. It
+// is neither the store nor any tree a case records, so a stamp of this value is
+// unambiguously the session fallback having fired.
+const hookClaimWorkBranchSessionDir = "/worktrees/claiming-session"
+
+// assertNoWorkDirConflict fails when applying patch to bead would leave the
+// canonical and legacy work-dir keys naming different trees. That combination is
+// not merely untidy: worktreeSpecForBead (pool_desired_state.go) returns an error
+// for it rather than picking a side, which surfaces as a pool trigger refusal and
+// leaves the bead without a session. workDirStampWouldClobberEvidence refuses to
+// create the same shape on the reconciler side.
+func assertNoWorkDirConflict(t *testing.T, bead beads.Bead, patch map[string]string) {
+	t.Helper()
+	conflict := func(canonical, legacy string) bool {
+		canonical, legacy = strings.TrimSpace(canonical), strings.TrimSpace(legacy)
+		return canonical != "" && legacy != "" && canonical != legacy
+	}
+	effective := func(key string) string {
+		if v, ok := patch[key]; ok {
+			return v
+		}
+		return bead.Metadata[key]
+	}
+	// Only a conflict the PATCH introduces is a defect. Some fixtures hand in a
+	// bead that already disagrees with itself (a canonical path that was never
+	// created alongside a real legacy tree), and reporting that would be blaming
+	// the patch for its input.
+	before := conflict(bead.Metadata[beadmeta.WorkDirMetadataKey], bead.Metadata[beadmeta.LegacyWorkDirMetadataKey])
+	after := conflict(effective(beadmeta.WorkDirMetadataKey), effective(beadmeta.LegacyWorkDirMetadataKey))
+	if !before && after {
+		t.Errorf("patch manufactures a work-dir conflict: %s=%q vs %s=%q. worktreeSpecForBead hard-errors on this and the bead never gets a session.",
+			beadmeta.WorkDirMetadataKey, effective(beadmeta.WorkDirMetadataKey),
+			beadmeta.LegacyWorkDirMetadataKey, effective(beadmeta.LegacyWorkDirMetadataKey))
+	}
+}
+
+// TestHookClaimIdentityPatchDoesNotManufactureWorkDirConflict is the regression
+// for the case the candidate-list-empty precondition got wrong. A bead that
+// recorded the store under BOTH keys has named a checkout; it merely named an
+// unusable one. Gating the session fallback on the post-exclusion candidate list
+// being empty treats that bead as if it had recorded nothing, stamps the session
+// dir over the canonical key, and leaves the legacy key on the store path. The
+// result is the conflict worktreeSpecForBead fails closed on, so the bead is
+// starved rather than helped.
+func TestHookClaimIdentityPatchDoesNotManufactureWorkDirConflict(t *testing.T) {
+	bead := beads.Bead{ID: "gc-work-conflict", Metadata: beads.StringMap{
+		beadmeta.WorkDirMetadataKey:       hookClaimWorkBranchStoreDir,
+		beadmeta.LegacyWorkDirMetadataKey: hookClaimWorkBranchStoreDir,
+	}}
+	ops := hookClaimOps{
+		ResolveWorkBranch:     hookClaimBranchByDir(map[string]string{hookClaimWorkBranchStoreDir: "someone-elses-branch"}),
+		ResolveSessionWorkDir: func(string) string { return hookClaimWorkBranchSessionDir },
+	}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1"}}
+
+	patch := hookClaimIdentityPatch(bead, opts, ops, hookClaimWorkBranchStoreDir)
+
+	if got, ok := patch[beadmeta.WorkDirMetadataKey]; ok {
+		t.Errorf("stamped %s=%q over a bead that already records a checkout under both keys; the session fallback is for a bead that records NONE",
+			beadmeta.WorkDirMetadataKey, got)
+	}
+	if got, ok := patch[beadmeta.WorkBranchMetadataKey]; ok {
+		t.Errorf("stamped gc.work_branch=%q; the only checkout this bead records is the store, so the honest outcome is no branch", got)
+	}
+	assertNoWorkDirConflict(t, bead, patch)
+}
+
+// TestHookClaimRecordsNoWorkDirAsksTheRawQuestion pins that the fallback
+// precondition is about what the bead RECORDS, not about what survived the
+// store-dir exclusion. The two differ exactly for the bead above, and conflating
+// them is what manufactured the conflict.
+func TestHookClaimRecordsNoWorkDirAsksTheRawQuestion(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		metadata map[string]string
+		want     bool
+	}{
+		{name: "no keys at all", metadata: nil, want: true},
+		{name: "blank values only", metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey:       "   ",
+			beadmeta.LegacyWorkDirMetadataKey: "",
+		}, want: true},
+		{name: "canonical records the store; still a record", metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey: hookClaimWorkBranchStoreDir,
+		}, want: false},
+		{name: "legacy records the store; still a record", metadata: map[string]string{
+			beadmeta.LegacyWorkDirMetadataKey: hookClaimWorkBranchStoreDir,
+		}, want: false},
+		{name: "canonical records a real worker tree", metadata: map[string]string{
+			beadmeta.WorkDirMetadataKey: "/worktrees/worker-7",
+		}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bead := beads.Bead{ID: "gc-raw-1", Metadata: beads.StringMap{}}
+			for k, v := range tc.metadata {
+				bead.Metadata[k] = v
+			}
+			if got := hookClaimRecordsNoWorkDir(bead); got != tc.want {
+				t.Errorf("hookClaimRecordsNoWorkDir = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHookClaimWorkerTreesExcludesTheStore pins the candidate list itself: the
+// store directory is passed in only to be excluded, so the negative predicate
+// stays expressible at the point of decision.
+func TestHookClaimWorkerTreesExcludesTheStore(t *testing.T) {
+	bead := beads.Bead{Metadata: beads.StringMap{
+		beadmeta.WorkDirMetadataKey:       hookClaimWorkBranchStoreDir,
+		beadmeta.LegacyWorkDirMetadataKey: "/worktrees/worker-3",
+	}}
+
+	got := hookClaimWorkerTrees(bead, hookClaimResolveStoreHead(hookClaimWorkBranchStoreDir))
+
+	if len(got) != 1 || got[0].Dir != "/worktrees/worker-3" {
+		t.Fatalf("hookClaimWorkerTrees = %v; want only the non-store checkout %q", got, "/worktrees/worker-3")
+	}
+}
+
+// TestHookClaimWorkerTreesDedupesIdenticalKeys keeps a bead that records the same
+// tree under both keys from producing two identical probes.
+func TestHookClaimWorkerTreesDedupesIdenticalKeys(t *testing.T) {
+	bead := beads.Bead{Metadata: beads.StringMap{
+		beadmeta.WorkDirMetadataKey:       "/worktrees/worker-4",
+		beadmeta.LegacyWorkDirMetadataKey: "/worktrees/worker-4",
+	}}
+
+	if got := hookClaimWorkerTrees(bead, hookClaimResolveStoreHead(hookClaimWorkBranchStoreDir)); len(got) != 1 {
+		t.Fatalf("hookClaimWorkerTrees = %v; want one candidate, the duplicate collapsed", got)
+	}
+}
+
+// TestHookClaimIdentityPatchFallsBackToSessionWorkDir covers gc-2n4c: a
+// pool-routed bead records no checkout, because no slot is chosen until the claim
+// happens, so the claim takes the checkout of the claiming session and stamps
+// BOTH gc.work_dir and the branch resolved from it in the same patch.
+func TestHookClaimIdentityPatchFallsBackToSessionWorkDir(t *testing.T) {
+	bead := beads.Bead{ID: "hw-pool-routed", Metadata: beads.StringMap{}}
+	ops := hookClaimOps{
+		ResolveWorkBranch:     hookClaimBranchByDir(map[string]string{"/worktrees/sess-1": "bd-from-session"}),
+		ResolveSessionWorkDir: func(string) string { return "/worktrees/sess-1" },
+	}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1"}}
+
+	patch := hookClaimIdentityPatch(bead, opts, ops, hookClaimWorkBranchStoreDir)
+
+	if got := patch[beadmeta.WorkDirMetadataKey]; got != "/worktrees/sess-1" {
+		t.Errorf("gc.work_dir = %q; want the checkout of the claiming session", got)
+	}
+	if got := patch[beadmeta.WorkBranchMetadataKey]; got != "bd-from-session" {
+		t.Errorf("gc.work_branch = %q; want bd-from-session resolved from that checkout", got)
+	}
+}
+
+// TestHookClaimIdentityPatchRefusesSessionWorkDirThatIsTheStore pins that the
+// store refusal covers the session fallback too. A rig-scoped session can be
+// running IN the shared rig checkout, and that tree is no more the workspace of
+// this bead than it was when the branch was read from the store directly.
+func TestHookClaimIdentityPatchRefusesSessionWorkDirThatIsTheStore(t *testing.T) {
+	bead := beads.Bead{ID: "hw-rig-scoped", Metadata: beads.StringMap{}}
+	ops := hookClaimOps{
+		ResolveWorkBranch:     hookClaimBranchByDir(map[string]string{hookClaimWorkBranchStoreDir: "someone-elses-branch"}),
+		ResolveSessionWorkDir: func(string) string { return hookClaimWorkBranchStoreDir },
+	}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1"}}
+
+	patch := hookClaimIdentityPatch(bead, opts, ops, hookClaimWorkBranchStoreDir)
+
+	if got, ok := patch[beadmeta.WorkDirMetadataKey]; ok {
+		t.Errorf("stamped gc.work_dir=%q; the shared rig checkout is not a per-bead workspace", got)
+	}
+	if got, ok := patch[beadmeta.WorkBranchMetadataKey]; ok {
+		t.Errorf("stamped gc.work_branch=%q; expected no branch once the store is refused", got)
+	}
+}
+
+// TestHookClaimIdentityPatchPrefersRecordedWorkDirOverSession keeps the session
+// value a FALLBACK rather than a rewrite: a recorded checkout is the declared
+// intent of the bead and the tree the work-record close gate resolves from.
+func TestHookClaimIdentityPatchPrefersRecordedWorkDirOverSession(t *testing.T) {
+	bead := beads.Bead{ID: "hw-recorded", Metadata: beads.StringMap{
+		beadmeta.WorkDirMetadataKey: "/worktrees/recorded",
+	}}
+	ops := hookClaimOps{
+		ResolveWorkBranch: hookClaimBranchByDir(map[string]string{
+			"/worktrees/recorded": "bd-recorded",
+			"/worktrees/sess-1":   "bd-from-session",
+		}),
+		ResolveSessionWorkDir: func(string) string {
+			t.Error("ResolveSessionWorkDir must not be consulted when the bead records a checkout")
+			return "/worktrees/sess-1"
+		},
+	}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1"}}
+
+	patch := hookClaimIdentityPatch(bead, opts, ops, hookClaimWorkBranchStoreDir)
+
+	if got := patch[beadmeta.WorkBranchMetadataKey]; got != "bd-recorded" {
+		t.Errorf("gc.work_branch = %q; want bd-recorded from the checkout the bead records", got)
+	}
+	if _, ok := patch[beadmeta.WorkDirMetadataKey]; ok {
+		t.Error("rewrote gc.work_dir; a recorded checkout must be left alone")
+	}
+}
+
+// TestHookClaimIdentityPatchSkipsSessionFallbackForControlBead holds the
+// control-bead boundary the session back-reference keys already observe: control
+// steps stay session-free by the graphroute design, so a control claim must not
+// acquire a session-derived workspace either.
+func TestHookClaimIdentityPatchSkipsSessionFallbackForControlBead(t *testing.T) {
+	bead := beads.Bead{ID: "hc-check", Metadata: beads.StringMap{beadmeta.KindMetadataKey: "check"}}
+	ops := hookClaimOps{
+		ResolveWorkBranch:     hookClaimBranchByDir(map[string]string{"/worktrees/sess-1": "bd-from-session"}),
+		ResolveSessionWorkDir: func(string) string { return "/worktrees/sess-1" },
+	}
+	opts := hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1"}}
+
+	patch := hookClaimIdentityPatch(bead, opts, ops, hookClaimWorkBranchStoreDir)
+
+	if _, ok := patch[beadmeta.WorkDirMetadataKey]; ok {
+		t.Error("stamped gc.work_dir on a control bead; control steps stay session-free")
+	}
+}
+
+// TestSessionStampableWorkDirRefusesPoolManaged covers gc-j0cfh: the WorkDir of a
+// pool-managed session is the slot label, a directory shared by every bead the
+// slot ever runs, so stamping it would manufacture worktree-ownership evidence
+// for a tree nobody owns.
+func TestSessionStampableWorkDirRefusesPoolManaged(t *testing.T) {
+	pooled := session.Info{PoolManaged: true, WorkDir: "/rigs/worker-slots/worker-3"}
+	if got := sessionStampableWorkDir(pooled); got != "" {
+		t.Errorf("sessionStampableWorkDir(pool-managed) = %q; want empty, a slot label is not a worktree", got)
+	}
+
+	owned := session.Info{WorkDir: "/worktrees/owned-1"}
+	if got := sessionStampableWorkDir(owned); got != "/worktrees/owned-1" {
+		t.Errorf("sessionStampableWorkDir(non-pool) = %q; want the recorded checkout", got)
+	}
+}
+
+// hookClaimFixtureStoreBranch and the branches beside it are what each checkout in
+// the fixture sits on. They all differ so a stamped branch names which tree it came
+// from: the defect under test is the shared branch reaching a bead, and only a
+// distinguishable name can show that it did.
+const (
+	hookClaimFixtureStoreBranch  = "shared-branch"
+	hookClaimFixtureWorkerBranch = "worker-branch"
+	hookClaimFixtureNestedBranch = "nested-branch"
+	hookClaimFixtureLinkedBranch = "linked-branch"
+)
+
+// hookClaimStoreFixture is real filesystem and git state for the store exclusion.
+// Every defect this file pins there exists only below the level of a path string
+// (an alias, an enclosing repository, an administrative directory), so invented
+// paths cannot exhibit any of them, and a predicate that only ever sees invented
+// paths cannot be shown to handle one.
+type hookClaimStoreFixture struct {
+	root    string // holds the store and the worker checkout side by side
+	store   string // the shared checkout, a repository on hookClaimFixtureStoreBranch
+	alias   string // a symlink naming the store
+	worker  string // an independent repository beside the store
+	subdir  string // a plain directory INSIDE the store, no repository of its own
+	gitDir  string // the store's own .git directory
+	objects string // a directory inside the store's .git
+	nested  string // an independent repository inside the store
+	linked  string // a linked worktree cut from the store's repository
+}
+
+// newHookClaimStoreFixture builds that state. Every repository gets a commit, so a
+// branch can actually be read out of it.
+func newHookClaimStoreFixture(t *testing.T) hookClaimStoreFixture {
+	t.Helper()
+	f := hookClaimStoreFixture{root: t.TempDir()}
+	f.store = filepath.Join(f.root, "shared-checkout")
+	f.worker = filepath.Join(f.root, "worker-1")
+	hookClaimInitRepo(t, f.store, hookClaimFixtureStoreBranch)
+	hookClaimInitRepo(t, f.worker, hookClaimFixtureWorkerBranch)
+
+	f.alias = filepath.Join(f.root, "store-by-another-name")
+	if err := os.Symlink(f.store, f.alias); err != nil {
+		t.Skipf("this filesystem does not support symlinks: %v", err)
+	}
+
+	f.subdir = filepath.Join(f.store, "worker-slots", "worker-1")
+	if err := os.MkdirAll(f.subdir, 0o755); err != nil {
+		t.Fatalf("creating a subdirectory of the store: %v", err)
+	}
+	f.gitDir = filepath.Join(f.store, ".git")
+	f.objects = filepath.Join(f.gitDir, "objects")
+	f.nested = filepath.Join(f.store, "nested-checkout")
+	hookClaimInitRepo(t, f.nested, hookClaimFixtureNestedBranch)
+	f.linked = filepath.Join(f.root, "linked-worktree")
+	mustGit(t, f.store, "worktree", "add", "-b", hookClaimFixtureLinkedBranch, f.linked)
+	return f
+}
+
+// hookClaimInitRepo makes dir a repository on branch with one commit, so rev-parse
+// can answer both --absolute-git-dir and --abbrev-ref HEAD from it.
+func hookClaimInitRepo(t *testing.T, dir, branch string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", dir, err)
+	}
+	mustGit(t, "", "-c", "init.defaultBranch="+branch, "init", dir)
+	mustGit(t, dir, "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "fixture")
+}
+
+// TestHookClaimStoreHeadComparesRepositoriesNotPaths covers the ways a candidate's
+// name can disagree with the repository its branch would come from. Each refusal
+// here is a way the exclusion was observed to fail, and each admission is a tree
+// that reports a branch of its own and must keep it.
+//
+// The branch is read by running git inside the candidate, and git answers that read
+// from the repository it discovers, so the comparison is between repositories. That
+// is also why the cases inside the store's own directory land on opposite sides: a
+// subdirectory and the .git directory are both answered by the store, while a
+// nested checkout and a linked worktree answer for themselves.
+func TestHookClaimStoreHeadComparesRepositoriesNotPaths(t *testing.T) {
+	t.Run("refuses every spelling the store answers for", func(t *testing.T) {
+		f := newHookClaimStoreFixture(t)
+		store := hookClaimResolveStoreHead(f.store)
+		for _, tc := range []struct {
+			name      string
+			candidate string
+		}{
+			{"a symlink naming the store", f.alias},
+			{"a plain subdirectory of the store", f.subdir},
+			{"the store's own .git directory", f.gitDir},
+			{"a directory inside the store's .git", f.objects},
+		} {
+			if !store.Covers(tc.candidate) {
+				t.Errorf("%s was admitted; a branch read there is answered by the store, so it re-stamps the shared branch", tc.name)
+			}
+		}
+		// The alias is the one case where direction is meaningful.
+		if !hookClaimResolveStoreHead(f.alias).Covers(f.store) {
+			t.Errorf("the refusal depends on which side carries the alias")
+		}
+	})
+
+	t.Run("admits every tree that answers for itself", func(t *testing.T) {
+		f := newHookClaimStoreFixture(t)
+		store := hookClaimResolveStoreHead(f.store)
+		for _, tc := range []struct {
+			name      string
+			candidate string
+		}{
+			{"a checkout beside the store", f.worker},
+			{"an independent checkout nested inside the store", f.nested},
+			{"a linked worktree cut from the store's repository", f.linked},
+		} {
+			if store.Covers(tc.candidate) {
+				t.Errorf("%s was refused; it reports a branch of its own, and refusing it costs the bead a branch it legitimately had", tc.name)
+			}
+		}
+	})
+
+	t.Run("a relative name for the store is the store", func(t *testing.T) {
+		f := newHookClaimStoreFixture(t)
+		t.Chdir(f.root)
+		if !hookClaimResolveStoreHead(f.store).Covers("shared-checkout") {
+			t.Errorf("a relative spelling of the store was admitted; it resolves to the same directory")
+		}
+	})
+
+	t.Run("a store with no repository refuses a usable candidate", func(t *testing.T) {
+		f := newHookClaimStoreFixture(t)
+		plain := filepath.Join(f.root, "not-a-repository")
+		if err := os.MkdirAll(plain, 0o755); err != nil {
+			t.Fatalf("creating %s: %v", plain, err)
+		}
+		// Nothing can be compared against a store whose repository was never
+		// identified, and the premise of the change is that the store's branch is
+		// worse than no branch, so the refusal holds when the answer is unknown. A
+		// store that genuinely holds no repository hands out no branch either, so
+		// this costs only the claim-time convenience stamp.
+		if !hookClaimResolveStoreHead(plain).Covers(f.worker) {
+			t.Errorf("a candidate was admitted against a store whose repository was never identified")
+		}
+	})
+
+	t.Run("a store whose probe never answered refuses a usable candidate", func(t *testing.T) {
+		f := newHookClaimStoreFixture(t)
+		// The arm a timed-out or unrunnable git lands in. It is reached by state
+		// rather than by a real slow mount, because a deadline cannot be made to
+		// expire on demand here; hookClaimClassifyGitOutput is where the mapping from
+		// a real timeout to this state is pinned.
+		unavailable := hookClaimStoreHead{dir: f.store, probe: hookClaimProbeUnavailable}
+		if !unavailable.Covers(f.worker) {
+			t.Errorf("a candidate was admitted while the store's probe had established nothing")
+		}
+	})
+
+	t.Run("dot-dot across a symlink does not fold to the store", func(t *testing.T) {
+		f := newHookClaimStoreFixture(t)
+
+		// The candidate has to be a path that cleans to the store and really names a
+		// DIFFERENT EXISTING repository. Both halves matter. If it cleans to something
+		// else the lexical shortcut was never in play, and if the real target is not a
+		// repository the case returns early on that instead, which proves nothing
+		// about the fold: the negative reading would be manufactured by a missing
+		// value rather than by the comparison under test.
+		//
+		// So: "hop" is a symlink to <elsewhere>/inner. "<root>/hop/../shared-checkout"
+		// cleans to "<root>/shared-checkout", the store. Followed for real it is
+		// <elsewhere>/inner/.. which is <elsewhere>, then <elsewhere>/shared-checkout,
+		// a checkout that exists and is not the store.
+		elsewhere := t.TempDir()
+		target := filepath.Join(elsewhere, "shared-checkout")
+		hookClaimInitRepo(t, target, "elsewhere-branch")
+		if err := os.MkdirAll(filepath.Join(elsewhere, "inner"), 0o755); err != nil {
+			t.Fatalf("creating the symlink target: %v", err)
+		}
+		hop := filepath.Join(f.root, "hop")
+		if err := os.Symlink(filepath.Join(elsewhere, "inner"), hop); err != nil {
+			t.Skipf("this filesystem does not support symlinks: %v", err)
+		}
+		// Concatenated, not filepath.Join: Join cleans its result and would fold the
+		// ".." away here, handing the predicate the store path itself.
+		candidate := hop + "/../shared-checkout"
+
+		// The fixture's own preconditions, asserted rather than assumed.
+		if got, want := filepath.Clean(candidate), filepath.Clean(f.store); got != want {
+			t.Fatalf("fixture does not exercise the fold: Clean(candidate) = %q, want the store %q", got, want)
+		}
+		candRepo, probe := hookClaimHeadRepoDir(candidate)
+		if probe != hookClaimProbeAnswered {
+			t.Fatalf("fixture candidate resolves no repository; the case would return early and prove nothing about the fold")
+		}
+		if !hookClaimSameDir(candRepo, filepath.Join(target, ".git")) {
+			t.Fatalf("fixture candidate resolves repository %s, not the one at %s", candRepo, target)
+		}
+		if hookClaimSameDir(candRepo, filepath.Join(f.store, ".git")) {
+			t.Fatalf("fixture candidate IS the store's repository; the case cannot distinguish anything")
+		}
+
+		if hookClaimResolveStoreHead(f.store).Covers(candidate) {
+			t.Errorf("a candidate that merely cleans to the store was refused; it names the checkout at %s", target)
+		}
+	})
+}
+
+// TestHookClaimClassifyGitOutputSeparatesAnsweredFromNotAsked pins the distinction
+// the store exclusion rests on. A git that ran and exited nonzero has ANSWERED for
+// the queries here: "not a git repository" and "cannot change to <dir>" both mean no
+// repository covers the directory, and the branch read will fail the same way. A
+// query that never completed has established nothing, and treating it as an answer
+// admits the shared checkout whenever a probe times out or git cannot be run.
+//
+// The deadline has to be checked before the run error, because a query the context
+// kills still surfaces as an ExitError.
+func TestHookClaimClassifyGitOutputSeparatesAnsweredFromNotAsked(t *testing.T) {
+	exitErr := &exec.ExitError{ProcessState: &os.ProcessState{}}
+	startErr := &exec.Error{Name: "git", Err: exec.ErrNotFound}
+
+	for _, tc := range []struct {
+		name      string
+		ctxErr    error
+		runErr    error
+		out       string
+		wantValue string
+		wantProbe hookClaimProbe
+	}{
+		{"a value came back", nil, nil, "/repo/.git\n", "/repo/.git", hookClaimProbeAnswered},
+		{"git ran and reported nothing here", nil, exitErr, "", "", hookClaimProbeAbsent},
+		{"the deadline expired", context.DeadlineExceeded, exitErr, "", "", hookClaimProbeUnavailable},
+		{"the caller canceled", context.Canceled, nil, "/repo/.git\n", "", hookClaimProbeUnavailable},
+		{"git could not be started", nil, startErr, "", "", hookClaimProbeUnavailable},
+		{"git exited cleanly with nothing to say", nil, nil, "  \n", "", hookClaimProbeUnavailable},
+	} {
+		value, probe := hookClaimClassifyGitOutput(tc.ctxErr, tc.runErr, tc.out)
+		if value != tc.wantValue || probe != tc.wantProbe {
+			t.Errorf("%s: got (%q, %v), want (%q, %v)", tc.name, value, probe, tc.wantValue, tc.wantProbe)
+		}
+	}
+}
+
+// TestHookClaimBranchLookupIgnoresALeakedGitDir pins the environment both git
+// queries run under. gc can be invoked from a pre-commit hook or from nested
+// worktree tooling, both of which export GIT_DIR and GIT_WORK_TREE, and git reads
+// those ahead of its own -C argument. A leaked pair would make every query answer
+// about the leaking repository instead of the directory the bead recorded: the
+// resolver would report a branch from a tree the bead never named, and the exclusion
+// would compare that repository against itself and refuse every candidate.
+// internal/git.SanitizedEnv exists for exactly this and documents that callers
+// shelling out to git should assign it; both queries here go through one runner that
+// does.
+func TestHookClaimBranchLookupIgnoresALeakedGitDir(t *testing.T) {
+	f := newHookClaimStoreFixture(t)
+	t.Setenv("GIT_DIR", f.gitDir)
+	t.Setenv("GIT_WORK_TREE", f.store)
+
+	if got := hookResolveWorkBranch(hookClaimTreeFor(t, f.worker)); got != hookClaimFixtureWorkerBranch {
+		t.Errorf("hookResolveWorkBranch read %q from the worker checkout, want %q; a leaked GIT_DIR redirected the lookup at the store",
+			got, hookClaimFixtureWorkerBranch)
+	}
+	store := hookClaimResolveStoreHead(f.store)
+	if store.Covers(f.worker) {
+		t.Errorf("the worker checkout was refused as the store; a leaked GIT_DIR made both sides resolve to the same repository")
+	}
+	if !store.Covers(f.subdir) {
+		t.Errorf("a subdirectory of the store was admitted while GIT_DIR was set; the refusal must not depend on the ambient environment")
+	}
+}
+
+// TestHookClaimWorkerTreesExcludesEverySpellingOfTheStore pins the refusal at the
+// candidate list, not only at the predicate, because the list is what the claim path
+// calls.
+func TestHookClaimWorkerTreesExcludesEverySpellingOfTheStore(t *testing.T) {
+	f := newHookClaimStoreFixture(t)
+	store := hookClaimResolveStoreHead(f.store)
+
+	for _, tc := range []struct {
+		name      string
+		candidate string
+	}{
+		{"an alias of the store", f.alias},
+		{"a subdirectory of the store", f.subdir},
+		{"the store's .git directory", f.gitDir},
+	} {
+		bead := beads.Bead{Metadata: beads.StringMap{beadmeta.WorkDirMetadataKey: tc.candidate}}
+		if trees := hookClaimWorkerTrees(bead, store); len(trees) != 0 {
+			t.Errorf("hookClaimWorkerTrees kept %v for a bead recording %s", trees, tc.name)
+		}
+	}
+
+	recorded := beads.Bead{Metadata: beads.StringMap{beadmeta.WorkDirMetadataKey: f.worker}}
+	trees := hookClaimWorkerTrees(recorded, store)
+	if len(trees) != 1 || trees[0].Dir != f.worker {
+		t.Fatalf("hookClaimWorkerTrees returned %v; a real worker checkout must survive", trees)
+	}
+	if trees[0].RepoDir == "" {
+		t.Errorf("the surviving checkout carries no repository; the branch read has nothing to pin to")
+	}
+}
+
+// TestHookClaimIdentityPatchReadsTheBranchFromTheWorkerNotTheStore drives the whole
+// identity patch with the PRODUCTION branch resolver over real repositories. Every
+// round of this fix was caught one layer below here, against a fake resolver or the
+// predicate alone, and the cases inside the store's own directory survived all of
+// them because a fake resolver cannot reproduce the one behavior that makes them
+// defects: git answers a branch read from the repository it discovers.
+//
+// The arms that expect a branch are the positive control. Without them an empty
+// branch would be indistinguishable from a resolver that answers nothing at all,
+// and the refusals would be unproven.
+func TestHookClaimIdentityPatchReadsTheBranchFromTheWorkerNotTheStore(t *testing.T) {
+	f := newHookClaimStoreFixture(t)
+	ops := hookClaimOps{ResolveWorkBranch: hookResolveWorkBranch}
+
+	for _, tc := range []struct {
+		name       string
+		recorded   string
+		wantBranch string
+	}{
+		{"the store itself", f.store, ""},
+		{"an alias of the store", f.alias, ""},
+		{"a plain subdirectory of the store", f.subdir, ""},
+		{"the store's own .git directory", f.gitDir, ""},
+		{"a directory inside the store's .git", f.objects, ""},
+		{"the worker's own checkout", f.worker, hookClaimFixtureWorkerBranch},
+		{"a checkout nested inside the store", f.nested, hookClaimFixtureNestedBranch},
+		{"a linked worktree of the store's repository", f.linked, hookClaimFixtureLinkedBranch},
+	} {
+		bead := beads.Bead{
+			ID:       "gc-branch-source",
+			Metadata: beads.StringMap{beadmeta.WorkDirMetadataKey: tc.recorded},
+		}
+		patch := hookClaimIdentityPatch(bead, hookClaimOptions{}, ops, f.store)
+		if got := patch[beadmeta.WorkBranchMetadataKey]; got != tc.wantBranch {
+			t.Errorf("a bead recording %s was stamped %s = %q, want %q",
+				tc.name, beadmeta.WorkBranchMetadataKey, got, tc.wantBranch)
+		}
+		assertNoWorkDirConflict(t, bead, patch)
+	}
+}
+
+// TestHookClaimIdentityPatchLeavesACanonicalOnlyStoreAlone covers the case a
+// contributor check found unpinned: a bead naming the store under the canonical key
+// with the legacy key empty. The session fallback must not fire for it, because the
+// bead does record a checkout, it just records an unusable one. Nothing else in the
+// suite fails when the precondition is reverted for this shape.
+func TestHookClaimIdentityPatchLeavesACanonicalOnlyStoreAlone(t *testing.T) {
+	bead := beads.Bead{
+		ID: "gc-canonical-only",
+		Metadata: beads.StringMap{
+			beadmeta.WorkDirMetadataKey: hookClaimWorkBranchStoreDir,
+		},
+	}
+	ops := hookClaimOps{
+		ResolveWorkBranch:     func(hookClaimWorkTree) string { return "" },
+		ResolveSessionWorkDir: func(string) string { return hookClaimWorkBranchSessionDir },
+	}
+	patch := hookClaimIdentityPatch(bead, hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sess1"}}, ops, hookClaimWorkBranchStoreDir)
+
+	if got, ok := patch[beadmeta.WorkDirMetadataKey]; ok {
+		t.Errorf("rewrote %s to %q over a bead that already records a checkout, even though the recorded one is the store",
+			beadmeta.WorkDirMetadataKey, got)
+	}
+	if got := patch[beadmeta.WorkBranchMetadataKey]; got != "" {
+		t.Errorf("stamped %s = %q; the only recorded checkout is the store, so the honest result is no branch",
+			beadmeta.WorkBranchMetadataKey, got)
+	}
+	assertNoWorkDirConflict(t, bead, patch)
+}
+
+// hookClaimFixtureGitFile is a directory OUTSIDE the store whose .git is a file
+// naming the store's git directory, which is how a linked worktree is spelled. git
+// resolves it to the store's own repository and answers the store's branch from it,
+// so it is a candidate that no path comparison can catch: it is not under the store,
+// it is not a symlink to it, and it cleans to a name of its own.
+const hookClaimFixtureGitFile = "worker-by-gitfile"
+
+// hookClaimGitFileToStore builds that candidate and returns its path.
+func hookClaimGitFileToStore(t *testing.T, f hookClaimStoreFixture) string {
+	t.Helper()
+	dir := filepath.Join(f.root, hookClaimFixtureGitFile)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: "+f.gitDir+"\n"), 0o644); err != nil {
+		t.Fatalf("writing the gitfile: %v", err)
+	}
+	repo, probe := hookClaimHeadRepoDir(dir)
+	if probe != hookClaimProbeAnswered || !hookClaimSameDir(repo, f.gitDir) {
+		t.Fatalf("fixture resolves (%q, %v); it has to answer for the store's repository or it proves nothing", repo, probe)
+	}
+	if !hookClaimPathOutside(dir, f.store) {
+		t.Fatalf("fixture does not lie outside the store; the case cannot show what the path comparison misses")
+	}
+	return dir
+}
+
+// hookClaimGitShim puts a fake git first on PATH that runs kill -TERM on itself for
+// the queries matchArg selects, and delegates everything else to the real git. A
+// signal is not a deadline and not an exit status: the process never answers.
+//
+// The shim delegates through an absolute PATH captured before the override, so the
+// test needs no lookup of its own and cannot recurse into itself.
+func hookClaimGitShim(t *testing.T, matchArg string) {
+	t.Helper()
+	realPath := os.Getenv("PATH")
+	bin := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"for a in \"$@\"; do\n" +
+		"  if [ \"$a\" = '" + matchArg + "' ]; then kill -TERM $$; fi\n" +
+		"done\n" +
+		"PATH='" + realPath + "' exec git \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing the git shim: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+realPath)
+}
+
+// hookClaimGitStallShim puts a fake git first on PATH that outlives the probe
+// deadline, so a case can observe a query the context really killed rather than a
+// state a test constructed. It costs one probe timeout of wall clock.
+func hookClaimGitStallShim(t *testing.T) {
+	t.Helper()
+	bin := t.TempDir()
+	script := "#!/bin/sh\nexec sleep " + strconv.Itoa(int(hookClaimGitProbeTimeout.Seconds())*4) + "\n"
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("writing the stalling git shim: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestHookClaimProbeDeadlineIsNotAnAnswer proves the UNAVAILABLE classification from
+// a real subprocess. The table above constructs its error states, which pins the
+// ordering of the branches but cannot show that a query the deadline kills reaches
+// the one that refuses: a killed process surfaces as an ExitError, the same type a
+// git that answered "no repository here" surfaces as.
+func TestHookClaimProbeDeadlineIsNotAnAnswer(t *testing.T) {
+	f := newHookClaimStoreFixture(t)
+	// Resolved before the shim, so the refusal below is attributable to the
+	// candidate's identity being unknown and not to the store's.
+	store := hookClaimResolveStoreHead(f.store)
+	if store.probe != hookClaimProbeAnswered {
+		t.Fatalf("the store probe is %v; this case needs a store that IS identified", store.probe)
+	}
+	hookClaimGitStallShim(t)
+
+	if value, probe := hookClaimHeadRepoDir(f.worker); probe != hookClaimProbeUnavailable {
+		t.Errorf("a probe the deadline killed classified as (%q, %v), want %v", value, probe, hookClaimProbeUnavailable)
+	}
+	if _, admitted := store.Admit(f.worker); admitted {
+		t.Error("admitted a candidate whose identity could not be established; an unknown repository has to be refused")
+	}
+}
+
+// TestHookClaimSignalKilledProbeIsNotAnAnswer pins the difference between a git that
+// ran and reported nothing and a git that never reported. Both surface as an
+// ExitError. Only the first one is an answer.
+//
+// A process killed by a signal has established nothing about which repository covers
+// a directory, and reading that as "no repository here" admits the shared checkout
+// under any spelling no path comparison can catch -- here a directory whose .git file
+// names the store's repository, which is outside the store and answers the store's
+// branch. The session fallback is what makes that costly: it writes the admitted
+// directory onto the bead as the workspace this work happened in.
+//
+// The arm where the probe is NOT killed is the positive control. Without it a refusal
+// would be indistinguishable from a shim that breaks git altogether.
+func TestHookClaimSignalKilledProbeIsNotAnAnswer(t *testing.T) {
+	f := newHookClaimStoreFixture(t)
+	candidate := hookClaimGitFileToStore(t, f)
+	hookClaimGitShim(t, "--absolute-git-dir")
+
+	if _, probe := hookClaimHeadRepoDir(candidate); probe != hookClaimProbeUnavailable {
+		t.Errorf("a signal-killed identity probe classified as %v, want %v", probe, hookClaimProbeUnavailable)
+	}
+	if branch, probe := hookClaimRunGit(f.worker, "rev-parse", "--abbrev-ref", "HEAD"); probe != hookClaimProbeAnswered ||
+		branch != hookClaimFixtureWorkerBranch {
+		t.Fatalf("the shim also broke the queries it was not told to kill: (%q, %v); the refusals below would prove nothing", branch, probe)
+	}
+
+	bead := beads.Bead{ID: "gc-signaled", Metadata: beads.StringMap{}}
+	ops := hookClaimOps{
+		ResolveWorkBranch:     hookResolveWorkBranch,
+		ResolveSessionWorkDir: func(string) string { return candidate },
+	}
+	patch := hookClaimIdentityPatch(bead, hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-sig1"}}, ops, f.store)
+
+	if got, ok := patch[beadmeta.WorkDirMetadataKey]; ok {
+		t.Errorf("stamped %s = %q from a probe that was killed before it answered", beadmeta.WorkDirMetadataKey, got)
+	}
+	if got := patch[beadmeta.WorkBranchMetadataKey]; got != "" {
+		t.Errorf("stamped %s = %q; the candidate resolves the store's repository", beadmeta.WorkBranchMetadataKey, got)
+	}
+	assertNoWorkDirConflict(t, bead, patch)
+}
+
+// TestHookClaimRefusesTheStoreWhenGitDeclinesToAnswer pins the one comparison that
+// needs no cooperation from git.
+//
+// git reports "no repository covers this directory" and "I will not look at this
+// repository" with the same exit status. A shared checkout owned by another user is
+// refused for dubious ownership, which is the common way this happens: the store IS a
+// repository, the claiming session cannot ask about it, and every query inside it
+// fails the same way. Reading that as "no repository" admits the store's own
+// subdirectories, and the session fallback then records one of them as the workspace
+// this bead's work happened in -- the exact false provenance this change exists to
+// stop, reached without a branch ever being read.
+//
+// The fixture asserts git really did refuse, so the case cannot pass by not reaching
+// the condition.
+func TestHookClaimRefusesTheStoreWhenGitDeclinesToAnswer(t *testing.T) {
+	f := newHookClaimStoreFixture(t)
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_TEST_ASSUME_DIFFERENT_OWNER", "1")
+
+	store := hookClaimResolveStoreHead(f.store)
+	if store.probe != hookClaimProbeAbsent {
+		t.Fatalf("the store probe is %v; this case needs git to refuse it with an exit status", store.probe)
+	}
+	if _, probe := hookClaimHeadRepoDir(f.subdir); probe != hookClaimProbeAbsent {
+		t.Fatalf("the subdirectory probe is %v; git has to refuse it the same way", probe)
+	}
+
+	if _, admitted := store.Admit(f.subdir); admitted {
+		t.Errorf("admitted %s, a directory inside the shared checkout, because git declined to identify either one", f.subdir)
+	}
+
+	bead := beads.Bead{ID: "gc-dubious", Metadata: beads.StringMap{}}
+	ops := hookClaimOps{
+		ResolveWorkBranch:     hookResolveWorkBranch,
+		ResolveSessionWorkDir: func(string) string { return f.subdir },
+	}
+	patch := hookClaimIdentityPatch(bead, hookClaimOptions{Env: []string{"GC_SESSION_ID=mc-dub1"}}, ops, f.store)
+	if got, ok := patch[beadmeta.WorkDirMetadataKey]; ok {
+		t.Errorf("stamped %s = %q, a directory inside the shared checkout", beadmeta.WorkDirMetadataKey, got)
+	}
+
+	// Outside the store directory is refused too, and that is not over-reach. A
+	// directory anywhere on disk can reach the store's repository through a .git file
+	// or an administrative path, and under this refusal it reads exactly like an
+	// unrelated directory: both answer ABSENT, and no comparison of paths separates
+	// them. So while the store holds a repository that will not identify itself,
+	// nothing can be cleared.
+	outside := filepath.Join(f.root, "not-in-the-store")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", outside, err)
+	}
+	if _, admitted := store.Admit(outside); admitted {
+		t.Errorf("admitted %s while the store holds a repository git refused to identify; an outside directory can still reach that repository through a .git file", outside)
+	}
+
+	// The refusal is about a repository that declined, not about git being unhappy in
+	// general. A store directory that holds no repository at all has no branch to
+	// leak, so the path comparison is the whole question there and an outside
+	// candidate is still admitted.
+	bare := t.TempDir()
+	plain := hookClaimResolveStoreHead(bare)
+	if plain.probe == hookClaimProbeAnswered {
+		t.Fatalf("the no-repository store probe is %v; this half needs a directory git finds nothing in", plain.probe)
+	}
+	if hookClaimDirLooksLikeRepo(bare) {
+		t.Fatalf("%s carries a repository on disk; the two readings are not separated", bare)
+	}
+	usable := filepath.Join(bare, "..", "usable-checkout")
+	if err := os.MkdirAll(filepath.Clean(usable), 0o755); err != nil {
+		t.Fatalf("creating %s: %v", usable, err)
+	}
+	if _, admitted := plain.Admit(filepath.Clean(usable)); !admitted {
+		t.Errorf("refused %s against a store that holds no repository; there is nothing to protect there", filepath.Clean(usable))
+	}
+}
+
+// TestHookClaimBranchComesFromTheValidatedRepository pins that the branch is read out
+// of the repository the exclusion was decided against, rather than out of whatever
+// the path resolves to when the read happens.
+//
+// Those are two different answers to the same question, and the gap between them is
+// writable: a recorded path can be a symlink, and repointing it at the shared
+// checkout between the two answers stamps the shared branch onto the bead with the
+// refusal having seen a different repository entirely. Reading HEAD from the
+// repository by name closes the gap -- there is no path left to repoint.
+func TestHookClaimBranchComesFromTheValidatedRepository(t *testing.T) {
+	f := newHookClaimStoreFixture(t)
+	workerRepo, probe := hookClaimHeadRepoDir(f.worker)
+	if probe != hookClaimProbeAnswered {
+		t.Fatalf("the worker checkout resolves no repository: %v", probe)
+	}
+
+	t.Run("the repository decides, not the directory", func(t *testing.T) {
+		crossed := hookClaimWorkTree{Dir: f.store, RepoDir: workerRepo}
+		if got := hookResolveWorkBranch(crossed); got != hookClaimFixtureWorkerBranch {
+			t.Errorf("read %q from a tree naming the store with the worker's repository, want %q; the read followed the path",
+				got, hookClaimFixtureWorkerBranch)
+		}
+	})
+
+	t.Run("a tree with no repository yields no branch", func(t *testing.T) {
+		if got := hookResolveWorkBranch(hookClaimWorkTree{Dir: f.worker}); got != "" {
+			t.Errorf("read %q from a tree that identified no repository, want no branch", got)
+		}
+	})
+
+	t.Run("repointing the recorded path after it is admitted does not move the branch", func(t *testing.T) {
+		candidate := filepath.Join(f.root, "moving-worker")
+		if err := os.Symlink(f.worker, candidate); err != nil {
+			t.Skipf("this filesystem does not support symlinks: %v", err)
+		}
+		retargeted := false
+		ops := hookClaimOps{ResolveWorkBranch: func(tree hookClaimWorkTree) string {
+			if !retargeted {
+				if err := os.Remove(candidate); err != nil {
+					t.Fatalf("removing the candidate symlink: %v", err)
+				}
+				if err := os.Symlink(f.store, candidate); err != nil {
+					t.Fatalf("repointing the candidate at the store: %v", err)
+				}
+				retargeted = true
+			}
+			return hookResolveWorkBranch(tree)
+		}}
+		bead := beads.Bead{
+			ID:       "gc-retargeted",
+			Metadata: beads.StringMap{beadmeta.WorkDirMetadataKey: candidate},
+		}
+		patch := hookClaimIdentityPatch(bead, hookClaimOptions{}, ops, f.store)
+		if !retargeted {
+			t.Fatal("the resolver was never called, so nothing was raced")
+		}
+		if branch := hookResolveWorkBranch(hookClaimTreeFor(t, candidate)); branch != hookClaimFixtureStoreBranch {
+			t.Fatalf("after the retarget the candidate resolves %q; the race did not reach the store", branch)
+		}
+		if got := patch[beadmeta.WorkBranchMetadataKey]; got != hookClaimFixtureWorkerBranch {
+			t.Errorf("stamped %s = %q, want %q: the branch was re-resolved from the path after the refusal had cleared a different repository",
+				beadmeta.WorkBranchMetadataKey, got, hookClaimFixtureWorkerBranch)
+		}
+		assertNoWorkDirConflict(t, bead, patch)
+	})
+}
+
+// TestHookClaimRefusesTheCandidatesItCannotCompare pins that the containment check
+// admits only on a reading it established, and refuses everything it could not.
+//
+// The earlier shape asked whether the candidate was inside the store and admitted
+// whenever the answer was not yes. Three readings are not "no": a relative candidate
+// means nothing without the directory it was written against, a relative store gives
+// the comparison two different origins, and a name folding ".." does not name the
+// directory Clean produces once a symlink precedes it. Each of those was measured to
+// pass the old check and take a false workspace stamp while git was declining to
+// identify the store.
+func TestHookClaimRefusesTheCandidatesItCannotCompare(t *testing.T) {
+	f := newHookClaimStoreFixture(t)
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_TEST_ASSUME_DIFFERENT_OWNER", "1")
+
+	store := hookClaimResolveStoreHead(f.store)
+	if store.probe != hookClaimProbeAbsent {
+		t.Fatalf("the store probe is %v; this case needs git to refuse it with an exit status", store.probe)
+	}
+	if !hookClaimDirLooksLikeRepo(f.store) {
+		t.Fatalf("%s does not carry a repository on disk; the refusal would be about the wrong thing", f.store)
+	}
+
+	rel, err := filepath.Rel(f.root, f.subdir)
+	if err != nil {
+		t.Fatalf("relating %s to %s: %v", f.subdir, f.root, err)
+	}
+	dotdot := filepath.Join(f.store, "worker-slots", "..", "worker-slots", "worker-1")
+
+	for _, tc := range []struct {
+		name      string
+		candidate string
+	}{
+		{"a relative candidate naming a directory inside the store", rel},
+		{"a candidate that folds a .. back into the store", dotdot},
+		{"a bare name with no directory at all", "worker-slots"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, admitted := store.Admit(tc.candidate); admitted {
+				t.Errorf("admitted %q; containment was never established for it", tc.candidate)
+			}
+		})
+	}
+
+	// The same asymmetry on the store side: a comparison with two origins is not a
+	// comparison, so it cannot clear a candidate either.
+	relStore := hookClaimStoreHead{dir: "shared-checkout", probe: hookClaimProbeAbsent}
+	if _, admitted := relStore.Admit(f.subdir); admitted {
+		t.Errorf("admitted %s against the relative store name %q", f.subdir, relStore.dir)
+	}
+}
+
+// TestHookClaimPinnedBranchReadKeepsRelativeConfigSemantics pins that naming the
+// repository did not move where git resolves relative paths from.
+//
+// --git-dir alone runs from the claiming process's own directory, and a relative
+// GIT_CONFIG_GLOBAL -- which survives the sanitizer -- is then read out of that
+// directory instead of the checkout being read. A seat whose own directory holds an
+// unreadable config loses every branch stamp, with the failure looking exactly like
+// "this worktree has no branch". The read carries -C as well so the pin chooses the
+// repository and the directory chooses nothing else.
+func TestHookClaimPinnedBranchReadKeepsRelativeConfigSemantics(t *testing.T) {
+	f := newHookClaimStoreFixture(t)
+	elsewhere := t.TempDir()
+	if err := os.WriteFile(filepath.Join(elsewhere, "rel.gitconfig"), []byte("[core]\n\tbare = not-a-boolean\n"), 0o644); err != nil {
+		t.Fatalf("writing the unreadable config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(f.worker, "rel.gitconfig"), []byte("[user]\n\tname = fixture\n"), 0o644); err != nil {
+		t.Fatalf("writing the worker config: %v", err)
+	}
+	t.Chdir(elsewhere)
+	t.Setenv("GIT_CONFIG_GLOBAL", "rel.gitconfig")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	tree := hookClaimTreeFor(t, f.worker)
+	if got := hookResolveWorkBranch(tree); got != hookClaimFixtureWorkerBranch {
+		t.Errorf("branch = %q, want %q; the pinned read resolved its relative config against the process directory", got, hookClaimFixtureWorkerBranch)
+	}
+}

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -722,7 +722,7 @@ func TestDoHookClaimEmitsRejectedOnLostClaim(t *testing.T) {
 		EmitClaimRejected: func(beadID, existing, attempted string) {
 			rejected = append(rejected, rejection{beadID, existing, attempted})
 		},
-		ResolveWorkBranch: func(string) string { return "" }, // suppress stamp noise
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" }, // suppress stamp noise
 	}
 	opts := hookClaimOptions{
 		Assignee:           "worker-1",
@@ -761,9 +761,14 @@ func TestDoHookClaimStampsWorkBranch(t *testing.T) {
 	ops := hookClaimOps{
 		Runner: runner,
 		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
-			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
+			// gc.work_dir is what gc.work_branch is resolved from; the "/tmp/work"
+			// store dir this test passes to doHookClaim is deliberately not it (gc-j4sr).
+			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{
+				"gc.routed_to": "worker",
+				"gc.work_dir":  "/worktrees/hw-stamp",
+			}}, true, nil
 		},
-		ResolveWorkBranch: func(string) string { return "bd-hw-stamp" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "bd-hw-stamp" },
 		StampWorkMeta: func(_ context.Context, _ string, _ []string, beadID, assignee string, patch map[string]string) error {
 			stampedBead, stampedAssignee, stampedBranch = beadID, assignee, patch["gc.work_branch"]
 			return nil
@@ -801,7 +806,7 @@ func TestDoHookClaimSkipsStampWhenBranchUnchanged(t *testing.T) {
 		Claim: func(_ context.Context, _ string, _ []string, beadID, assignee string) (beads.Bead, bool, error) {
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker", "gc.work_branch": "bd-hw-idem", "gc.claimed_at": "2026-01-01T00:00:00Z"}}, true, nil
 		},
-		ResolveWorkBranch: func(string) string { return "bd-hw-idem" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "bd-hw-idem" },
 		StampWorkMeta: func(_ context.Context, _ string, _ []string, _, _ string, _ map[string]string) error {
 			stampCalls++
 			return nil
@@ -1079,8 +1084,8 @@ func TestClaimHookWorkRetriesLaterStoreWhenSelectedStoreLosesClaimRace(t *testin
 			claimDir = dir
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
 		},
-		EmitClaimRejected: func(string, string, string) {},   // suppress event side effect
-		ResolveWorkBranch: func(string) string { return "" }, // suppress stamp noise
+		EmitClaimRejected: func(string, string, string) {},              // suppress event side effect
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" }, // suppress stamp noise
 	}
 	opts := hookClaimOptions{
 		Assignee:           "worker-1",
@@ -1138,7 +1143,7 @@ func TestClaimHookWorkDrainsWhenPrimaryLosesRaceThenFederatedStoreErrors(t *test
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: "worker-2", Metadata: map[string]string{"gc.routed_to": "worker"}}, false, nil
 		},
 		EmitClaimRejected: func(string, string, string) {},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		DrainAck:          func(io.Writer) error { return nil },
 	}
 	opts := hookClaimOptions{
@@ -1202,7 +1207,7 @@ func TestClaimHookWorkUsesFallbackStoreDirEnvAndOutput(t *testing.T) {
 			claimDir, claimEnv = dir, env
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
 		},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 	}
 	opts := hookClaimOptions{
 		Assignee:           "worker-1",
@@ -3088,7 +3093,7 @@ func TestClaimHookWorkDrainsClaimsErroredWhenEveryCandidateErrors(t *testing.T) 
 			return beads.Bead{}, false, fmt.Errorf("claiming %s: store write timeout", beadID)
 		},
 		EmitClaimRejected: func(string, string, string) {},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		DrainAck:          func(io.Writer) error { return nil },
 	}
 	opts := hookClaimOptions{

--- a/cmd/gc/hook_claim_assigned_federation_test.go
+++ b/cmd/gc/hook_claim_assigned_federation_test.go
@@ -73,7 +73,7 @@ func TestClaimHookWorkAssignedTierUnresolvableBeadDoesNotStrandLaterStore(t *tes
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee, Metadata: map[string]string{"gc.routed_to": "worker"}}, true, nil
 		},
 		EmitClaimRejected: func(string, string, string) {},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		DrainAck:          func(io.Writer) error { return nil },
 	}
 
@@ -115,7 +115,7 @@ func TestClaimHookWorkAssignedTierUnresolvableBeadDrainsClaimsErrored(t *testing
 			return beads.Bead{}, false, fmt.Errorf("claiming bead %q: %w", beadID, beads.ErrNotFound)
 		},
 		EmitClaimRejected: func(string, string, string) {},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		DrainAck: func(io.Writer) error {
 			drained = true
 			return nil
@@ -171,7 +171,7 @@ func TestClaimHookWorkAssignedTierOperationalErrorStaysTerminal(t *testing.T) {
 			return beads.Bead{}, false, fmt.Errorf("claiming bead %q: store write timeout", beadID)
 		},
 		EmitClaimRejected: func(string, string, string) {},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		DrainAck:          func(io.Writer) error { return nil },
 	}
 

--- a/cmd/gc/hook_claim_class_fanout_test.go
+++ b/cmd/gc/hook_claim_class_fanout_test.go
@@ -52,7 +52,7 @@ func hookFanoutBaseOps(claim hookClaimFunc) hookClaimOps {
 	return hookClaimOps{
 		Claim:             claim,
 		EmitClaimRejected: func(string, string, string) {},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		DrainAck:          func(io.Writer) error { return nil },
 		StampWorkMeta: func(context.Context, string, []string, string, string, map[string]string) error {
 			return nil

--- a/cmd/gc/hook_claim_failure_honesty_test.go
+++ b/cmd/gc/hook_claim_failure_honesty_test.go
@@ -63,7 +63,7 @@ func (h *failureHookHarness) ops() hookClaimOps {
 			return beads.Bead{ID: beadID, Status: "in_progress", Assignee: assignee}, true, nil
 		},
 		DrainAck:                 func(io.Writer) error { h.drained = true; return nil },
-		ResolveWorkBranch:        func(string) string { return "" },
+		ResolveWorkBranch:        func(hookClaimWorkTree) string { return "" },
 		PublishRunMap:            func(string, string, ...string) error { return nil },
 		EmitExecutionStepStarted: func(beads.Bead, string, []string, string) {},
 		EmitClaimRejected:        func(string, string, string) {},

--- a/cmd/gc/hook_claim_sigpipe_unwind_test.go
+++ b/cmd/gc/hook_claim_sigpipe_unwind_test.go
@@ -68,7 +68,7 @@ func runSigpipeUnwindHelper(mode, markerPath string) {
 		EmitExecutionStepStarted: func(beads.Bead, string, []string, string) {},
 		PublishRunMap:            func(string, string, ...string) error { return nil },
 		StampWorkMeta:            func(context.Context, string, []string, string, string, map[string]string) error { return nil },
-		ResolveWorkBranch:        func(string) string { return "" },
+		ResolveWorkBranch:        func(hookClaimWorkTree) string { return "" },
 	}
 	// os.Stdout, not a buffer: the whole point is the real file descriptor.
 	code := doHookClaim("query", "/rig", hookClaimOptions{

--- a/cmd/gc/hook_session_claim.go
+++ b/cmd/gc/hook_session_claim.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"io"
+	"log"
 	"strings"
 
+	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
@@ -84,4 +86,68 @@ func hookSessionDrainPending(sessionID string) (bool, error) {
 		return false, err
 	}
 	return state == session.StateDraining, nil
+}
+
+// hookResolveSessionWorkDir returns the checkout the session identified by
+// sessionID is running in, or "" when that is not knowable. It is the production
+// implementation of the hookClaimOps.ResolveSessionWorkDir seam.
+//
+// A bead routed to a POOL records no checkout of its own: cliBeadRouter.Route
+// normalizes a pool target through agentutil.NormalizePoolRouteTarget, so
+// gc.routed_to names a pool identity and no slot exists to name a worktree until
+// a claim happens (gc-2n4c). Stamping a work_dir at route time would bind a
+// pool-label path to the bead, which is the gc-j0cfh defect. The claiming session
+// is the first actor that knows the concrete tree, and the session bead is the
+// only place that records it: GC_WORK_DIR is not in the env of a pool session.
+//
+// The id is resolved EXACTLY, for the same reason SetCurrentClaim does: the bd
+// fuzzy resolver would otherwise let a prefix collision hand back the checkout of
+// a different session, and this value is stamped onto the work bead as durable
+// execution identity. Every failure yields "" -- an unset gc.work_dir is the
+// honest outcome, and the caller stamps nothing rather than guessing a path.
+func hookResolveSessionWorkDir(sessionID string) string {
+	if strings.TrimSpace(sessionID) == "" {
+		return ""
+	}
+	sessFront, err := sessionCurrentClaimFrontDoor()
+	if err != nil {
+		// Each failure below returns the same "" as a session that simply has no
+		// stampable checkout, so without naming the step a lookup fault is
+		// indistinguishable in production from the ordinary refusal. The caller
+		// behavior is unchanged; only the diagnosis is.
+		log.Printf("hookResolveSessionWorkDir: opening the session front door for %q: %v; stamping no %s",
+			sessionID, err, beadmeta.WorkDirMetadataKey)
+		return ""
+	}
+	resolved, err := sessFront.ResolveIDByExactID(strings.TrimSpace(sessionID))
+	if err != nil {
+		log.Printf("hookResolveSessionWorkDir: resolving session id %q exactly: %v; stamping no %s",
+			sessionID, err, beadmeta.WorkDirMetadataKey)
+		return ""
+	}
+	info, err := sessFront.Get(resolved)
+	if err != nil {
+		log.Printf("hookResolveSessionWorkDir: reading session bead %q: %v; stamping no %s",
+			resolved, err, beadmeta.WorkDirMetadataKey)
+		return ""
+	}
+	return sessionStampableWorkDir(info)
+}
+
+// sessionStampableWorkDir returns the checkout of info that may be stamped onto a
+// work bead as gc.work_dir, or "" when info has none that qualifies. It is the
+// decidable half of hookResolveSessionWorkDir, split out so the pool refusal is
+// testable without a live city.
+//
+// A POOL-MANAGED session is refused outright: its WorkDir is the slot label
+// (worker-slots/worker-N), a SHARED directory rather than an isolated worktree,
+// so stamping it would turn a slot label into worktree-ownership evidence on the
+// bead (gc-j0cfh). The reconciler side refuses the same value for the same reason
+// (workDirStampHasOwnershipEvidence), and this keeps the claim path from becoming
+// a second way to mint it.
+func sessionStampableWorkDir(info session.Info) string {
+	if info.PoolManaged {
+		return ""
+	}
+	return strings.TrimSpace(info.WorkDir)
 }

--- a/cmd/gc/sling_order_handoff_test.go
+++ b/cmd/gc/sling_order_handoff_test.go
@@ -271,7 +271,7 @@ func (h *handoffFixture) ops() hookClaimOps {
 		ListContinuation: func(context.Context, string, []string, string, string) ([]beads.Bead, error) {
 			return nil, nil
 		},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		PublishRunMap:     func(string, string, ...string) error { return nil },
 		DrainAck:          func(io.Writer) error { h.drainAcked = true; return nil },
 	}

--- a/cmd/gc/split_topology_conformance_test.go
+++ b/cmd/gc/split_topology_conformance_test.go
@@ -2779,7 +2779,7 @@ func conformanceAssignedTierClaimsTheGraphStep(t *testing.T, e splitEnv, assigne
 	ops := classRoutedHookClaimOps(hookClaimOps{
 		Claim:             splitEnvStoreClaim(e.work),
 		EmitClaimRejected: func(string, string, string) {},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		StampWorkMeta: func(context.Context, string, []string, string, string, map[string]string) error {
 			return nil
 		},
@@ -2860,7 +2860,7 @@ func conformanceUnresolvableCandidateStillDoesNotStrandWork(t *testing.T, e spli
 	ops := classRoutedHookClaimOps(hookClaimOps{
 		Claim:             splitEnvStoreClaim(e.work),
 		EmitClaimRejected: func(string, string, string) {},
-		ResolveWorkBranch: func(string) string { return "" },
+		ResolveWorkBranch: func(hookClaimWorkTree) string { return "" },
 		StampWorkMeta: func(context.Context, string, []string, string, string, map[string]string) error {
 			return nil
 		},


### PR DESCRIPTION
## Problem

`gc hook --claim` stamped `gc.work_branch` by running the branch lookup against the directory the work query was answered from. For a rig-scoped worker that directory is the shared rig checkout, a tree the worker never commits to, sitting on whatever branch someone last left it on.

That branch then became the bead's durable execution identity. The work-record close gate validates a shipped commit for reachability on `gc.work_branch`, so it was checking commits against unrelated code: a hard failure when the worker branch genuinely differed, and a pass attesting to the wrong tree when the shared checkout happened to contain the commit.

One verification bead recorded two different branches over its life, each one whatever the shared checkout happened to be on at claim time. A reachability check failed the bead against both.

## Fix

Resolve the branch from the checkouts the bead itself records, most authoritative first: canonical `gc.work_dir`, then the legacy `work_dir`, taking the first that resolves. The canonical key leads because it is the key the close gate resolves its repository from, so the branch stamped at claim time and the branch a commit is validated against at close time name the same tree. The legacy key follows because it is not dead data in this fork. `gc.work_dir` records the per-bead worktree path the system intends, which may never be created, while `work_dir` records the tree the worker actually used. No usable candidate means no stamp.

The store directory stays a parameter specifically so it can be excluded. Resolving a branch proves a candidate is well-formed, not that it is the right tree, so dropping candidates that merely fail to resolve (missing path, not a repository, detached HEAD) cannot reject a candidate that is a perfectly good repository which is itself the store. That case is live. A bead whose `gc.work_dir` was itself stamped from the shared checkout carries the store path under the canonical key, and without the negative filter the chain resolves it happily and re-stamps the shared branch.

Two consequences of the new contract are handled here, because without them a pool-routed bead would record no branch at all:

- A pool-routed bead cannot record a checkout, since the route target is normalized to a pool identity and no slot exists until a claim happens. The claim falls back to the claiming session's checkout, resolved by exact session id so a prefix collision cannot hand back another session's tree, and stamps `gc.work_dir` alongside the branch. The fallback only fills a gap. A bead that records its own checkout keeps it.
- The `WorkDir` of a pool-managed session is the slot label, a directory shared by every bead that slot ever runs, so stamping it would manufacture worktree-ownership evidence for a tree nobody owns. Such a session is refused and the claim waits for the provisioner to record a real per-bead tree. The reconciler already refuses this value for the same reason; this keeps the claim path from becoming a second way to mint it.

A bead left with no branch is not stranded, for three separate reasons:

- The close gate scopes itself off any bead carrying `gc.kind`, which covers every pool and control step bead.
- Enforcement is opt-in and defaults off.
- The gate validates the metadata the closer submits, and nothing in non-test Go writes `gc.work_commit`. Whichever actor supplies the commit supplies the branch in the same call.

An absent branch is also safer than the store's branch, which a reachability check either rejects with a confusing message or accepts while attesting to the wrong tree.

## A live instance of the store-as-canonical-key case

This case is not hypothetical, and the bead tracking this bug is itself an instance of
it. Its recorded `gc.work_dir` is the shared rig checkout, the store directory, while
its legacy `work_dir` holds the actual worktree the fix was written in. Without the
exclusion the candidate chain resolves the canonical key happily, because the store is a
perfectly good repository, and re-stamps the shared checkout's branch. With it, the chain
skips the store, falls through to the legacy key, and resolves the branch from the tree
that did the work.

## One tracked follow-up, not fixed here

The detached-handoff orphan sweep requires a branch before it will restore a bead's pool route, treating the branch as evidence that work was done and pushed. That refusal predates this change and is pinned by an existing test. The branch is used only as that discriminator. The recovery itself resolves the route from the session back-reference and never reads the branch.

Before this change the claim path gave every claimed bead some branch, so that discriminator passed on evidence this code had fabricated. With the fix, a pool-routed bead claimed by a pool-managed session correctly records no branch, and the sweep therefore skips it where it would previously have restored it. That narrows recoverability for one bead class, for a correct reason. What the sweep should require instead is a question about its own evidence contract, not about where the claim reads its branch, so it is filed as #6272. The branch check stays in place meanwhile: it is currently the only thing keeping never-started beads out of the sweep.

## The session fallback keys off what the bead records, not off what survived

The fallback for a pool-routed bead cannot trigger on the candidate list being empty, because two different states produce an empty list: a bead that records no checkout, and a bead whose recorded checkouts were all excluded as the store. Only the first is the fallback's case.

A bead that recorded the store under both keys is in the second state. Treating it as the first stamps the session's checkout onto the canonical key while the legacy key keeps the store path, and `worktreeSpecForBead` treats a canonical/legacy disagreement as a hard error rather than picking a side. The bead is then refused a session entirely, which is worse than the wrong branch it started with. `workDirStampWouldClobberEvidence` refuses to create that same shape on the reconciler side, and says so in its comment.

So the precondition asks whether the bead names a checkout under either key, before any exclusion runs. A bead that names only the store is left alone and stamped with no branch. That records what the bead actually says, instead of repointing it at a tree it never named.

## The store exclusion compares repositories, not the paths that name them

The branch is read by running git inside the candidate, and git answers that read from
the repository it discovers, not from the candidate's own path. So the repository is
what has to differ from the store's. `git rev-parse --absolute-git-dir` names it: git
climbs to a repository from any depth, resolves symlinked and bind-mounted spellings on
the way, gives a linked worktree its own directory under the main repository's
`worktrees/`, and resolves a `.git` directory, or anything inside one, to the repository
it belongs to.

Four cheaper questions were tried before that one, and each let something through.

Comparing the two path names is wrong in both directions. It says no for two names that
do denote one directory: a symlink, a relative spelling, a bind mount, a directory hard
link, or a case-insensitive filesystem all produce that, and each readmits the shared
checkout as a candidate and re-stamps its branch. That failure is invisible, because the
candidate resolves to a real branch in a real repository and nothing downstream can tell
it apart from a correct answer. It also says yes for two names that denote different
directories: `filepath.Clean` folds `..` lexically, which is only valid when no earlier
element is a symlink, so `<root>/link/../shared` cleans to `<root>/shared` but names
whatever sits beside the link's target, and the bead loses a branch it legitimately had.

Comparing the two directories by the kernel's own device and inode fixes both of those
and still admits a plain subdirectory of the shared checkout. That directory has its own
inode and shares only a prefix with the store, so it is different by every filesystem
measure, and git hands it the store's branch anyway.

Comparing the enclosing worktrees fixes that and still admits the checkout's own `.git`
directory, and anything inside it. Those are under no worktree at all, and a branch read
there reports the checkout's branch.

A path prefix test would catch both of the last two, and would refuse a linked worktree
cut from the rig checkout. This fork creates exactly those per bead, and each reports a
branch of its own, so a prefix test would cost the beads this change exists to serve.

Name comparison is kept ahead of the probe, where it cannot be wrong and where nothing
else can answer: two paths that clean alike and contain no `..` element are the same path,
and that is the only available answer for a recorded directory that no longer exists.

Where a path comparison is the only thing left, it has to ESTABLISH its answer rather
than fail to disprove one. A predicate shaped "admit unless proven inside the store"
admits every input it could not judge, and three defensible refusals to judge became
three false stamps: a relative candidate, a relative store, and a name folding `..`. The
predicate asks the positive question instead, and an input it cannot decide is refused.
A relative name is refused because it means nothing without the directory it was written
against, and two names resolved against different origins compare as unrelated, which
would otherwise read as "outside".

Past that, what matters about a probe is not whether it succeeded but whether it
**answered**. A git that ran and exited nonzero has answered for these queries: "not a git
repository" and "cannot change to \<dir\>" both mean no repository covers the directory, and
the branch read will fail the same way because it is the same discovery. A query that never
completed, killed by its deadline or unable to start, has established nothing. Reading the
second as the first admits the shared checkout whenever a probe times out.

- A candidate git answered for, finding no repository, is admitted. It yields no branch
  downstream either, so there is nothing to exclude.
- A candidate whose probe did not answer is refused. A later branch read may still succeed
  while which repository would serve it is unknown.
- A store whose probe did not answer, but which carries a repository on disk, clears
  nothing at all: not a candidate inside it and not one outside it either. Under that
  refusal a directory that reaches the store's repository through a `.git` file or an
  administrative path is indistinguishable from an unrelated directory, because both
  answer the same way, so no comparison of paths separates them. Whether a repository is
  present is asked without git, by `stat` on `.git` or on `HEAD` beside `objects/`. A
  store that holds no repository has no branch to leak, so there the path comparison is
  the whole question and a candidate outside the store is still admitted.

The premise of the change decides all three: the store's branch is worse than no branch, so
that ordering has to hold whenever the answer is unknown. What a refusal costs is the
claim-time convenience stamp, not the claim and not the close, since the closer supplies the
branch with its own metadata.

Both git queries go through one runner, so they cannot drift in the environment they run
under or the deadline they respect, and they have to agree because the exclusion compares
one against the other.

The branch read names the repository the exclusion validated, `--git-dir=<repo>`, so the
path cannot be repointed between the two observations. It also passes `-C <dir>`, and both
arguments are load-bearing. `--git-dir` pins which repository answers; `-C` supplies the
directory git runs from, because a relative path in the environment is resolved against
the process directory, and `GIT_CONFIG_GLOBAL` is exactly such a path and survives
`SanitizedEnv`. With `--git-dir` alone, a caller whose own directory holds an unreadable
config loses every branch stamp, and it fails with the same exit status that means "no
repository here", so it presents as a checkout with no branch rather than as an error.
git applies `-C` first, so the directory never overrides the pin.

The environment is load-bearing. git reads `GIT_DIR` and `GIT_WORK_TREE` ahead of its own
`-C` argument, a pre-commit hook or nested worktree tooling exports both, and
`internal/git.SanitizedEnv` exists for this and documents that callers shelling out to git
should assign it. Without it the bug is reachable through a second door: with `GIT_DIR`
naming the shared checkout, the resolver reads the shared branch out of the worker's own
tree.

The deadline is load-bearing too. Repository discovery reads the filesystem and can block on
an unresponsive mount, and no caller deadline covers it: the claim's delivery window is
checked before the identity patch is built, and the metadata-write timeout is created after
it. Each query is bounded, though the claim as a whole is not, and the store is probed once
per claim rather than once per candidate.

## Test plan

- New `cmd/gc/cmd_hook_claim_work_branch_test.go`: worker checkout stamped rather than the store branch; no recorded checkout leaves the key unset; a canonical `gc.work_dir` that is itself the store dir is refused; legacy recovers when canonical does not resolve; a legacy value that is the store dir is refused too; a trailing separator does not smuggle the store past the refusal; an already-current branch issues no write. Plus direct coverage of the candidate list (store excluded, identical keys deduped), the session fallback, its store refusal, recorded-checkout precedence, the control-bead skip, and the pool-managed refusal.
- Every case in the table runs twice, once with the session fallback unwired and once with it wired and a session id in the environment, which is the shape production always has. Without the second arm a `want: ""` case cannot discriminate the shipped path: the fallback precondition is false when the seam is nil, so the assertion passes whether or not the fallback would have stamped.
- The store-dir cases were proven red against an implementation that resolved only from the recorded keys without the exclusion, which is what made the gap visible rather than argued.
- The store-exclusion tests build real git repositories, real symlinks, a real linked worktree and real nested directories under `t.TempDir()`, because every defect in this area exists only below the level of a path string and a fixture of invented paths cannot exhibit one. The refusals covered: a symlink naming the store, a relative spelling of it, a plain subdirectory, its own `.git` directory, a directory inside that `.git`, a store that holds no repository, and a store whose probe established nothing. The admissions covered: a checkout beside the store, an independent checkout nested inside it, and a linked worktree cut from its repository. Plus a `..` folded across a symlink. The candidate list is checked alongside the predicate, since the list is what the claim path calls.
- `TestHookClaimIdentityPatchReadsTheBranchFromTheWorkerNotTheStore` drives the whole identity patch with the production branch resolver over those repositories, asserting the exact branch each recorded path produces. Earlier rounds of this fix were all pinned one layer lower, against a fake resolver or the predicate alone, and the subdirectory and `.git` cases survived every one of them: a fake resolver cannot reproduce what makes them defects. The arms that expect a branch are the positive control, so an empty result cannot be confused with a resolver that answers nothing at all.
- `TestHookClaimClassifyGitOutputSeparatesAnsweredFromNotAsked` pins the probe classifier directly, including that the deadline is checked before the run error, since a query the context kills still surfaces as an `ExitError`.
- `TestHookClaimBranchLookupIgnoresALeakedGitDir` sets `GIT_DIR` and `GIT_WORK_TREE` at the store and asserts the worker checkout still reports its own branch, that it is not refused as the store, and that a subdirectory of the store is still refused.
- Thirteen reverts, thirteen different failure sets, seven of them pinned to exactly one test. Cleaned names miss the alias, the relative spelling and the dot-dot fold. Device and inode miss the subdirectory and the `.git` paths. Enclosing worktrees miss the `.git` paths. A path prefix refuses the nested checkout that must stay allowed. Three arms are pinned by exactly one test each: admitting a candidate when the store's probe did not answer fails the two store-probe cases alone, dropping the environment sanitation fails the leaked-`GIT_DIR` test alone, and reading a deadline kill as an answer fails the classifier alone.
- One fixture detail worth stating, because it silently defeats the test otherwise: the `..` path is built by concatenation, not `filepath.Join`, which cleans its result and would fold the `..` away before the code under test ever sees it.
- `TestHookClaimIdentityPatchLeavesACanonicalOnlyStoreAlone` covers a bead naming the store under the canonical key with the legacy key empty. Reverting the fallback precondition fails it and `TestHookClaimIdentityPatchDoesNotManufactureWorkDirConflict`, and nothing else, so both shapes are pinned independently.
- `TestHookClaimIdentityPatchDoesNotManufactureWorkDirConflict` is revert-proof against the precondition: restoring the candidate-list trigger makes it fail with the stamped session dir and the store path sitting in the two keys.
- Existing stamp tests that supplied no recorded checkout now record one, since a bead with no workspace is correctly stamped with no branch.
- `gofmt` clean, `go build ./...`, `go vet ./...`, full `go test ./cmd/gc -count=1` (253.8s), `go test ./internal/session/... ./internal/api/... -count=1`, the test-resource census and CI-policy guards (`internal/testpolicy/resourcecensus`, `scripts/cipolicy`, `internal/testenv`), `make check-routed-test-rows`, `make check-split-topology-rows`, `make check-residency-boundary`, and `golangci-lint run ./cmd/gc/...` all pass.

## What this does not fix

Four admission defects remain in the exclusion and are tracked in #6289 rather than left
in this description. Briefly: the repository-marker check reads an inaccessible marker, a
repository discovered above the store directory, and a linked worktree's administrative
directory as "no repository", which disables the broad refusal; the older gate in the
answered arm refuses a cleanly identified candidate whenever the store itself was never
identified, so a deployment whose store is not a repository stamps nothing; a descendant
of the store whose symlinks cannot be resolved compares as outside it; and the admitted
repository's pathname can be renamed aside and replaced with a symlink to the store
before the read, which is a wrong stamp rather than a stale one and needs a handle-based
API this codebase does not have.

None of the four is a regression from this change. On `main` today every one of those
inputs is admitted outright, so this narrows the defect surface without closing it. They
are filed because the review series that found them reached the point where each round
produced another variant of one predicate rather than a new class, and a follow-up named
in a merged description stops being read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcPXz8AxpyCCoDcK7Bu5W
