### PR TITLE
refactor(runtime): translate agent status into semantic event kinds

### DIFF
--- a/internal/runtime/herdr/activity.go
+++ b/internal/runtime/herdr/activity.go
@@ -2,9 +2,10 @@ package herdr
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/runtime"
 )
 
 // This file implements GetLastActivity for herdr. herdr exposes no activity
@@ -189,6 +190,15 @@ func (a *activityTracker) run(ctx context.Context, p *Provider) {
 	if err != nil {
 		events = nil // nil channel blocks forever: degrade to ticker-only
 	}
+	a.reconcileLoop(ctx, events, func() { a.poll(ctx, p.c) })
+}
+
+// reconcileLoop is the acceleration itself, split from run so a test can
+// deliver an event without standing up a provider and its socket. It reads
+// only that an event ARRIVED: no kind is inspected, which is the whole
+// mechanism, and is why a translation layer that filters events by kind
+// silently demotes this loop to its fallback ticker.
+func (a *activityTracker) reconcileLoop(ctx context.Context, events <-chan runtime.SessionEvent, poll func()) {
 	ticker := time.NewTicker(activityPollInterval)
 	defer ticker.Stop()
 	debounce := time.NewTimer(activityEventDebounce)
@@ -212,9 +222,9 @@ func (a *activityTracker) run(ctx context.Context, p *Provider) {
 			}
 		case <-debounce.C:
 			armed = false
-			a.poll(ctx, p.c)
+			poll()
 		case <-ticker.C:
-			a.poll(ctx, p.c)
+			poll()
 		}
 	}
 }
@@ -237,7 +247,7 @@ func (a *activityTracker) poll(ctx context.Context, c *client) {
 		if ag.Name == "" {
 			continue
 		}
-		status := strings.ToLower(strings.TrimSpace(ag.AgentStatus))
+		status := normalizeAgentState(ag.AgentStatus)
 		prev, seen := a.entries[ag.Name]
 		e := activityEntry{status: status, revision: ag.Revision, stamp: prev.stamp}
 		switch {

--- a/internal/runtime/herdr/activity_test.go
+++ b/internal/runtime/herdr/activity_test.go
@@ -1,8 +1,11 @@
 package herdr
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/gastownhall/gascity/internal/runtime"
 )
 
 // activityTestProvider wires a Provider at the fake server's socket with the
@@ -274,4 +277,48 @@ func shrinkActivityKnobs(t *testing.T) {
 	t.Cleanup(func() { activityPollInterval, activityEventDebounce = pi, ed })
 	activityPollInterval = 25 * time.Millisecond
 	activityEventDebounce = 5 * time.Millisecond
+}
+
+// TestActivityReconcileLoopPollsOnAnyEventKind pins the protection that the
+// event-translation boundary depends on and cannot itself assert. The tracker
+// reads arrival only: it never inspects SessionEvent.Kind, so a provider
+// boundary that filters events by kind silently demotes this acceleration to
+// the fallback ticker, with nothing failing and nothing logging. The fallback
+// here is set far out of reach, so a poll within the deadline can only have
+// come from the event.
+//
+// agent_state_changed is listed because it is the kind a non-idle herdr state
+// translates to, and a boundary that dropped those states instead of
+// translating them is exactly the regression this test exists to catch.
+func TestActivityReconcileLoopPollsOnAnyEventKind(t *testing.T) {
+	for _, kind := range []runtime.SessionEventKind{
+		runtime.SessionEventAgentStateChanged,
+		runtime.SessionEventAgentIdle,
+		runtime.SessionEventAgentDetected,
+		runtime.SessionEventResync,
+		runtime.SessionEventKind("a-kind-no-provider-emits-yet"),
+	} {
+		t.Run(string(kind), func(t *testing.T) {
+			prevInterval, prevDebounce := activityPollInterval, activityEventDebounce
+			t.Cleanup(func() {
+				activityPollInterval, activityEventDebounce = prevInterval, prevDebounce
+			})
+			activityPollInterval = time.Hour // the ticker must not be the cause
+			activityEventDebounce = time.Millisecond
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			events := make(chan runtime.SessionEvent, 1)
+			polled := make(chan struct{}, 4)
+			a := &activityTracker{}
+			go a.reconcileLoop(ctx, events, func() { polled <- struct{}{} })
+
+			events <- runtime.SessionEvent{Kind: kind, Session: "beta"}
+			select {
+			case <-polled:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("kind %q did not accelerate a poll; the tracker must treat any event as a hint", kind)
+			}
+		})
+	}
 }

--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -353,6 +353,17 @@ const (
 // absent from startupConfirmStates.
 const agentStateIdle = "idle"
 
+// normalizeAgentState folds one reported agent_status to the spelling the
+// package's classifying readers compare against. It is deliberately shared:
+// two readers normalizing the same field differently classify the same payload
+// differently, and the disagreement is invisible at both sites. Note the
+// keystroke guard below does NOT use it, on purpose — it withholds a real
+// keystroke unless herdr reported exactly the idle state, and widening that is
+// a behavior change, not a cleanup.
+func normalizeAgentState(status string) string {
+	return strings.ToLower(strings.TrimSpace(status))
+}
+
 // startupConfirmStates are the post-submission states that prove the submit
 // CR took: the turn is running (working), already finished (done — an
 // ultra-short turn can settle between herdr's observations), or hit a dialog

--- a/internal/runtime/herdr/events.go
+++ b/internal/runtime/herdr/events.go
@@ -316,8 +316,25 @@ func (s *sessionEventStream) handleFrame(line []byte) (relistHint bool) {
 		ev.Kind = runtime.SessionEventAgentDetected
 		relistHint = true
 	case "pane.agent_status_changed":
-		ev.Kind = runtime.SessionEventAgentStatus
-		ev.AgentStatus = f.Data.AgentStatus
+		// Translate at the boundary: herdr's idle state is the one with a
+		// generic meaning, so it maps to the semantic kind, and every other
+		// state maps to the vocabulary-free change kind. agentStateIdle is
+		// herdr's own spelling and stays in this package; nothing downstream
+		// learns it.
+		//
+		// The frame is never swallowed. Its arrival carries two things besides
+		// a status: emit below flushes a resync this stream already owes the
+		// consumer, and the package's own activity tracker polls on any event
+		// without reading its kind. Dropping non-idle frames would cost both,
+		// turning 300ms event-driven reconciliation into a 30s ticker.
+		//
+		// normalizeAgentState is shared with the tracker so the two cannot
+		// classify the same payload differently.
+		if normalizeAgentState(f.Data.AgentStatus) == agentStateIdle {
+			ev.Kind = runtime.SessionEventAgentIdle
+		} else {
+			ev.Kind = runtime.SessionEventAgentStateChanged
+		}
 	case "pane_created":
 		// Filter-maintenance hint only (the payload nests the pane object and
 		// carries no agent mapping yet); consumers see the session once its

--- a/internal/runtime/herdr/events_live_test.go
+++ b/internal/runtime/herdr/events_live_test.go
@@ -12,7 +12,7 @@ import (
 // waitForEvent drains the stream until an event matches, tolerating
 // interleaved noise (resyncs from resubscribe cycles, stray-pane events,
 // unrelated status flaps).
-func waitForEvent(t *testing.T, ch <-chan runtime.SessionEvent, timeout time.Duration, match func(runtime.SessionEvent) bool) runtime.SessionEvent {
+func waitForEvent(t *testing.T, ch <-chan runtime.SessionEvent, timeout time.Duration, match func(runtime.SessionEvent) bool) {
 	t.Helper()
 	deadline := time.After(timeout)
 	for {
@@ -22,9 +22,9 @@ func waitForEvent(t *testing.T, ch <-chan runtime.SessionEvent, timeout time.Dur
 				t.Fatalf("event channel closed while waiting")
 			}
 			if match(ev) {
-				return ev
+				return
 			}
-			t.Logf("  (skipping %s session=%q status=%q ref=%q)", ev.Kind, ev.Session, ev.AgentStatus, ev.Ref)
+			t.Logf("  (skipping %s session=%q ref=%q)", ev.Kind, ev.Session, ev.Ref)
 		case <-deadline:
 			t.Fatalf("timed out after %v waiting for matching event", timeout)
 		}
@@ -79,13 +79,12 @@ func TestSessionEventsLive(t *testing.T) {
 			t.Fatalf("pane report-agent %s %s: %v: %s", pane, state, err, out)
 		}
 	}
+	// Both translations are exercised live: a non-idle state arrives as the
+	// vocabulary-free change kind here, and evt-b forces idle below.
 	report(a.PaneID, "working")
-	ev := waitForEvent(t, ch, 10*time.Second, func(ev runtime.SessionEvent) bool {
-		return ev.Kind == runtime.SessionEventAgentStatus && ev.Session == "evt-a"
+	waitForEvent(t, ch, 10*time.Second, func(ev runtime.SessionEvent) bool {
+		return ev.Kind == runtime.SessionEventAgentStateChanged && ev.Session == "evt-a"
 	})
-	if ev.AgentStatus != "working" {
-		t.Errorf("evt-a status event = %q, want working", ev.AgentStatus)
-	}
 
 	// evt-b starts while the stream is live: pane_created → debounced re-list
 	// → resubscribe; its status events must then flow, attributed.
@@ -103,13 +102,10 @@ func TestSessionEventsLive(t *testing.T) {
 	waitForEvent(t, ch, 15*time.Second, func(ev runtime.SessionEvent) bool {
 		return ev.Kind == runtime.SessionEventResync
 	})
-	report(b.PaneID, "blocked")
-	ev = waitForEvent(t, ch, 10*time.Second, func(ev runtime.SessionEvent) bool {
-		return ev.Kind == runtime.SessionEventAgentStatus && ev.Session == "evt-b"
+	report(b.PaneID, "idle")
+	waitForEvent(t, ch, 10*time.Second, func(ev runtime.SessionEvent) bool {
+		return ev.Kind == runtime.SessionEventAgentIdle && ev.Session == "evt-b"
 	})
-	if ev.AgentStatus != "blocked" {
-		t.Errorf("evt-b status event = %q, want blocked", ev.AgentStatus)
-	}
 
 	// evt-c exits on its own: pane_exited must arrive attributed (the
 	// merge-only pane map keeps the mapping even if herdr reaps the agent

--- a/internal/runtime/herdr/events_test.go
+++ b/internal/runtime/herdr/events_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -224,10 +225,39 @@ func TestSessionEventStreamStartupAndTranslation(t *testing.T) {
 	}
 
 	stream.push(t, `{"data":{"agent":"claude","agent_status":"idle","pane_id":"w2:p1","workspace_id":"w2"},"event":"pane.agent_status_changed"}`)
-	if ev := recvEvent(t, ch, 2*time.Second); ev.Kind != runtime.SessionEventAgentStatus || ev.Session != "beta" || ev.AgentStatus != "idle" {
-		t.Errorf("agent_status_changed => %+v, want agent_status/beta/idle", ev)
+	if ev := recvEvent(t, ch, 2*time.Second); ev.Kind != runtime.SessionEventAgentIdle || ev.Session != "beta" {
+		t.Errorf("agent_status_changed idle => %+v, want agent_idle/beta", ev)
 	}
 
+	// The same state reported with different case or padding is the same state,
+	// and "the same" is decided by the normalizer the activity tracker also
+	// uses. That shared spelling is the point: a boundary that folded case its
+	// own way would classify a payload idle here and not-idle there, or the
+	// reverse, and neither site would show the disagreement. U+0130 is in the
+	// list because it is exactly where an independently-plausible choice
+	// diverges: strings.ToLower maps it to "i", strings.EqualFold does not.
+	for _, spelling := range []string{"IDLE", "Idle", " idle ", "\u0130dle"} {
+		stream.push(t, fmt.Sprintf(`{"data":{"agent":"claude","agent_status":%q,"pane_id":"w2:p1","workspace_id":"w2"},"event":"pane.agent_status_changed"}`, spelling))
+		if ev := recvEvent(t, ch, 2*time.Second); ev.Kind != runtime.SessionEventAgentIdle || ev.Session != "beta" {
+			t.Errorf("agent_status_changed %q => %+v, want agent_idle/beta", spelling, ev)
+		}
+	}
+
+	// A non-idle state crosses as the vocabulary-free kind, never as herdr's
+	// own spelling. It has to cross at all: the frame's arrival is what flushes
+	// an owed resync and what wakes the activity tracker, neither of which reads
+	// the kind. Those two effects are pinned by
+	// TestSessionEventStreamFlushesOwedResyncOnNonIdleFrame and
+	// TestActivityReconcileLoopPollsOnAnyEventKind respectively, not here.
+	stream.push(t, `{"data":{"agent":"claude","agent_status":"working","pane_id":"w2:p1","workspace_id":"w2"},"event":"pane.agent_status_changed"}`)
+	if ev := recvEvent(t, ch, 2*time.Second); ev.Kind != runtime.SessionEventAgentStateChanged || ev.Session != "beta" {
+		t.Errorf("agent_status_changed working => %+v, want agent_state_changed/beta", ev)
+	}
+	// Ordering only: the detected frame must still arrive, attributed, after a
+	// status frame. The no-provider-vocabulary property is NOT asserted here,
+	// because this assertion would not notice a relayed status field being
+	// reintroduced; TestSessionEventCarriesNoProviderVocabulary in
+	// internal/runtime owns that, as a field-set guard on the struct itself.
 	stream.push(t, `{"data":{"agent":"claude","pane_id":"w1:p1","type":"pane_agent_detected","workspace_id":"w1"},"event":"pane_agent_detected"}`)
 	if ev := recvEvent(t, ch, 2*time.Second); ev.Kind != runtime.SessionEventAgentDetected || ev.Session != "alpha" {
 		t.Errorf("pane_agent_detected => %+v, want agent_detected/alpha", ev)
@@ -316,6 +346,84 @@ func TestSessionEventStreamAttachesWhenServerAppears(t *testing.T) {
 	}
 }
 
+// TestSessionEventStreamFlushesOwedResyncOnNonIdleFrame pins the side effect
+// that is easy to lose when a translation layer learns to filter. emit flushes
+// a resync the stream already owes its consumer before delivering anything, so
+// every accepted frame is a chance to discharge that debt. A boundary that
+// returned early for non-idle states would skip the flush, and the consumer
+// would sit on an undelivered loss notification until some other frame
+// happened to be accepted, a reconnect occurred, or a relist timer fired.
+//
+// Deliberately socket-free: the regression lives in handleFrame, and driving it
+// directly is what lets the test state the owed-resync precondition instead of
+// trying to provoke a full channel through a live stream.
+func TestSessionEventStreamFlushesOwedResyncOnNonIdleFrame(t *testing.T) {
+	for _, status := range []string{"working", "blocked", "done", "unknown", "a-state-herdr-has-not-shipped-yet"} {
+		t.Run(status, func(t *testing.T) {
+			s := &sessionEventStream{
+				ch:            make(chan runtime.SessionEvent, 1),
+				paneNames:     map[string]string{"w2:p1": "beta"},
+				pendingResync: true,
+			}
+			frame := fmt.Sprintf(`{"data":{"agent":"claude","agent_status":%q,"pane_id":"w2:p1","workspace_id":"w2"},"event":"pane.agent_status_changed"}`, status)
+			s.handleFrame([]byte(frame))
+			select {
+			case ev := <-s.ch:
+				if ev.Kind != runtime.SessionEventResync {
+					t.Fatalf("first delivered event = %v, want the owed resync", ev.Kind)
+				}
+			default:
+				t.Fatal("owed resync still undelivered after a non-idle status frame")
+			}
+		})
+	}
+}
+
+// TestSessionEventStreamTranslatesEveryAgentStateToOneOfTwoKinds states the
+// whole translation table in one place, including states herdr does not ship
+// today. The point of the semantic kinds is that an unrecognized provider state
+// is not a special case: it reports that something changed without claiming to
+// know what, which is the only honest reading of a state this package has never
+// seen.
+func TestSessionEventStreamTranslatesEveryAgentStateToOneOfTwoKinds(t *testing.T) {
+	cases := []struct {
+		status string
+		want   runtime.SessionEventKind
+	}{
+		{"idle", runtime.SessionEventAgentIdle},
+		{"IDLE", runtime.SessionEventAgentIdle},
+		{" idle\t", runtime.SessionEventAgentIdle},
+		{"\u0130dle", runtime.SessionEventAgentIdle},
+		{"working", runtime.SessionEventAgentStateChanged},
+		{"blocked", runtime.SessionEventAgentStateChanged},
+		{"done", runtime.SessionEventAgentStateChanged},
+		{"unknown", runtime.SessionEventAgentStateChanged},
+		{"", runtime.SessionEventAgentStateChanged},
+		{"idle-adjacent-but-not-idle", runtime.SessionEventAgentStateChanged},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%q", tc.status), func(t *testing.T) {
+			s := &sessionEventStream{
+				ch:        make(chan runtime.SessionEvent, 1),
+				paneNames: map[string]string{"w2:p1": "beta"},
+			}
+			frame := fmt.Sprintf(`{"data":{"agent":"claude","agent_status":%q,"pane_id":"w2:p1","workspace_id":"w2"},"event":"pane.agent_status_changed"}`, tc.status)
+			s.handleFrame([]byte(frame))
+			select {
+			case ev := <-s.ch:
+				if ev.Kind != tc.want {
+					t.Errorf("status %q => kind %v, want %v", tc.status, ev.Kind, tc.want)
+				}
+				if ev.Session != "beta" {
+					t.Errorf("status %q => session %q, want beta", tc.status, ev.Session)
+				}
+			default:
+				t.Fatalf("status %q emitted nothing; every reported state must cross as one of the two kinds", tc.status)
+			}
+		})
+	}
+}
+
 // TestSessionEventStreamResubscribesForNewAgentPane pins dynamic filter
 // maintenance: a pane_created burst triggers a debounced re-list, and a newly
 // discovered agent pane forces an immediate resubscribe (new cycle) whose
@@ -357,8 +465,8 @@ func TestSessionEventStreamResubscribesForNewAgentPane(t *testing.T) {
 	}
 	stream = recvStream(t, f)
 	stream.push(t, `{"data":{"agent":"claude","agent_status":"idle","pane_id":"w3:p1","workspace_id":"w3"},"event":"pane.agent_status_changed"}`)
-	if ev := recvEvent(t, ch, 2*time.Second); ev.Kind != runtime.SessionEventAgentStatus || ev.Session != "gamma" {
-		t.Errorf("new pane agent_status => %+v, want agent_status/gamma", ev)
+	if ev := recvEvent(t, ch, 2*time.Second); ev.Kind != runtime.SessionEventAgentIdle || ev.Session != "gamma" {
+		t.Errorf("new pane agent_status => %+v, want agent_idle/gamma", ev)
 	}
 }
 

--- a/internal/runtime/herdr/provider.go
+++ b/internal/runtime/herdr/provider.go
@@ -817,7 +817,7 @@ func livenessFromAgent(info agentInfo, present bool, err error) runtime.Liveness
 // and non-destructive) is the acceptable direction to err. The terminal set is
 // validated against live herdr output during rollout; extend it there.
 func agentAliveFromStatus(status string) bool {
-	switch strings.ToLower(strings.TrimSpace(status)) {
+	switch normalizeAgentState(status) {
 	case "exited", "stopped", "dead", "gone", "terminated", "closed", "crashed":
 		return false
 	default:

--- a/internal/runtime/session_events.go
+++ b/internal/runtime/session_events.go
@@ -25,9 +25,24 @@ const (
 	// SessionEventAgentDetected means the provider recognized an agent TUI
 	// running inside the session.
 	SessionEventAgentDetected SessionEventKind = "agent_detected"
-	// SessionEventAgentStatus reports a change of the session agent's
-	// activity status (see SessionEvent.AgentStatus).
-	SessionEventAgentStatus SessionEventKind = "agent_status"
+	// SessionEventAgentIdle means the session's agent reached the state where
+	// it is ready for input. It is a semantic kind, not a relayed provider
+	// status: each provider decides which of its own states is the
+	// idle-equivalent and translates at its boundary, so no provider
+	// vocabulary reaches a generic consumer.
+	SessionEventAgentIdle SessionEventKind = "agent_idle"
+	// SessionEventAgentStateChanged means the provider reported the session's
+	// agent in some state other than the idle-equivalent, including a state the
+	// provider cannot classify or did not name. It is deliberately weaker than
+	// a transition: nothing here compares against a previous state, so a
+	// provider that re-reports an unchanged state, or replays its recent
+	// backlog on resubscribe, produces this kind more than once for one state.
+	// It also does not say WHICH state. The arrival is the information, and a
+	// consumer acts on it by reconciling against live state rather than by
+	// trusting the event to describe one. Providers emit it instead of relaying
+	// their own spelling, so a consumer needing a specific state asks for a
+	// kind for it rather than matching a string.
+	SessionEventAgentStateChanged SessionEventKind = "agent_state_changed"
 )
 
 // SessionEvent is a push notification about one session, delivered by a
@@ -47,10 +62,6 @@ type SessionEvent struct {
 	// with no agent mapping); consumers should treat unattributed lifecycle
 	// events as a hint to reconcile broadly rather than ignore them.
 	Session string
-	// AgentStatus carries the new status for SessionEventAgentStatus events,
-	// in the provider's native vocabulary (herdr: idle | working | blocked |
-	// done | unknown).
-	AgentStatus string
 	// Ref identifies the provider-native object the event came from (e.g. the
 	// herdr pane id). For logging and diagnosis only — not a stable handle.
 	Ref string

--- a/internal/runtime/session_events_contract_test.go
+++ b/internal/runtime/session_events_contract_test.go
@@ -1,0 +1,36 @@
+package runtime
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestSessionEventCarriesNoProviderVocabulary guards the property the whole
+// event contract rests on: a generic consumer must never have to know one
+// provider's words. Every field here is either a semantic value this package
+// defines (Kind), a gc-side identifier (Session), a timestamp, or Ref, which is
+// documented as opaque and diagnostic.
+//
+// This is a field-set assertion rather than a comment because the failure mode
+// is additive and looks harmless at the call site: relaying a provider's status
+// string is one struct field and one assignment, and nothing else in the suite
+// notices. If you are here because this test failed, the question to answer is
+// not "how do I add my field to the list" but "can a consumer act on this
+// without knowing which provider produced it". If it cannot, it belongs behind
+// a semantic Kind, translated at the provider's own boundary. If it genuinely
+// can, add it here with that reasoning in the commit message.
+func TestSessionEventCarriesNoProviderVocabulary(t *testing.T) {
+	want := []string{"Kind", "Ref", "Session", "Time"}
+
+	typ := reflect.TypeOf(SessionEvent{})
+	got := make([]string, 0, typ.NumField())
+	for i := range typ.NumField() {
+		got = append(got, typ.Field(i).Name)
+	}
+	sort.Strings(got)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SessionEvent fields = %v, want %v; see this test's doc comment before changing the list", got, want)
+	}
+}


### PR DESCRIPTION
Follow-up on a platform-agnosticism item raised in review of the #4217 stack: `SessionEvent` carried the agent's activity status as a raw string in the provider's own vocabulary, so the only way to act on it was to string-match one provider's spelling of idle.

## Why that is a problem

A status string in the provider's own words pushes the comparison onto every consumer. A second `SessionEventProvider` whose idle-equivalent state is named anything else compiles fine, and every such comparison silently stops matching. Nothing errors and nothing logs; a fast path just stops firing and the system degrades to its resync and patrol paths. That is the expensive kind of failure to diagnose, because the only symptom is latency with no obvious cause.

No consumer switches on `SessionEvent.Kind` anywhere in the tree today, so nothing is unblocked by this. It fixes the shape of a contract before the next provider or consumer is written against it, while the change is still free of migration cost.

## What changed

Ready-for-input is the one status semantic a generic consumer acts on, so the contract names that and nothing else.

- `internal/runtime/session_events.go`: `SessionEventAgentIdle` for the idle-equivalent state, `SessionEventAgentStateChanged` for a reported change to any other state, including one the provider cannot classify. Neither carries a status string, and `SessionEvent.AgentStatus` is deleted rather than normalized.
- `internal/runtime/herdr/events.go`: `handleFrame` maps herdr's idle state to the first kind and every other state to the second. The constant naming herdr's idle state stays inside `internal/runtime/herdr/`.

Both kinds are emitted, rather than the non-idle frames being filtered out, because a frame's arrival is load-bearing independently of what it reports. Two things ride on it and neither reads the kind:

- `emit` flushes a resync the stream already owes its consumer before delivering anything, so every accepted frame is a chance to discharge that debt. A boundary that returned early would leave an undelivered loss notification until some other frame happened to be accepted, a reconnect occurred, or a relist timer fired.
- `internal/runtime/herdr/activity.go`'s tracker subscribes to the same channel and polls on any event, with a 300ms debounce against a 30s fallback ticker. Dropping working, blocked and done frames would turn event-driven reconciliation into the ticker for exactly the transitions the tracker exists to notice.

A kind that reports a state without describing it keeps both effects and still relays no vocabulary. It also means an unrecognized provider state is not a special case: the event says something was reported without claiming to know what, which is the only honest reading of a state the package has never seen. The kind is deliberately weaker than a transition, and its doc comment says so: nothing compares against a previous state, so a provider that re-reports an unchanged state, or replays its recent backlog on resubscribe, produces it more than once for one state. The consumer that exists reconciles rather than counting transitions.

The idle comparison goes through `normalizeAgentState`, now shared by all three classifying readers of that field (this boundary, the activity tracker, and `provider.go`'s liveness map), so they cannot classify one payload differently. The case that motivates sharing rather than asserting it is U+0130: `strings.ToLower` maps it to `i`, `strings.EqualFold` does not, so two independently plausible choices disagree and neither site shows the disagreement. `client.go` keeps its exact comparison on purpose, and does not use the helper: it withholds a real keystroke unless herdr reported exactly idle, and widening that would be a behavior change rather than a cleanup.

A normalized status enum would also work and would keep the individual non-idle states addressable. Nothing consumes them, so two kinds is the smaller contract; the enum is the better choice if those states should stay distinguishable, and that call belongs to whoever owns the contract.

## Test plan

- `TestSessionEventStreamTranslatesEveryAgentStateToOneOfTwoKinds` states the whole translation table, covering every state herdr ships, the empty string, case and padding spellings, U+0130, and a state herdr has not shipped. Each must cross as exactly one of the two kinds.
- Both arrival-keyed effects get an owning test, because neither is visible from the boundary that depends on them and a comment asserting them is worth nothing:
  - `TestSessionEventStreamFlushesOwedResyncOnNonIdleFrame` sets the owed-resync precondition directly and asserts a non-idle frame still discharges it, across five statuses. Socket-free on purpose: the regression lives in `handleFrame`, and driving it directly is what lets the test state the precondition rather than trying to provoke a full channel through a live stream.
  - `TestActivityReconcileLoopPollsOnAnyEventKind` asserts the tracker accelerates on every kind, including one no provider emits, with the fallback ticker set an hour out so a poll inside the deadline can only have come from the event. The tracker's select loop is split out as `reconcileLoop` for this, since driving `run` needs a provider and a socket.
- `TestSessionEventCarriesNoProviderVocabulary` is a field-set guard on the struct. No behavioral assertion notices a relayed status field being reintroduced: that is one field and one assignment, and the rest of the suite stays green. Its doc comment says what to think about before extending the list rather than how to extend it.
- `TestSessionEventStreamStartupAndTranslation` asserts the ordered wire path end to end, including that a non-idle frame arrives as the change kind and not as the idle one.
- Five mutation arms, each caught by a different assertion: swallowing non-idle frames again (owed-resync test, all five statuses, plus the ordered path test); folding case at the boundary with `EqualFold` instead of sharing the normalizer (the U+0130 case only); dropping the normalizer's lowering (the uppercase cases); filtering the change kind inside the tracker (the acceleration test); adding a status field back to the generic event (the field-set guard).
- `TestSessionEventStreamResubscribesForNewAgentPane` updated to the new kind.
- The live tier exercises both kinds, forcing a non-idle state on one pane and idle on another. It is opt-in and did not execute here, so those edits are compile-verified only: run with the opt-in set against the locally installed herdr it reports `herdr "herdr 0.8.0" uses a detection-based agent registry; tracked as #5808` and skips, which is that guard working as intended rather than a new gap.
- `go build ./...`, `go vet ./...`, `go test ./internal/runtime/... -count=1`, `go test ./internal/api/... ./internal/session/... ./internal/worker/...`, `go test ./internal/testpolicy/...`, `scripts/check-core-boundary.sh`, and `golangci-lint run` over the touched packages all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcPXz8AxpyCCoDcK7Bu5W
