### PR TITLE
fix(dolt): age a backup remote by its manifest, not by its newest chunk

### DIFF
--- a/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh
@@ -87,19 +87,49 @@ backup_path_matches_db() {
     return 1
 }
 
-newest_backup_mtime_for_db() {
+# Age of the newest *restorable* backup for a database, which is the mtime of
+# the remote's manifest and never the mtime of the newest file of any kind.
+# `dolt backup sync` writes chunk data first and adopts it by rewriting the
+# manifest last, so a sync killed in between leaves chunk files newer than
+# anything the manifest references. Measured on a live city: an hq remote whose
+# newest chunk landed at 21:04 carried a manifest still reading 15:04, and the
+# manifest did not reference that chunk. Reading file mtimes there reports a
+# six-hour-old backup as nine minutes old.
+#
+# Layouts with no manifest fall back to the newest matching file, because
+# BACKUP_ARTIFACT_DIR may point at something that is not a Dolt remote at all
+# and those layouts have no commit point to read. The one exception is a
+# db-named directory holding no manifest: that is a Dolt remote whose first
+# sync never completed, so it holds nothing restorable and reports 0.
+backup_commit_mtime_for_db() {
     db_name="$1"
     newest_mtime=0
+    manifest_mtime=0
     while IFS= read -r -d '' backup_path; do
         backup_rel_path="${backup_path#$BACKUP_ARTIFACT_DIR/}"
         if backup_path_matches_db "$db_name" "$backup_rel_path"; then
             backup_mtime=$(file_mtime "$backup_path")
-            if [ "$backup_mtime" -gt "$newest_mtime" ]; then
-                newest_mtime="$backup_mtime"
-            fi
+            case "$backup_path" in
+                */manifest)
+                    if [ "$backup_mtime" -gt "$manifest_mtime" ]; then
+                        manifest_mtime="$backup_mtime"
+                    fi
+                    ;;
+                *)
+                    if [ "$backup_mtime" -gt "$newest_mtime" ]; then
+                        newest_mtime="$backup_mtime"
+                    fi
+                    ;;
+            esac
         fi
     done < <(find "$BACKUP_ARTIFACT_DIR" -type f -print0 2>/dev/null)
-    printf '%s\n' "$newest_mtime"
+    if [ "$manifest_mtime" -gt 0 ]; then
+        printf '%s\n' "$manifest_mtime"
+    elif [ -d "$BACKUP_ARTIFACT_DIR/$db_name" ]; then
+        printf '0\n'
+    else
+        printf '%s\n' "$newest_mtime"
+    fi
 }
 
 append_backup_stale() {
@@ -172,7 +202,8 @@ if [ "${ORPHAN_COUNT:-0}" -gt 0 ]; then
     ORPHAN_WARN=" [WARN: $ORPHAN_COUNT orphan DBs detected — run gc dolt cleanup]"
 fi
 
-# Backup freshness: check newest backup artifact per database.
+# Backup freshness: check each database's newest restorable backup, read from
+# the backup remote's manifest. See backup_commit_mtime_for_db.
 # Every user database is in scope. DBs without a configured <db>-backup
 # remote are reported as a coverage gap rather than silently excluded —
 # the exclusion is how unconfigured production DBs went unbacked-up until
@@ -200,12 +231,12 @@ if [ -n "$BACKUP_ELIGIBLE_DBS" ]; then
     else
         NOW_S=$(date +%s)
         for db in $BACKUP_ELIGIBLE_DBS; do
-            NEWEST_BACKUP_MTIME=$(newest_backup_mtime_for_db "$db")
-            if [ "$NEWEST_BACKUP_MTIME" -le 0 ]; then
+            BACKUP_COMMIT_MTIME=$(backup_commit_mtime_for_db "$db")
+            if [ "$BACKUP_COMMIT_MTIME" -le 0 ]; then
                 append_backup_stale "$db backup missing"
                 continue
             fi
-            BACKUP_AGE=$((NOW_S - NEWEST_BACKUP_MTIME))
+            BACKUP_AGE=$((NOW_S - BACKUP_COMMIT_MTIME))
             if [ "$BACKUP_AGE" -gt "$BACKUP_STALE_S" ]; then
                 append_backup_stale "$db backup is $((BACKUP_AGE / 3600))h old"
             fi

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -5401,6 +5401,145 @@ exit 0
 	}
 }
 
+// TestDoctorReadsBackupFreshnessFromTheManifestNotTheNewestChunk asserts the
+// doctor ages a Dolt backup remote by its manifest rather than by whatever file
+// in the directory was touched last.
+//
+// `dolt backup sync` writes chunk data first and adopts it by rewriting the
+// manifest last, so a sync the server kills in between leaves chunk files newer
+// than anything the manifest references. On the city that produced this test an
+// hq remote held a chunk written at 21:04 beside a manifest still reading 15:04,
+// and the manifest did not reference that chunk: the newest restorable backup
+// was six hours old while the directory read as nine minutes old.
+//
+// Both directions are asserted from one fixture. The stale-manifest database
+// has the fresher chunk, so a file-mtime reading calls it fresh; the
+// fresh-manifest database has the older chunk, so a reading that took the
+// oldest file instead would call it stale.
+func TestDoctorReadsBackupFreshnessFromTheManifestNotTheNewestChunk(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	artifactDir := filepath.Join(cityPath, ".dolt-backup")
+	for _, db := range []string{"prod", "archive"} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", db, err)
+		}
+		if err := os.MkdirAll(filepath.Join(artifactDir, db), 0o755); err != nil {
+			t.Fatalf("mkdir backup remote %s: %v", db, err)
+		}
+	}
+	now := time.Now()
+	old := now.Add(-2 * time.Hour)
+
+	// archive: the incident shape — a half-written sync left a fresh chunk
+	// behind a manifest that never adopted it.
+	writeBackupRemoteFile(t, filepath.Join(artifactDir, "archive", "manifest"), old)
+	writeBackupRemoteFile(t, filepath.Join(artifactDir, "archive", "chunk.darc"), now)
+
+	// prod: a sync that completed. Its chunk is the older file of the two.
+	writeBackupRemoteFile(t, filepath.Join(artifactDir, "prod", "chunk.darc"), old)
+	writeBackupRemoteFile(t, filepath.Join(artifactDir, "prod", "manifest"), now)
+
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	writeDoctorFakeDoltWithBackupRemotes(t, binDir, "prod", "archive")
+
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir, doctorBackupStaleEnv)
+	if !strings.Contains(out, "server: ok") {
+		t.Fatalf("unexpected doctor output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "archive backup is") {
+		t.Fatalf("doctor read the fresh chunk instead of the stale manifest, log:\n%s", gcLog)
+	}
+	if strings.Contains(string(gcLog), "prod backup is") {
+		t.Fatalf("a completed sync with an older chunk was reported stale, log:\n%s", gcLog)
+	}
+}
+
+// TestDoctorReportsBackupRemoteWithNoManifestAsMissing asserts a Dolt remote
+// directory holding chunk data but no manifest reports as missing rather than
+// as a backup as fresh as its newest chunk. Nothing in it is restorable: the
+// manifest is what names the root chunk, so without one there is no backup to
+// restore however recently the chunks were written.
+func TestDoctorReportsBackupRemoteWithNoManifestAsMissing(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	artifactDir := filepath.Join(cityPath, ".dolt-backup")
+	if err := os.MkdirAll(filepath.Join(dataDir, "prod", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir prod: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(artifactDir, "prod"), 0o755); err != nil {
+		t.Fatalf("mkdir backup remote: %v", err)
+	}
+	writeBackupRemoteFile(t, filepath.Join(artifactDir, "prod", "chunk.darc"), time.Now())
+
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	writeDoctorFakeDoltWithBackupRemotes(t, binDir, "prod")
+
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir, doctorBackupStaleEnv)
+	if !strings.Contains(out, "server: ok") {
+		t.Fatalf("unexpected doctor output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "prod backup missing") {
+		t.Fatalf("a remote with chunks but no manifest should report missing, log:\n%s", gcLog)
+	}
+}
+
+// writeBackupRemoteFile creates one file inside a fake Dolt backup remote and
+// stamps it, so a fixture can order a manifest against the chunks around it.
+func writeBackupRemoteFile(t *testing.T, path string, mtime time.Time) {
+	t.Helper()
+	writeTestFile(t, path, "backup")
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}
+
+// writeDoctorFakeDoltWithBackupRemotes stands in for the dolt CLI the doctor
+// shells out to, reporting every named database as having its <db>-backup
+// remote configured so each one reaches the freshness check.
+func writeDoctorFakeDoltWithBackupRemotes(t *testing.T, binDir string, dbs ...string) {
+	t.Helper()
+	var backupCases strings.Builder
+	var showDatabases strings.Builder
+	showDatabases.WriteString("Database\\n")
+	for _, db := range dbs {
+		fmt.Fprintf(&backupCases, "      %s) printf '%s-backup\\n' ;;\n", db, db)
+		fmt.Fprintf(&showDatabases, "%s\\n", db)
+	}
+	writeExecutable(t, filepath.Join(binDir, "dolt"), fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  backup)
+    case "$(basename "$PWD")" in
+%s
+    esac
+    exit 0
+    ;;
+esac
+case "$*" in
+  *"COUNT(*) FROM information_schema.PROCESSLIST"*)
+    printf 'COUNT(*)\\n1\\n'
+    exit 0
+    ;;
+  *"SHOW DATABASES"*)
+    printf '%s'
+    exit 0
+    ;;
+esac
+exit 0
+`, backupCases.String(), showDatabases.String()))
+}
+
 func TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness(t *testing.T) {
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "dolt-data")


### PR DESCRIPTION
## Summary

The doctor aged a Dolt backup remote by whatever file in it happened to be touched last. `dolt backup sync` writes chunk data first and adopts it by rewriting the manifest last, so a sync the server kills in between leaves chunk files newer than anything the manifest references. The directory then reads fresh, while the newest restorable backup is however old the manifest says it is.

That's measured rather than hypothetical. On the city that produced it, an `hq` remote held a chunk written at 21:04 beside a manifest still reading 15:04, and the manifest didn't reference that chunk at all. [The old reading](https://github.com/gastownhall/gascity/blob/a718dd689/examples/bd/dolt/assets/scripts/mol-dog-doctor.sh#L90-L103) called that backup nine minutes old. It was six hours old. The sibling `aa` remote synced cleanly on the same run and its manifest is the newest file there, so both cases sit side by side on one disk.

Freshness now comes from the manifest, which is the point where a sync becomes restorable. The risk sits in one place, and it's layouts with no manifest anywhere: those keep the old newest-file reading, since the artifact dir can be pointed at something that isn't a Dolt remote at all. One exception to that fallback — a db-named directory holding chunks but no manifest is a remote whose first sync never finished, so it now reports missing rather than fresh.

```mermaid
flowchart LR
    A["sync writes chunk data"] --> B{"server ends the connection"}
    B -->|"killed mid-sync"| C["chunks land, manifest untouched"]
    B -->|"completes"| D["manifest rewritten, chunks adopted"]
    C --> E["newest file is an orphan chunk"]
    D --> F["newest file is the manifest"]
    E --> G["reading file mtimes: backup looks minutes old"]
    E --> H["reading the manifest: backup is as old as the last completed sync"]
```

<details>
<summary>Test plan, the live evidence, and the surface this shares</summary>

### Test plan

`go test ./examples/bd/dolt/...` passes, the package in full rather than under a `-run` filter (148s).

Two new tests, both mutation-checked by splicing the fix back out and confirming the intended test turns red with no sibling guard covering for it:

| Fix removed | Test that turned red |
|---|---|
| the whole helper, reverted to the newest-file reading | `TestDoctorReadsBackupFreshnessFromTheManifestNotTheNewestChunk`, `TestDoctorReportsBackupRemoteWithNoManifestAsMissing` |
| only the no-manifest-remote rule, manifest preference kept | `TestDoctorReportsBackupRemoteWithNoManifestAsMissing` alone |

That second mutation is what shows the two tests guard different halves, rather than one quietly covering for the other. Every other `TestDoctor*` test stayed green under both, including the three that already exercised this path — the flat `<db>.backup` fixtures they use still take the fallback reading.

The first test asserts both directions from one fixture, deliberately. Its stale-manifest database carries the *fresher* chunk, so a file-mtime reading calls it fresh; its fresh-manifest database carries the *older* chunk, so a reading that just took the oldest file would call it stale. One fixture, both failure modes.

### Verified against the live remote

Running the new helper against the affected city's artifact directory, before any of this merged:

```
hq: commit_mtime=1789139042  age=6h16m  (2026-09-11 15:04)
aa: commit_mtime=1789160923  age=0h11m  (2026-09-11 21:08)
```

The old helper reported `hq` at 11 minutes. Worth being plain about what this does and doesn't change today: with `GC_DOCTOR_BACKUP_STALE_S` at its 12h default, 6h16m sits under the threshold either way, so no advisory fires that wouldn't have fired before. What changes is that the number's now true, and the next missed sync crosses the line instead of being masked by a fresh orphan chunk.

### Shared surface

`change_surface_collision.py` reports one contested finding, [#5230](https://github.com/gastownhall/gascity/pull/5230), which touches this script's lines 230-282 against this change's 234-239, and is 12 days stale. Its own recommendation is to keep the edit narrow rather than stack, which is what this is: two hunks in one helper, one renamed caller, one comment. Ten other open PRs share the test file at disjoint ranges.

### What this deliberately leaves alone

The Go `rig:<name>:dolt-backup` check tests whether a backup is *registered*, not whether it is fresh, and its own message says "assumed previously synced". It is honest about what it does not measure, so widening it belongs in its own change.

</details>

---
> Generated by the operator's software factory.
> • City: `city` · Agent: `local-core.builder-3`
> • On behalf of: @austinborn
