### PR TITLE
fix(runtime): intersect every capability field in the auto and hybrid composites

### DIFF
--- a/internal/runtime/auto/auto.go
+++ b/internal/runtime/auto/auto.go
@@ -403,6 +403,8 @@ func (p *Provider) Capabilities() runtime.ProviderCapabilities {
 	return runtime.ProviderCapabilities{
 		CanReportAttachment: dc.CanReportAttachment && ac.CanReportAttachment,
 		CanReportActivity:   dc.CanReportActivity && ac.CanReportActivity,
+		CanStream:           dc.CanStream && ac.CanStream,
+		CanAttachTTY:        dc.CanAttachTTY && ac.CanAttachTTY,
 		NeedsClaimBackstop:  dc.NeedsClaimBackstop || ac.NeedsClaimBackstop,
 	}
 }

--- a/internal/runtime/auto/auto_test.go
+++ b/internal/runtime/auto/auto_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -529,5 +530,92 @@ func TestWaitForInterruptBoundaryDelegatesToRoutedBackend(t *testing.T) {
 	last := acpSP.Calls[len(acpSP.Calls)-1]
 	if last.Method != "WaitForInterruptBoundary" || last.Name != "interactive-agent" {
 		t.Fatalf("last call = %#v, want WaitForInterruptBoundary for interactive-agent", last)
+	}
+}
+
+// capsFake overrides the fake's capabilities so the intersection can be
+// exercised with differing backend support.
+type capsFake struct {
+	*runtime.Fake
+	caps runtime.ProviderCapabilities
+}
+
+func (c *capsFake) Capabilities() runtime.ProviderCapabilities { return c.caps }
+
+// TestProvider_CapabilitiesIntersectsEachConnectionOp exercises one field at a
+// time, in both backend orders, so a field cannot pass by being wired to the
+// wrong field, the wrong backend, or with the wrong operator. Setting both
+// fields on both backends, as an earlier shape did, leaves a CanStream wired to
+// CanAttachTTY reporting the right answer for the wrong reason.
+func TestProvider_CapabilitiesIntersectsEachConnectionOp(t *testing.T) {
+	for _, field := range []string{"CanStream", "CanAttachTTY"} {
+		for _, tc := range []struct {
+			name          string
+			first, second bool
+			want          bool
+		}{
+			{name: "both backends capable", first: true, second: true, want: true},
+			{name: "first backend only", first: true},
+			{name: "second backend only", second: true},
+			{name: "neither backend"},
+		} {
+			t.Run(field+"/"+tc.name, func(t *testing.T) {
+				p := New(&capsFake{runtime.NewFake(), capsWith(t, field, tc.first)},
+					&capsFake{runtime.NewFake(), capsWith(t, field, tc.second)})
+				if got := capsField(t, p.Capabilities(), field); got != tc.want {
+					t.Errorf("%s = %v, want %v", field, got, tc.want)
+				}
+			})
+		}
+	}
+}
+
+// capsWith returns capabilities with exactly one named bool field set, so each
+// field's wiring is observed on its own.
+func capsWith(t *testing.T, field string, v bool) runtime.ProviderCapabilities {
+	t.Helper()
+	var caps runtime.ProviderCapabilities
+	f := reflect.ValueOf(&caps).Elem().FieldByName(field)
+	if !f.IsValid() {
+		t.Fatalf("runtime.ProviderCapabilities has no field %q", field)
+	}
+	f.SetBool(v)
+	return caps
+}
+
+// capsField reads one named bool capability.
+func capsField(t *testing.T, caps runtime.ProviderCapabilities, field string) bool {
+	t.Helper()
+	f := reflect.ValueOf(caps).FieldByName(field)
+	if !f.IsValid() {
+		t.Fatalf("runtime.ProviderCapabilities has no field %q", field)
+	}
+	return f.Bool()
+}
+
+// TestProvider_CapabilitiesIntersectsEveryField fails when a field is added to
+// runtime.ProviderCapabilities and not wired into this composite. The
+// intersection is a hand-maintained literal, and a field missing from it reads
+// as "not supported" no matter what either backend reports, which is how
+// CanStream and CanAttachTTY both went unnoticed: nothing consumes them yet, so
+// the first consumer would have inherited the wrong answer with no test red.
+//
+// Both backends report everything true, so the check holds for the fields that
+// intersect with AND and for NeedsClaimBackstop, which is an OR.
+func TestProvider_CapabilitiesIntersectsEveryField(t *testing.T) {
+	all := runtime.ProviderCapabilities{}
+	set := reflect.ValueOf(&all).Elem()
+	for i := 0; i < set.NumField(); i++ {
+		if set.Field(i).Kind() != reflect.Bool {
+			t.Fatalf("%s is not a bool, so this test no longer covers every capability", set.Type().Field(i).Name)
+		}
+		set.Field(i).SetBool(true)
+	}
+
+	got := reflect.ValueOf(New(&capsFake{runtime.NewFake(), all}, &capsFake{runtime.NewFake(), all}).Capabilities())
+	for i := 0; i < got.NumField(); i++ {
+		if !got.Field(i).Bool() {
+			t.Errorf("%s = false with both backends reporting it true: the field is missing from the intersection", got.Type().Field(i).Name)
+		}
 	}
 }

--- a/internal/runtime/hybrid/hybrid.go
+++ b/internal/runtime/hybrid/hybrid.go
@@ -235,6 +235,8 @@ func (p *Provider) Capabilities() runtime.ProviderCapabilities {
 	return runtime.ProviderCapabilities{
 		CanReportAttachment: lc.CanReportAttachment && rc.CanReportAttachment,
 		CanReportActivity:   lc.CanReportActivity && rc.CanReportActivity,
+		CanStream:           lc.CanStream && rc.CanStream,
+		CanAttachTTY:        lc.CanAttachTTY && rc.CanAttachTTY,
 		NeedsClaimBackstop:  lc.NeedsClaimBackstop || rc.NeedsClaimBackstop,
 	}
 }

--- a/internal/runtime/hybrid/hybrid_test.go
+++ b/internal/runtime/hybrid/hybrid_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -309,5 +310,92 @@ func TestIsDeadRuntimeSessionReturnsRoutedCheckerError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "runtime unavailable") {
 		t.Fatalf("IsDeadRuntimeSession error = %v, want runtime unavailable", err)
+	}
+}
+
+// capsFake overrides the fake's capabilities so the intersection can be
+// exercised with differing backend support.
+type capsFake struct {
+	*runtime.Fake
+	caps runtime.ProviderCapabilities
+}
+
+func (c *capsFake) Capabilities() runtime.ProviderCapabilities { return c.caps }
+
+// TestProvider_CapabilitiesIntersectsEachConnectionOp exercises one field at a
+// time, in both backend orders, so a field cannot pass by being wired to the
+// wrong field, the wrong backend, or with the wrong operator. Setting both
+// fields on both backends, as an earlier shape did, leaves a CanStream wired to
+// CanAttachTTY reporting the right answer for the wrong reason.
+func TestProvider_CapabilitiesIntersectsEachConnectionOp(t *testing.T) {
+	for _, field := range []string{"CanStream", "CanAttachTTY"} {
+		for _, tc := range []struct {
+			name          string
+			first, second bool
+			want          bool
+		}{
+			{name: "both backends capable", first: true, second: true, want: true},
+			{name: "first backend only", first: true},
+			{name: "second backend only", second: true},
+			{name: "neither backend"},
+		} {
+			t.Run(field+"/"+tc.name, func(t *testing.T) {
+				p := New(&capsFake{runtime.NewFake(), capsWith(t, field, tc.first)},
+					&capsFake{runtime.NewFake(), capsWith(t, field, tc.second)}, isRemote)
+				if got := capsField(t, p.Capabilities(), field); got != tc.want {
+					t.Errorf("%s = %v, want %v", field, got, tc.want)
+				}
+			})
+		}
+	}
+}
+
+// capsWith returns capabilities with exactly one named bool field set, so each
+// field's wiring is observed on its own.
+func capsWith(t *testing.T, field string, v bool) runtime.ProviderCapabilities {
+	t.Helper()
+	var caps runtime.ProviderCapabilities
+	f := reflect.ValueOf(&caps).Elem().FieldByName(field)
+	if !f.IsValid() {
+		t.Fatalf("runtime.ProviderCapabilities has no field %q", field)
+	}
+	f.SetBool(v)
+	return caps
+}
+
+// capsField reads one named bool capability.
+func capsField(t *testing.T, caps runtime.ProviderCapabilities, field string) bool {
+	t.Helper()
+	f := reflect.ValueOf(caps).FieldByName(field)
+	if !f.IsValid() {
+		t.Fatalf("runtime.ProviderCapabilities has no field %q", field)
+	}
+	return f.Bool()
+}
+
+// TestProvider_CapabilitiesIntersectsEveryField fails when a field is added to
+// runtime.ProviderCapabilities and not wired into this composite. The
+// intersection is a hand-maintained literal, and a field missing from it reads
+// as "not supported" no matter what either backend reports, which is how
+// CanStream and CanAttachTTY both went unnoticed: nothing consumes them yet, so
+// the first consumer would have inherited the wrong answer with no test red.
+//
+// Both backends report everything true, so the check holds for the fields that
+// intersect with AND and for NeedsClaimBackstop, which is an OR.
+func TestProvider_CapabilitiesIntersectsEveryField(t *testing.T) {
+	all := runtime.ProviderCapabilities{}
+	set := reflect.ValueOf(&all).Elem()
+	for i := 0; i < set.NumField(); i++ {
+		if set.Field(i).Kind() != reflect.Bool {
+			t.Fatalf("%s is not a bool, so this test no longer covers every capability", set.Type().Field(i).Name)
+		}
+		set.Field(i).SetBool(true)
+	}
+
+	got := reflect.ValueOf(New(&capsFake{runtime.NewFake(), all}, &capsFake{runtime.NewFake(), all}, isRemote).Capabilities())
+	for i := 0; i < got.NumField(); i++ {
+		if !got.Field(i).Bool() {
+			t.Errorf("%s = false with both backends reporting it true: the field is missing from the intersection", got.Type().Field(i).Name)
+		}
 	}
 }


### PR DESCRIPTION
## What broke

`auto` and `hybrid` each wrap two backends and report the intersection of their
capabilities as a hand-written literal. Two of the five fields were missing from
both literals:

```go
	return runtime.ProviderCapabilities{
		CanReportAttachment: dc.CanReportAttachment && ac.CanReportAttachment,
		CanReportActivity:   dc.CanReportActivity && ac.CanReportActivity,
		NeedsClaimBackstop:  dc.NeedsClaimBackstop || ac.NeedsClaimBackstop,
	}
```

A field left out of the literal is the zero value, so `CanStream` and `CanAttachTTY`
read as false from either composite no matter what the backends reported. `exec`
declares both from its protocol handshake and `herdr` declares `CanAttachTTY`
outright, and routing either of them through `auto` or `hybrid` erased the answer.

Nothing outside tests reads either field yet, which is why nothing went red. The
first consumer would have inherited the wrong answer, and it would have looked like
the backend's own report.

## The fix, and the guard

Both fields are added to both literals with the same `&&` their neighbours use: a
composite can only promise a connection op both backends can serve.

The part worth more than the two lines is that these were the second and third
fields to go missing from a hand-maintained intersection, and nothing was watching.
Each package gets two tests for that.

The first exercises each connection op on its own, in both backend orders: capable
on both, on the first only, on the second only, on neither. Setting both fields
together on both backends, which the first draft did, passes even when `CanStream`
is wired to `CanAttachTTY`; one field at a time does not, and the asymmetric orders
also catch a field wired to one backend twice, an `||` where `&&` was meant, an
equality, and a constant.

The second is a field-sync test: set every bool on both backends, then require the
composite to report every bool. That holds for the `&&` fields and for
`NeedsClaimBackstop`, which is an `||`, and it fails by name when a field is added
to `ProviderCapabilities` and left out of a composite. What it does not cover is a
field present but miswired, which is the first test's job.

## Test plan

```
go build ./... && go vet ./...
go test ./internal/runtime/auto/ ./internal/runtime/hybrid/
go test -race ./internal/runtime/auto/ ./internal/runtime/hybrid/
go test ./internal/runtime/ ./internal/runtime/herdr/ ./internal/runtime/exec/
go test ./cmd/gc/
go test ./internal/testpolicy/... ./test/docsync/
golangci-lint run ./internal/runtime/...
```

All pass at this head. Each claim was also run against a mutation of the production
code it should catch:

| Mutation | Test that goes red |
| --- | --- |
| `CanAttachTTY` removed from `auto`'s literal | both `auto` tests, naming the field |
| `CanStream` removed from `hybrid`'s literal | both `hybrid` tests, naming the field |
| a new bool field added to `ProviderCapabilities` and wired nowhere | the field-sync test in both packages, naming the new field |
| `CanStream` wired to `CanAttachTTY` | the per-field test, both-backends case |
| `CanStream` wired to one backend only | the per-field test, whichever backend was dropped |
| `&&` written as `\|\|` | the per-field test, both single-backend cases |
| `&&` written as `==` | the per-field test, neither-backend case |
| the field set to a constant | the per-field test, three cases |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcPXz8AxpyCCoDcK7Bu5W
