### PR TITLE
fix(herdr): restore the paste fallback for panes with no named agent

### DIFF
--- a/internal/runtime/herdr/capabilities.go
+++ b/internal/runtime/herdr/capabilities.go
@@ -55,7 +55,7 @@ func (p *Provider) waitForIdleOutcome(ctx context.Context, name string, timeout 
 		return idleWaitReached
 	case herdrErrorCode(err) == "timeout":
 		return idleWaitTimeout
-	case isAgentNotFound(err):
+	case p.c.targetHasNoNamedAgent(ctx, herdrAgentName(name), err):
 		return idleWaitNoAgent
 	default:
 		return idleWaitError

--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -65,6 +65,130 @@ func herdrErrorCode(err error) string {
 	return ""
 }
 
+// disqualifyingCode returns a herdr error code that rules the paste fallback out,
+// or "" if none does. It is the only use this change makes of a failure's text, and
+// the direction is the whole point: see targetHasNoNamedAgent for why text cannot
+// be trusted to GRANT anything.
+//
+// Two sources, both herdr's own. The typed envelope is herdr's structured answer to
+// an invocation that reached the server. The other is herdr's stderr from an
+// invocation that exited non-zero, which is a type here (herdrStderr) precisely so
+// this scan cannot reach the argv rendered beside it: the argv holds the nudge, and
+// a nudge that could put a code in front of herdr's would be able to DISPLACE
+// herdr's real rejection rather than merely add to it.
+//
+// Within herdr's own stderr, every envelope is considered and any refusing code
+// wins. That keeps the one property this rests on: caller text can only ever ADD a
+// refusal, never remove one. A refusal is a visible error the caller retries on, so
+// the worst a nudge can do to itself is decline its own fallback; the reverse,
+// granting a fallback, would paste into a pane whose real failure was something
+// else. Do not introduce a bound on this scan, or a long echo becomes a way to
+// push herdr's rejection out of view.
+func disqualifyingCode(err error) string {
+	if err == nil {
+		return ""
+	}
+	if code := herdrErrorCode(err); code != "" && !agentlessCapableCode(code) {
+		return code
+	}
+	var hs *herdrStderr
+	if !errors.As(err, &hs) {
+		return ""
+	}
+	for i := strings.Index(hs.Text, "{"); i >= 0; {
+		var env envelope
+		// A decoder rather than Unmarshal: it stops at the end of the first
+		// complete value, so an envelope with text after it still parses.
+		if derr := json.NewDecoder(strings.NewReader(hs.Text[i:])).Decode(&env); derr == nil && env.Error != nil {
+			if code := env.Error.Code; code != "" && !agentlessCapableCode(code) {
+				return code
+			}
+		}
+		next := strings.Index(hs.Text[i+1:], "{")
+		if next < 0 {
+			break
+		}
+		i += 1 + next
+	}
+	return ""
+}
+
+// agentlessCapableCode reports whether a herdr error code leaves open that the
+// target carries no named agent. agent_not_found says so outright; 0.8.0's
+// agent_not_ready covers both that and an agent still booting, which is why the
+// code cannot settle the question on its own. Every other code is herdr naming a
+// different problem (a busy pane, a bad flag), and naming one rules the fallback
+// out: pasting then would type into whatever the real failure was about and
+// swallow it.
+func agentlessCapableCode(code string) bool {
+	return code == "" || code == "agent_not_found" || code == "agent_not_ready"
+}
+
+// agentStateRejection reports whether herdr declined THIS invocation over the
+// target's agent, rather than failing for some unrelated reason. It is the
+// positive half of the gate: disqualifyingCode rules the paste fallback out when
+// herdr names a different problem, and this rules it out when herdr named no
+// problem at all. The registry can establish that a pane carries no named agent;
+// only herdr can establish that this is why the call failed, and a failure herdr
+// never coded (a malformed argv of ours, a binary that did not run) means it never
+// reached the question. Without this, such a failure plus an empty registry pasted
+// into a pane herdr had not checked for a foreground process.
+//
+// The two channels are asymmetric on purpose. A refusal may be found anywhere in
+// herdr's stderr, because adding one only declines a fallback. A GRANT has to come
+// from a channel a caller cannot write: either the typed envelope parsed off
+// stdout, or a stderr stream that is NOTHING BUT one error envelope. That second
+// shape is herdr 0.8.0's rejection as verified against the installed binary (the
+// bare envelope, no prefix and nothing after it), and an echo cannot reach it,
+// because when herdr rejects our argv it prints its own words alongside whatever it
+// quotes back. Loosen it to "an envelope somewhere in the stream" and a nudge
+// carrying one grants itself a paste.
+//
+// The cost is the direction this fails in. herdr respelling its agent-state code a
+// third time would leave the fallback refused rather than wrongly granted: the
+// caller sees herdr's error instead of a paste into a pane nothing was checked on.
+func agentStateRejection(err error) bool {
+	code := herdrAnswerCode(err)
+	return code != "" && agentlessCapableCode(code)
+}
+
+// herdrAnswerCode returns the code herdr answered THIS invocation with, read only
+// from the two channels a caller's text cannot write. The first is the envelope this
+// client parsed off stdout. The second is a stderr stream that is nothing but one
+// error envelope, which is how the CLI reports a rejection when it exits non-zero
+// (verified against the installed herdr 0.8.0: the bare envelope, no prefix and
+// nothing after it) and is the shape most rejections actually arrive in, since
+// nothing reaches the stdout decode on a non-zero exit.
+//
+// An echo cannot reach either. When herdr rejects our argv it prints its own words
+// alongside whatever it quotes back, so a forged envelope inside that text is never
+// the whole stream. That is what makes this answer usable to GRANT the paste
+// fallback, where disqualifyingCode's permissive scan of the same text is only ever
+// usable to refuse it.
+func herdrAnswerCode(err error) string {
+	if code := herdrErrorCode(err); code != "" {
+		return code
+	}
+	var hs *herdrStderr
+	if !errors.As(err, &hs) {
+		return ""
+	}
+	var env envelope
+	if derr := json.Unmarshal([]byte(strings.TrimSpace(hs.Text)), &env); derr != nil || env.Error == nil {
+		return ""
+	}
+	return env.Error.Code
+}
+
+// herdrStderr carries what herdr wrote to stderr on an invocation that exited
+// non-zero without a parseable envelope on stdout. It is a type rather than text
+// spliced into the error message so that a reader can reach herdr's half of the
+// failure without reaching the argv this client also renders there: the argv holds
+// the nudge body, and the nudge is free text. See disqualifyingCode.
+type herdrStderr struct{ Text string }
+
+func (e *herdrStderr) Error() string { return e.Text }
+
 type envelope struct {
 	Result json.RawMessage `json:"result"`
 	Error  *herdrError     `json:"error"`
@@ -89,7 +213,7 @@ func (c *client) runWithSecrets(ctx context.Context, declared []string, args ...
 		safe, secrets := redactedArgv(args, declared)
 		var ee *exec.ExitError
 		if errors.As(err, &ee) && len(ee.Stderr) > 0 {
-			return nil, fmt.Errorf("herdr %v: %s", safe, redactText(string(ee.Stderr), secrets))
+			return nil, fmt.Errorf("herdr %v: %w", safe, &herdrStderr{Text: redactText(string(ee.Stderr), secrets)})
 		}
 		// err here is exec's own (*exec.Error, *exec.ExitError): it carries the
 		// binary name and a status, never anything from args.
@@ -233,7 +357,7 @@ func (c *client) runRaw(ctx context.Context, args ...string) (string, error) {
 		safe, secrets := redactedArgv(args, nil)
 		var ee *exec.ExitError
 		if errors.As(err, &ee) && len(ee.Stderr) > 0 {
-			return "", fmt.Errorf("herdr %v: %s", safe, redactText(string(ee.Stderr), secrets))
+			return "", fmt.Errorf("herdr %v: %w", safe, &herdrStderr{Text: redactText(string(ee.Stderr), secrets)})
 		}
 		// See run: exec's own error carries the binary name and a status only.
 		return "", fmt.Errorf("herdr %v: %w", safe, err)
@@ -329,7 +453,7 @@ func (c *client) deliverNudge(ctx context.Context, paneID, text string) error {
 	if err == nil {
 		return nil
 	}
-	if !isAgentNotFound(err) {
+	if !c.targetHasNoNamedAgent(ctx, paneID, err) {
 		return err
 	}
 	return c.pasteAndSubmit(ctx, paneID, text)
@@ -406,7 +530,7 @@ func (c *client) deliverStartupTurn(ctx context.Context, paneID, text string) er
 	if err == nil {
 		return nil
 	}
-	if isAgentNotFound(err) {
+	if c.targetHasNoNamedAgent(ctx, paneID, err) {
 		return c.pasteAndSubmit(ctx, paneID, text)
 	}
 	switch herdrErrorCode(err) {
@@ -449,17 +573,82 @@ func (c *client) pasteAndSubmit(ctx context.Context, paneID, text string) error 
 	return c.sendKeys(ctx, paneID, "Enter")
 }
 
-// isAgentNotFound reports whether err is herdr's missing-agent rejection
-// (typed agent_not_found, or the message-text forms the pre-typed-error
-// callers matched on).
-func isAgentNotFound(err error) bool {
+// targetHasNoNamedAgent reports whether a failed herdr verb failed because the
+// target carries no named agent to act on: a raw `exec /bin/sh -c` pane, a bare
+// shell, a pane holding only a reported agent state. Those have no prompt
+// machinery, so callers degrade to typing into the pane directly, or treat an
+// idle wait as nothing to wait on.
+//
+// The question is answered by asking herdr's agent registry, not by reading the
+// failure's text. Text cannot answer it. The error this client returns renders the
+// argv next to herdr's complaint, and for `agent prompt` that argv is the nudge
+// body, so matching the rendered error asks what the nudge said as much as what
+// herdr said: a nudge quoting herdr's own wording made deliverNudge treat an
+// unrelated busy-pane rejection as agentless, swallow it, and paste into a pane
+// with a foreground process. Narrowing to herdr's own stderr does not fix it,
+// because herdr quotes the offending operand back on its ordinary failure paths
+// (see redaction.go), and subtracting our operands from its text deletes a phrase
+// herdr wrote whenever a nudge repeats it. One text stream carrying both voices
+// cannot be attributed. The registry can: nothing a caller passes in changes what
+// `agent list` reports.
+//
+// It is also the distinction itself, not a proxy for it. A kind-launched agent is
+// registered from the moment it starts, so an agent that is merely still booting
+// is present and this returns false, which is what keeps a startup turn from
+// being typed into a TUI that is not accepting input yet. 0.7.x and 0.8.0 spell
+// the rejection differently (agent_not_found became agent_not_ready plus "is not
+// an active named agent"), and that respelling is exactly what silently killed
+// this fallback before; the registry answer does not move when herdr renames a
+// code.
+//
+// The registry answers what the pane carries, though, never why this call failed,
+// so herdr still has to have declined over the agent: see agentStateRejection for
+// why an uncoded failure is not evidence, and why a grant is read from a narrower
+// channel than a refusal. When herdr names a different problem that rules the
+// fallback out; see disqualifyingCode. And when herdr answers agent_not_found, it
+// has answered THIS question about THIS invocation, so that is taken directly and
+// no query is made. A registry lookup that itself fails rules the fallback out too,
+// so the caller sees the original failure rather than a guess.
+//
+// The query is a present-time snapshot, which leaves a window: between the
+// rejection and the lookup, a booting agent can exit (the lookup then reports an
+// agentless pane and the turn is pasted into whatever is left of it) or a new one
+// can register (the lookup reports an agent and a raw pane loses its fallback,
+// which surfaces as an error the caller retries). The window is not closable from
+// here. Answering from the failure itself would mean reading its text, and the
+// text is not attributable; herdr offers no way to ask "was there an agent when
+// that call failed". agent_not_found above is the one case where herdr does answer
+// exactly that, which is why it bypasses the query rather than confirming it.
+func (c *client) targetHasNoNamedAgent(ctx context.Context, target string, err error) bool {
 	if err == nil {
 		return false
 	}
-	if herdrErrorCode(err) == "agent_not_found" {
+	if disqualifyingCode(err) != "" {
+		return false
+	}
+	// The registry answers what the pane carries, never why this call failed.
+	// Without herdr having declined over the agent, an empty registry would turn
+	// any failure at all into a paste. See agentStateRejection.
+	if !agentStateRejection(err) {
+		return false
+	}
+	// agent_not_found is herdr answering the question itself, about the
+	// invocation that just failed, so take it and skip the query: that answer
+	// cannot be stale, and the query's answer can. It counts from either channel
+	// herdr answers in, and on a non-zero exit that is the stderr one.
+	if herdrAnswerCode(err) == "agent_not_found" {
 		return true
 	}
-	return strings.Contains(err.Error(), "not_found") || strings.Contains(err.Error(), "not found")
+	agents, lerr := c.listAgents(ctx)
+	if lerr != nil {
+		return false
+	}
+	for _, a := range agents {
+		if a.PaneID == target || a.Name == target {
+			return false
+		}
+	}
+	return true
 }
 
 // submitSettleDelay is how long the unregistered-pane fallback waits for a

--- a/internal/runtime/herdr/no_named_agent_test.go
+++ b/internal/runtime/herdr/no_named_agent_test.go
@@ -1,0 +1,430 @@
+package herdr
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// registryFake writes a fake herdr that answers `agent list` from registered and
+// rejects `agent prompt` / `agent wait` with rejection, recording every argv it
+// was called with to the returned trace path.
+//
+// rejection is the text the fake emits for those verbs. A leading "!" means it
+// goes to stderr with a non-zero exit, which is how herdr reports a rejection
+// from the CLI; otherwise it is an envelope on stdout.
+func registryFake(t *testing.T, registered []string, rejection string) (bin, trace string) {
+	t.Helper()
+	entries := make([]string, 0, len(registered))
+	for i, entry := range registered {
+		name, pane := fmt.Sprintf("a%d", i), entry
+		// "<name>=<pane>" registers an agent whose name and pane differ, which is
+		// how the name branch of the lookup gets exercised: delivery passes a
+		// pane id to the predicate, waitForIdleOutcome passes an agent name.
+		if n, p, ok := strings.Cut(entry, "="); ok {
+			name, pane = n, p
+		}
+		entries = append(entries, fmt.Sprintf(`{"agent":"%s","pane_id":"%s","agent_status":"working"}`, name, pane))
+	}
+	list := `{"result":{"agents":[` + strings.Join(entries, ",") + `]}}`
+	if registered == nil {
+		list = `{"error":{"code":"server_not_running","message":"no herdr server is running"}}`
+	}
+
+	trace = filepath.Join(t.TempDir(), "verbs")
+	reject := "    echo '" + rejection + "'\n"
+	switch {
+	case rejection == "!!echo-argv":
+		// A usage rejection that lists the operands it choked on, each on its
+		// own line, which is how a caller's text can reach stderr in a shape
+		// that parses as an envelope.
+		reject = "    echo 'unexpected arguments:' >&2\n" +
+			"    for a in \"$@\"; do echo \"$a\" >&2; done\n" +
+			"    exit 1\n"
+	case strings.HasPrefix(rejection, "!"):
+		reject = "    echo '" + rejection[1:] + "' >&2\n    exit 1\n"
+	}
+	script := "#!/bin/sh\n" +
+		"for a in \"$@\"; do echo \"$a\" >> " + trace + "; done\n" +
+		"echo '---' >> " + trace + "\n" +
+		"case \"$*\" in\n" +
+		"  *'agent list'*)\n" +
+		"    echo '" + list + "'\n" +
+		"    ;;\n" +
+		"  *'agent prompt'*|*'agent wait'*)\n" +
+		reject +
+		"    ;;\n" +
+		"esac\n" +
+		"exit 0\n"
+	return writeFakeHerdr(t, script), trace
+}
+
+// TestTargetHasNoNamedAgentAsksTheRegistryNotTheErrorText pins the decision the
+// paste fallback turns on, and pins WHERE the answer comes from.
+//
+// The registry is the authority because the failure's text cannot be one: it
+// renders the argv this client passed next to herdr's own complaint, and for
+// `agent prompt` that argv is the nudge body. Every arm carrying a nudge that
+// quotes or forges herdr's wording exists because a text-matching version of this
+// predicate got that arm wrong.
+//
+// The reported code still has one job, which the busy-pane arms pin: when herdr
+// names a different problem, the fallback is off, because pasting then would type
+// into whatever the real failure was about and swallow it.
+func TestTargetHasNoNamedAgentAsksTheRegistryNotTheErrorText(t *testing.T) {
+	const (
+		agentless = `{"error":{"code":"agent_not_ready","message":"agent w1:p1 is not an active named agent"},"id":"cli:agent:prompt"}`
+		booting   = `{"error":{"code":"agent_not_ready","message":"agent w1:p1 is starting up"},"id":"cli:agent:prompt"}`
+		busy      = `{"error":{"code":"agent_pane_busy","message":"pane w1:p1 has a foreground process"},"id":"cli:agent:prompt"}`
+		notFound  = `{"error":{"code":"agent_not_found","message":"no agent registered for w1:p1"},"id":"cli:agent:prompt"}`
+	)
+	for _, tc := range []struct {
+		name       string
+		registered []string
+		nudge      string
+		rejection  string
+		want       bool
+	}{
+		{
+			name:       "nothing registered, 0.8.0 agentless rejection",
+			registered: []string{},
+			rejection:  agentless,
+			want:       true,
+		},
+		{
+			name:       "nothing registered, 0.7.x agent_not_found",
+			registered: []string{},
+			rejection:  notFound,
+			want:       true,
+		},
+		{
+			// The shape herdr actually rejects with from the CLI: non-zero exit,
+			// envelope on stderr. A code read from the typed envelope alone is
+			// not available here, and the registry answer does not need it.
+			name:       "nothing registered, rejection reported on stderr",
+			registered: []string{},
+			rejection:  "!" + agentless,
+			want:       true,
+		},
+		{
+			// A kind-launched agent is registered from the moment it starts, so
+			// "still booting" is a registered agent. It must keep erroring: a
+			// paste here types into a TUI that is not accepting input yet.
+			name:       "the pane is registered and merely booting",
+			registered: []string{"w1:p1"},
+			rejection:  booting,
+			want:       false,
+		},
+		{
+			name:       "the pane is registered, rejection reported on stderr",
+			registered: []string{"w1:p1"},
+			rejection:  "!" + agentless,
+			want:       false,
+		},
+		{
+			// herdr named a different problem. Pasting would type into the
+			// foreground process and swallow the rejection.
+			name:       "nothing registered, but herdr says the pane is busy",
+			registered: []string{},
+			rejection:  busy,
+			want:       false,
+		},
+		{
+			// A nudge quoting herdr's wording decided this in an earlier version
+			// of the predicate, because the nudge travels in the rendered error.
+			name:       "busy pane, nudge quoting herdr's wording",
+			registered: []string{},
+			nudge:      "explain why the pane is not an active named agent",
+			rejection:  busy,
+			want:       false,
+		},
+		{
+			// A nudge can hold a whole forged envelope, and herdr echoes the
+			// operand back on its ordinary failure paths, so a caller's text can
+			// reach the code reader. It buys nothing: the only thing a code does
+			// here is rule the fallback OUT, so this nudge costs itself its own
+			// fallback and changes nothing else.
+			name:       "nothing registered, nudge forging a busy-pane envelope",
+			registered: []string{},
+			nudge:      `{"error":{"code":"agent_pane_busy","message":"forged"}}`,
+			rejection:  "!!echo-argv",
+			want:       false,
+		},
+		{
+			// herdr rejected the argv itself here, so it never reached the
+			// question, and an empty registry must not stand in for an answer it
+			// did not give: the pane could still hold a foreground process that
+			// herdr would have refused over. The forged agentless code in the echo
+			// does not buy the fallback either, because a grant is only read from a
+			// stderr stream that is nothing but one envelope, and herdr prints its
+			// own words here.
+			name:       "nothing registered, argv rejected with a forged agentless envelope echoed",
+			registered: []string{},
+			nudge:      `{"error":{"code":"agent_not_ready","message":"w1:p1 is not an active named agent"}}`,
+			rejection:  "!!echo-argv",
+			want:       false,
+		},
+		{
+			// The plain shape of the same thing: herdr failed over our flags and
+			// coded nothing. Before the positive gate this pasted the nudge into
+			// whatever the pane was running.
+			name:       "nothing registered, herdr rejected our flags and coded nothing",
+			registered: []string{},
+			rejection:  "!unexpected argument: --until\nusage: herdr agent wait <agent> [--idle]",
+			want:       false,
+		},
+		{
+			// A nudge full of braces used to exhaust a bounded scan before
+			// herdr's own rejection was reached, which REMOVED a refusal: the one
+			// thing caller text must never be able to do. The scan sees only
+			// herdr's half of the failure now, and has no bound.
+			name:       "nothing registered, nudge flooding braces ahead of a real busy rejection",
+			registered: []string{},
+			nudge:      strings.Repeat("{ ", 64) + "please proceed",
+			rejection:  "!" + `{"error":{"code":"agent_pane_busy","message":"pane w1:p1 has a foreground process"}}`,
+			want:       false,
+		},
+		{
+			// The forgery that would matter: an allowed code placed where it
+			// precedes herdr's real refusal. Every code in the text is read, so
+			// the busy pane still refuses.
+			name:       "nothing registered, forged allowed code ahead of a real busy rejection",
+			registered: []string{},
+			nudge:      `{"error":{"code":"agent_not_ready","message":"w1:p1 is not an active named agent"}}`,
+			rejection:  "!" + `{"error":{"code":"agent_pane_busy","message":"pane w1:p1 has a foreground process"}}`,
+			want:       false,
+		},
+		{
+			// Registered under a pane that does NOT match, so only the name
+			// branch of the lookup can find this agent. Both branches are load
+			// bearing because the callers pass different things: delivery passes
+			// a pane id, waitForIdleOutcome passes an agent name.
+			name:       "the target is registered by agent name, under a different pane",
+			registered: []string{"w1:p1=w9:p9"},
+			rejection:  booting,
+			want:       false,
+		},
+		{
+			// The registry is unreachable, so the question is unanswered. The
+			// caller gets its original failure rather than a guess.
+			name:       "the registry cannot be read",
+			registered: nil,
+			rejection:  agentless,
+			want:       false,
+		},
+		{
+			// An unreadable registry is not fatal when herdr already answered
+			// the question outright, which is the other half of skipping the
+			// query on agent_not_found.
+			name:       "the registry cannot be read, but herdr answered agent_not_found",
+			registered: nil,
+			rejection:  "!" + notFound,
+			want:       true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bin, _ := registryFake(t, tc.registered, tc.rejection)
+			c := &client{session: "gc-test", bin: bin}
+			nudge := tc.nudge
+			if nudge == "" {
+				nudge = "proceed"
+			}
+			err := c.agentPrompt(context.Background(), "w1:p1", nudge)
+			if err == nil {
+				t.Fatal("fake herdr rejection produced no error")
+			}
+			if got := c.targetHasNoNamedAgent(context.Background(), "w1:p1", err); got != tc.want {
+				t.Errorf("targetHasNoNamedAgent = %v, want %v (err: %v)", got, tc.want, err)
+			}
+		})
+	}
+
+	c := &client{session: "gc-test", bin: "unused"}
+	if c.targetHasNoNamedAgent(context.Background(), "w1:p1", nil) {
+		t.Error("targetHasNoNamedAgent(nil error) = true")
+	}
+}
+
+// TestDeliverNudgeFallsBackWhenThePaneHasNoNamedAgent is the behavior the
+// decision buys, asserted through the verb a caller actually uses: a pane with no
+// named agent has no prompt machinery, so the nudge still lands via paste + Enter.
+func TestDeliverNudgeFallsBackWhenThePaneHasNoNamedAgent(t *testing.T) {
+	const (
+		agentless = `{"error":{"code":"agent_not_ready","message":"agent w1:p1 is not an active named agent"},"id":"cli:agent:prompt"}`
+		booting   = `{"error":{"code":"agent_not_ready","message":"agent w1:p1 is starting up"},"id":"cli:agent:prompt"}`
+	)
+	for _, tc := range []struct {
+		name       string
+		registered []string
+		rejection  string
+		wantErr    bool
+		wantPasted bool
+	}{
+		{
+			name:       "no named agent on the pane",
+			registered: []string{},
+			rejection:  agentless,
+			wantPasted: true,
+		},
+		{
+			name:       "named agent still booting",
+			registered: []string{"w1:p1"},
+			rejection:  booting,
+			wantErr:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bin, trace := registryFake(t, tc.registered, tc.rejection)
+			c := &client{session: "gc-test", bin: bin}
+
+			err := c.deliverNudge(context.Background(), "w1:p1", "proceed with the drain")
+			if tc.wantErr && err == nil {
+				t.Fatal("deliverNudge returned nil for a booting agent; the turn was typed into a TUI that is not accepting input")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("deliverNudge: %v", err)
+			}
+			assertPasted(t, trace, tc.wantPasted)
+		})
+	}
+}
+
+// TestDeliverStartupTurnFallsBackWhenThePaneHasNoNamedAgent covers the second
+// caller, which the nudge test does not reach: deliverStartupTurn asks herdr for
+// submission confirmation, and a pane with no named agent has nothing to confirm
+// against, so the first turn must still land via paste + Enter.
+func TestDeliverStartupTurnFallsBackWhenThePaneHasNoNamedAgent(t *testing.T) {
+	bin, trace := registryFake(t, []string{},
+		`{"error":{"code":"agent_not_ready","message":"agent w1:p1 is not an active named agent"},"id":"cli:agent:prompt"}`)
+	c := &client{session: "gc-test", bin: bin}
+
+	if err := c.deliverStartupTurn(context.Background(), "w1:p1", "first turn"); err != nil {
+		t.Fatalf("deliverStartupTurn on a pane with no named agent: %v", err)
+	}
+	assertPasted(t, trace, true)
+}
+
+// TestWaitForIdleOutcomeTreatsAPaneWithNoNamedAgentAsNothingToWaitOn covers the
+// third caller. A raw shell pane has no agent to wait on, so the wait is a no-op
+// the caller may proceed past; classifying it as an error instead stalls a session
+// start behind a wait that can never be satisfied. The booting arm is the other
+// side: a registered agent's failed wait is a real error, not an absence.
+func TestWaitForIdleOutcomeTreatsAPaneWithNoNamedAgentAsNothingToWaitOn(t *testing.T) {
+	const rejection = `{"error":{"code":"agent_not_ready","message":"agent gc-shell-only is not an active named agent"},"id":"cli:agent:wait"}`
+
+	bin, _ := registryFake(t, []string{}, rejection)
+	if got := (&Provider{c: &client{session: "gc-test", bin: bin}}).
+		waitForIdleOutcome(context.Background(), "shell-only", 10*time.Millisecond); got != idleWaitNoAgent {
+		t.Errorf("waitForIdleOutcome on an unregistered pane = %v, want %v", got, idleWaitNoAgent)
+	}
+
+	bin, _ = registryFake(t, []string{herdrAgentName("shell-only")}, rejection)
+	if got := (&Provider{c: &client{session: "gc-test", bin: bin}}).
+		waitForIdleOutcome(context.Background(), "shell-only", 10*time.Millisecond); got != idleWaitError {
+		t.Errorf("waitForIdleOutcome on a registered agent = %v, want %v", got, idleWaitError)
+	}
+}
+
+// TestAgentNotFoundIsTakenFromHerdrWithoutAQuery pins the one answer that needs no
+// query. agent_not_found is herdr answering this very question about this very
+// invocation, so it cannot be stale, while the registry snapshot can: a booting
+// agent that exits between the rejection and the lookup would read as an agentless
+// pane. Where herdr has already answered, the window does not get opened.
+//
+// Both arms matter, and the stderr one is the shape this actually arrives in: on a
+// non-zero exit nothing reaches the stdout decode, so an answer read only from the
+// typed envelope would be missed on almost every real rejection.
+func TestAgentNotFoundIsTakenFromHerdrWithoutAQuery(t *testing.T) {
+	const notFound = `{"error":{"code":"agent_not_found","message":"no agent registered for w1:p1"},"id":"cli:agent:prompt"}`
+	for _, tc := range []struct {
+		name      string
+		rejection string
+	}{
+		{name: "envelope parsed from stdout", rejection: notFound},
+		{name: "bare envelope on stderr, non-zero exit", rejection: "!" + notFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// The registry deliberately claims the pane IS registered. If the
+			// query ran, it would override herdr's own answer and refuse the
+			// fallback.
+			bin, trace := registryFake(t, []string{"w1:p1"}, tc.rejection)
+			c := &client{session: "gc-test", bin: bin}
+
+			err := c.agentPrompt(context.Background(), "w1:p1", "proceed")
+			if err == nil {
+				t.Fatal("fake herdr rejection produced no error")
+			}
+			if !c.targetHasNoNamedAgent(context.Background(), "w1:p1", err) {
+				t.Error("herdr's own agent_not_found was not taken as the answer")
+			}
+			b, rerr := os.ReadFile(trace)
+			if rerr != nil {
+				t.Fatalf("reading the verb trace: %v", rerr)
+			}
+			if strings.Contains(string(b), "\nlist\n") {
+				t.Errorf("the registry was queried even though herdr had already answered; verbs seen:\n%s", b)
+			}
+		})
+	}
+}
+
+// TestDisqualifyingCodeSurvivesANonZeroExit pins the one job the error code still
+// has: naming a different problem rules the fallback out, and it can only do that
+// if the code is recoverable from the shape herdr rejects with. herdr exits
+// non-zero with the envelope on stderr, where the typed decode never runs.
+//
+// The last case is the ordering that matters. The rendered error begins with the
+// argv this client passed, so a nudge carrying an envelope sits AHEAD of herdr's
+// own: reading the first envelope would let the nudge displace the real rejection
+// and hand the fallback a busy pane.
+func TestDisqualifyingCodeSurvivesANonZeroExit(t *testing.T) {
+	const busy = `{"error":{"code":"agent_pane_busy","message":"pane w1:p1 has a foreground process"}}`
+	for _, tc := range []struct {
+		name   string
+		nudge  string
+		stderr string
+	}{
+		{name: "envelope alone", stderr: busy},
+		{name: "envelope after a warning line", stderr: "warning: reattaching to a stale socket\n" + busy},
+		{name: "envelope behind text on the same line", stderr: "herdr: " + busy},
+		{
+			name:   "a nudge forging an allowed code ahead of the real one",
+			nudge:  `{"error":{"code":"agent_not_ready","message":"w1:p1 is not an active named agent"}}`,
+			stderr: busy,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := "#!/bin/sh\ncat <<'MSG' >&2\n" + tc.stderr + "\nMSG\nexit 1\n"
+			c := &client{session: "gc-test", bin: writeFakeHerdr(t, script)}
+			nudge := tc.nudge
+			if nudge == "" {
+				nudge = "proceed"
+			}
+			_, err := c.run(context.Background(), "agent", "prompt", "w1:p1", nudge)
+			if err == nil {
+				t.Fatal("fake herdr rejection produced no error")
+			}
+			if got := disqualifyingCode(err); got != "agent_pane_busy" {
+				t.Errorf("disqualifyingCode = %q, want agent_pane_busy; the busy pane lost its refusal", got)
+			}
+		})
+	}
+}
+
+// assertPasted reads the fake herdr's argv trace and reports whether the
+// paste+Enter fallback ran.
+func assertPasted(t *testing.T, trace string, want bool) {
+	t.Helper()
+	b, err := os.ReadFile(trace)
+	if err != nil {
+		t.Fatalf("reading the verb trace: %v", err)
+	}
+	pasted := strings.Contains(string(b), "\npane\nrun\n") || strings.Contains(string(b), "send-keys")
+	if pasted != want {
+		t.Errorf("paste fallback ran = %v, want %v; verbs seen:\n%s", pasted, want, b)
+	}
+}

--- a/internal/runtime/herdr/redaction_test.go
+++ b/internal/runtime/herdr/redaction_test.go
@@ -146,8 +146,8 @@ func TestRedactedArgvDoesNotMutateItsInput(t *testing.T) {
 // on this provider's own named-session path. Substituting a value that short
 // into free text is blind to word boundaries, so it would rewrite the label, the
 // cwd, an argv-safe GC_RUNTIME_EPOCH=1, and — the part that breaks behavior —
-// herdr's "agent not found", which isAgentNotFound and runtime.IsSessionGone
-// both decide by matching.
+// herdr's "agent not found", which runtime.IsSessionGone
+// decides by matching.
 //
 // So the short value is still withheld structurally, where the grammar knows
 // exactly which bytes it is, and simply not hunted for anywhere else.
@@ -249,41 +249,48 @@ func TestPaneRunLeavesPastedTextAlone(t *testing.T) {
 	}
 }
 
-// TestPromptRedactionDoesNotBreakNotFoundMatching is why that matters.
-// deliverNudge and deliverStartupTurn degrade to the paste+Enter path when
-// herdr reports the agent is not registered, and isAgentNotFound decides that by
-// matching the message text; runtime.IsSessionGone matches "not found" the same
-// way to tell a benign missing session from a real failure. Redacting "no" out
-// of a nudge would take the "no" in "not found" with it and flip both verdicts —
-// a redactor breaking control-flow branches it has no business touching.
+// TestPromptRedactionDoesNotBreakNotFoundMatching is why that matters. Two
+// consumers read this text and both decide control flow from it:
+// runtime.IsSessionGone tells a vanished session from a real failure by matching
+// "not found" in whatever the provider returned, and this client recovers herdr's
+// refusing error code by finding the error envelope in the same text. Redacting "no" out of
+// a nudge would take the "no" in "not found" with it, and redacting a fragment of
+// the envelope would cost the code, so a redactor would be silently taking over
+// branches it has no business touching.
 //
-// Both delivery verbs are covered: the prompt operand of `agent prompt` and the
-// pasted operand of `pane run`.
+// The short value is DECLARED here, which is the only way it reaches the redactor:
+// the values the argv grammar finds on its own are --env assignments and launch
+// arguments, and prose in a nudge is never one. Declaring it is what puts the
+// length floor under test rather than the absence of any substitution at all.
+// Lower substitutionFloor and both subtests go red.
 func TestPromptRedactionDoesNotBreakNotFoundMatching(t *testing.T) {
 	const text = "Rerun the drain with mode=no so nothing merges."
-	script := "#!/bin/sh\necho 'agent not found: %12' >&2\nexit 1\n"
 
-	for _, tc := range []struct {
-		name string
-		call func(c *client) error
-	}{
-		{"agent prompt", func(c *client) error {
-			return c.agentPrompt(context.Background(), "%12", text)
-		}},
-		{"pane run paste", func(c *client) error {
-			return c.paneRun(context.Background(), "%12", text)
-		}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.call(&client{session: "gc-test", bin: writeFakeHerdr(t, script)})
-			if err == nil {
-				t.Fatal("call against a failing herdr returned no error")
-			}
-			if !isAgentNotFound(err) {
-				t.Errorf("redaction mangled the message isAgentNotFound reads, so the fallback is dead: %v", err)
-			}
-		})
-	}
+	t.Run("a declared short value does not eat the session-gone phrase", func(t *testing.T) {
+		script := "#!/bin/sh\necho 'agent not found: %12' >&2\nexit 1\n"
+		c := &client{session: "gc-test", bin: writeFakeHerdr(t, script)}
+		_, err := c.runWithSecrets(context.Background(), []string{"no"}, "agent", "prompt", "%12", text)
+		if err == nil {
+			t.Fatal("call against a failing herdr returned no error")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("redacting a declared %q mangled the phrase runtime.IsSessionGone reads: %v", "no", err)
+		}
+	})
+
+	t.Run("a declared short value does not cost the refusing code", func(t *testing.T) {
+		script := "#!/bin/sh\ncat <<'JSON' >&2\n" +
+			`{"error":{"code":"agent_pane_busy","message":"pane %12 has a foreground process"}}` +
+			"\nJSON\nexit 1\n"
+		c := &client{session: "gc-test", bin: writeFakeHerdr(t, script)}
+		_, err := c.runWithSecrets(context.Background(), []string{"an"}, "agent", "prompt", "%12", text)
+		if err == nil {
+			t.Fatal("call against a failing herdr returned no error")
+		}
+		if got := disqualifyingCode(err); got != "agent_pane_busy" {
+			t.Errorf("redacting a declared %q cost the refusing code: %q from %v", "an", got, err)
+		}
+	})
 }
 
 // TestClientRunErrorsOmitCredentials is the end-to-end assertion behind the unit

--- a/internal/runtime/redact.go
+++ b/internal/runtime/redact.go
@@ -12,9 +12,11 @@ const RedactedValue = "<redacted>"
 // substitutionFloor is the shortest value [RedactSecrets] will substitute.
 // Substitution is blind to word boundaries, so hiding a short value mangles
 // unrelated text: with "no" a secret, herdr's "agent not found" becomes
-// "agent <redacted>t found", and both the herdr client's isAgentNotFound and
-// [IsSessionGone] decide by matching that phrase — a redactor silently taking
-// over branches that turn a tolerated missing session into a hard failure.
+// "agent <redacted>t found", and [IsSessionGone] decides by matching that phrase
+// — a redactor silently taking over branches that turn a tolerated missing
+// session into a hard failure. (The herdr client used to decide the same way and
+// now gates on herdr's reported error code instead, for a related reason: the
+// rendered text it was matching also carried the argv it had passed in.)
 //
 // The floor buys that back because the two populations barely overlap: the
 // credentials that reach a session are long (the instance token is 32 hex


### PR DESCRIPTION
## What broke

`isAgentNotFound` matched one spelling of "the target pane carries no named agent
to act on": herdr 0.7.x's `agent_not_found` code. herdr 0.8.0 answers the same
situation differently, with `agent_not_ready` and the message "is not an active
named agent", so three call sites lost their fallback:

- `deliverNudge` stopped falling back to pasting the nudge into the pane.
- `deliverStartupTurn` stopped falling back to pasting the startup turn.
- `waitForIdleOutcome` stopped reporting `idleWaitNoAgent` and fell through to
  `idleWaitError`, so a raw shell pane with no agent to wait on read as a transport
  failure.

Nothing failed to compile and no test went red. The two tests in `cmd/gc` that
drive a real herdr skip themselves when `exec.LookPath("herdr")` finds no binary,
which is the case on the build machines, so the loss was invisible there.

## The question is asked of herdr's registry, not of the error text

Matching the error text was the deeper defect, and widening the match would have
kept it. This client renders the argv it passed next to herdr's complaint, and for
`agent prompt` that argv is the nudge body, so `strings.Contains(err.Error(), ...)`
asks what the nudge said as much as what herdr said: a nudge quoting the phrase
turned an unrelated `agent_pane_busy` rejection into "no named agent here",
swallowed the real error, and pasted into a pane with a foreground process.

Narrowing to herdr's own stderr does not fix that. herdr quotes the offending
operand back on its ordinary failure paths, which `redaction.go` already documents
and builds on, so its stderr fuses its words with an echo of ours; and subtracting
our operands from its text deletes a phrase herdr wrote whenever a nudge happens
to repeat it. One text stream carrying two voices cannot be attributed.

So the decision now asks the registry:

```go
agents, lerr := c.listAgents(ctx)
if lerr != nil {
	return false
}
for _, a := range agents {
	if a.PaneID == target || a.Name == target {
		return false
	}
}
return true
```

Nothing a caller passes in changes what `agent list` reports. The registry is also
the distinction itself rather than a proxy for it: a kind-launched agent is
registered from the moment it starts, so an agent that is merely still booting is
present and keeps erroring, which is what stops a startup turn from being typed
into a TUI that is not accepting input yet. And the registry's answer does not move when
herdr renames a code, which is how this fallback died in the first place; what a
rename still costs is below.

The cost is one `agent list` round-trip, on the failure path only.

## What the error code is still for

When herdr names a different problem, that rules the fallback out.
`agent_pane_busy` is herdr saying the pane has a foreground process, and pasting
there would type into whatever the failure was about and swallow it. So the code is
read, and anything outside `agent_not_found` / `agent_not_ready` (or no code at
all) refuses the fallback.

The code is read in both directions, from different channels, and that asymmetry is
what keeps a nudge from deciding anything.

A refusal may be found anywhere in herdr's stderr, because adding one only declines
a fallback: a nudge that forges `agent_pane_busy` costs itself its own delivery and
changes nothing else. What caller text must never do is REMOVE a refusal, which
would buy a paste into a busy pane. Two things stop it. herdr's stderr is carried as
its own error type rather than spliced into the message, so the scan reaches herdr's
half of the failure and not the argv rendered beside it, and the argv is where the
nudge body lives. And within that text every envelope is considered, any refusing
code winning, rather than the first one found. Neither is decorative: when only the
first envelope counted, a forged `agent_not_found` placed ahead of herdr's real
`agent_pane_busy` displaced it, and when the scan carried a candidate budget, a nudge
full of `{` exhausted the budget before herdr's own rejection was reached. Both are
pinned by tests, and the no-bound rule is written at the function.

A grant is narrower, because the registry says what a pane carries and never why a
call failed. A failure herdr coded nothing for is our own argv, or a binary that did
not run, and an empty registry must not stand in for an answer herdr never gave: the
pane can still hold a foreground process, which is the thing herdr would have refused
over. So the fallback requires a positive agent-state rejection, read only from a
channel a caller cannot write. That is either the envelope parsed off stdout, or a
stderr stream that is nothing but one error envelope. The second shape is herdr
0.8.0's rejection as verified against the installed binary (the bare envelope, no
prefix and nothing after it), and it carries most real rejections, since a non-zero
exit never reaches the stdout decode. An echo cannot produce it, because when herdr
rejects our argv it prints its own words alongside what it quotes back.

That leaves one cost, in the safe direction. herdr respelling its agent-state code a
third time would leave the fallback refused and herdr's error surfacing, rather than
a paste into a pane nothing was checked on.

One answer skips the registry. `agent_not_found` is herdr answering this question
about the invocation that just failed, so it is taken directly and no query runs,
from either channel it can arrive in.

That matters because the registry read is a present-time snapshot taken after the
rejection: an agent that exits in between would read as an agentless pane, and one
that registers in between as a live one. The window is small, it is not closable
from inside this client, and where herdr has already answered it never opens.

## Tests

New `internal/runtime/herdr/no_named_agent_test.go`, over a fake herdr that serves
a configurable registry and records every argv it is called with:

- A table across registry state and rejection: nothing registered with each
  rejection spelling (including the non-zero-exit stderr shape), the pane
  registered and merely booting, herdr naming a busy pane, a nudge quoting herdr's
  wording, a nudge carrying a forged envelope in either direction, a usage
  rejection herdr coded nothing for, and a registry that cannot be read.
- `deliverNudge`, `deliverStartupTurn`: the paste fallback ran for an unregistered
  pane and did not for a registered one, asserted from the argv trace.
- `waitForIdleOutcome` returns `idleWaitNoAgent` unregistered and `idleWaitError`
  registered.
- The refusing code survives a non-zero exit, including an envelope printed after a
  warning line, one behind text on the same line, and a nudge placing an allowed
  code ahead of the real one.
- A nudge flooding `{` ahead of a real `agent_pane_busy` still refuses the
  fallback, which is the bounded-scan bypass.
- `agent_not_found` is taken from herdr with no `agent list` call, for both the
  stdout envelope and the non-zero-exit stderr shape, asserted from the argv trace
  against a registry that claims the pane IS registered. An unreadable registry
  does not cost the fallback when herdr answered that way either.
- herdr rejecting our own flags, with nothing coded, refuses the fallback even
  against an empty registry, and still refuses when the echoed argv carries a
  forged agentless envelope.

`TestPromptRedactionDoesNotBreakNotFoundMatching` now declares the short value it
is about, which is the only way one reaches the redactor, so the length floor is
what the test exercises rather than the absence of any substitution. Lower
`substitutionFloor` and it goes red. Its two cases are the phrase
`runtime.IsSessionGone` reads and the code recovery above.

`isAgentNotFound` and `isNoNamedAgent` are both gone.

## Test plan

```
go build ./... && go vet ./...
go test ./internal/runtime/herdr/
go test -race ./internal/runtime/herdr/
go test ./internal/runtime/ ./internal/runtime/auto/ ./internal/runtime/hybrid/
go test ./cmd/gc/
go test ./internal/testpolicy/... ./test/docsync/
golangci-lint run ./internal/runtime/...
```

All pass at this head. Each decision in the change was also run against a mutation
of the production code it should catch:

| Mutation | Test that goes red |
| --- | --- |
| decide from the error text instead of the registry | the quoting arm, the stderr arms, the unreadable-registry arm |
| no refusal when herdr names another problem | the busy-pane arms, four startup-delivery tests |
| an unreachable registry read as "no agent" | the unreadable-registry arm |
| registry matched by name only, not pane id | the booting arms |
| `deliverNudge` never falls back | the nudge fallback test |
| `deliverStartupTurn` never falls back | the startup fallback test, and a pre-existing one |
| `waitForIdleOutcome` never reports no-agent | the idle-wait tests |
| the code is no longer recovered from stderr | the code test, the forged-code arm, the redaction guard |
| the scan reads the whole rendered error under a candidate budget | the brace-flood arm |
| `agent_not_found` goes through the registry instead of being taken directly | the query-free test |
| the fallback no longer needs a positive agent-state rejection | the flag-rejection arm, the forged-echo arm |
| a grant is read from any envelope in the stream, not only a whole-stream one | the forged-echo arm |
| herdr's answer is read from the typed envelope only, not from its stderr | the stderr arm of the query-free test, the `agent_not_found` unreadable-registry arm |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcPXz8AxpyCCoDcK7Bu5W
