### PR TITLE
fix(herdr): bound the session-socket dial by sessionEventOpTimeout

### DIFF
--- a/internal/runtime/herdr/client.go
+++ b/internal/runtime/herdr/client.go
@@ -32,16 +32,17 @@ import (
 // client runs `herdr` CLI verbs against a named herdr session and decodes the
 // response envelope ({"id":…,"result":…} | {"id":…,"error":{code,message}}).
 type client struct {
-	session     string        // herdr named session (shared per city)
-	bin         string        // herdr binary (default "herdr")
-	cityRoot    string        // city root: the shared server's launch cwd, and the effectiveWorkDir fallback when a session's WorkDir doesn't exist yet (empty in city-less/standalone construction)
-	settleDelay time.Duration // paste-fallback settle before the submit Enter (submitSettleDelay; shortened by tests against a fake herdr)
-	serverMu    sync.Mutex    // serializes startServer: serverAlive → removeStaleSocket → launch → readiness
-	sockPath    string        // test override for socketPath (unit tests point it at a fake server)
+	session     string                                                   // herdr named session (shared per city)
+	bin         string                                                   // herdr binary (default "herdr")
+	cityRoot    string                                                   // city root: the shared server's launch cwd, and the effectiveWorkDir fallback when a session's WorkDir doesn't exist yet (empty in city-less/standalone construction)
+	settleDelay time.Duration                                            // paste-fallback settle before the submit Enter (submitSettleDelay; shortened by tests against a fake herdr)
+	serverMu    sync.Mutex                                               // serializes startServer: serverAlive → removeStaleSocket → launch → readiness
+	sockPath    string                                                   // test override for socketPath (unit tests point it at a fake server)
+	dialUnix    func(ctx context.Context, path string) (net.Conn, error) // test override for the socket connect (unit tests observe the context the dial runs under)
 }
 
 func newClient(session, cityRoot string) *client {
-	return &client{session: session, bin: "herdr", cityRoot: cityRoot, settleDelay: submitSettleDelay}
+	return &client{session: session, bin: "herdr", cityRoot: cityRoot, settleDelay: submitSettleDelay, dialUnix: dialUnix}
 }
 
 type herdrError struct {

--- a/internal/runtime/herdr/dial_bound_test.go
+++ b/internal/runtime/herdr/dial_bound_test.go
@@ -1,0 +1,151 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"net"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestDialSocketBoundsTheConnect pins the bound that sessionEventOpTimeout's own
+// doc comment claims for the dial, and that the dial did not have: both callers
+// set the connection deadline only after DialContext returns, and subscribeCycle
+// dials under the long-lived stream context, which carries no deadline by design,
+// so a connect that never completed hung the stream loop the bound exists to
+// protect.
+//
+// Every arm goes through dialSocket and reads the context the connect actually
+// received, because that is the only thing a listener-free test can observe: a real
+// unix connect completes or fails at once unless the listener's backlog is
+// saturated, so a missing bound looks exactly like a present one.
+func TestDialSocketBoundsTheConnect(t *testing.T) {
+	// dialSlack bounds how far past the op bound a correct deadline may land,
+	// measured from a clock read taken immediately before dialSocket rather than
+	// after it, so only the setup inside the call counts and nothing that happens
+	// to the test goroutine afterwards does. The arms assert the deadline IS the
+	// bound to within that, not merely no later than it: a one-nanosecond bound is
+	// also "no later than" the op bound, and would otherwise pass. Keeping it tight
+	// is what makes a merely-wrong bound, 9.9s for 10s, fail.
+	const dialSlack = 100 * time.Millisecond
+
+	// dialedUnder runs dialSocket with the connect replaced by dial, which
+	// receives the bounded context.
+	dialedUnder := func(t *testing.T, ctx context.Context, dial func(context.Context) error) error {
+		t.Helper()
+		c := &client{
+			session:  "gc-test",
+			sockPath: filepath.Join(t.TempDir(), "herdr.sock"),
+			dialUnix: func(dctx context.Context, _ string) (net.Conn, error) {
+				return nil, dial(dctx)
+			},
+		}
+		_, err := c.dialSocket(ctx)
+		return err
+	}
+
+	// deadlineOf captures the connect's deadline and refuses the dial. It also
+	// returns the moment just before dialSocket ran, which is what the arms
+	// measure the deadline against.
+	notDialing := errors.New("not dialing in a unit test")
+	deadlineOf := func(t *testing.T, ctx context.Context) (deadline time.Time, start time.Time, ok bool) {
+		t.Helper()
+		var got context.Context
+		start = time.Now()
+		if err := dialedUnder(t, ctx, func(dctx context.Context) error {
+			got = dctx
+			return notDialing
+		}); !errors.Is(err, notDialing) {
+			t.Fatalf("dialSocket error = %v, want the fake connect's own error", err)
+		}
+		deadline, ok = got.Deadline()
+		return deadline, start, ok
+	}
+
+	t.Run("a caller without a deadline gets the op bound", func(t *testing.T) {
+		deadline, start, ok := deadlineOf(t, context.Background())
+		if !ok {
+			t.Fatal("the connect ran with no deadline, so a stalled dial is unbounded")
+		}
+		if window := deadline.Sub(start); window < sessionEventOpTimeout || window > sessionEventOpTimeout+dialSlack {
+			t.Errorf("connect deadline %v after the call, want the op bound %v", window, sessionEventOpTimeout)
+		}
+	})
+
+	t.Run("a caller deadline beyond the bound is tightened", func(t *testing.T) {
+		caller, cancel := context.WithTimeout(context.Background(), 3*sessionEventOpTimeout)
+		defer cancel()
+
+		deadline, start, ok := deadlineOf(t, caller)
+		if !ok {
+			t.Fatal("the connect ran with no deadline")
+		}
+		if window := deadline.Sub(start); window < sessionEventOpTimeout || window > sessionEventOpTimeout+dialSlack {
+			t.Errorf("connect deadline %v after the call, want the op bound %v, not merely sooner than the caller's", window, sessionEventOpTimeout)
+		}
+	})
+
+	t.Run("a caller deadline inside the bound survives", func(t *testing.T) {
+		want := time.Now().Add(sessionEventOpTimeout / 10)
+		caller, cancel := context.WithDeadline(context.Background(), want)
+		defer cancel()
+
+		deadline, _, ok := deadlineOf(t, caller)
+		if !ok {
+			t.Fatal("the caller's deadline was dropped")
+		}
+		if !deadline.Equal(want) {
+			t.Errorf("connect deadline = %v, want the caller's own %v", deadline, want)
+		}
+	})
+
+	t.Run("an expired caller deadline stays expired", func(t *testing.T) {
+		caller, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+
+		err := dialedUnder(t, caller, func(dctx context.Context) error { return dctx.Err() })
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("dialSocket error = %v, want context.DeadlineExceeded", err)
+		}
+	})
+
+	t.Run("the constructor installs the production connect", func(t *testing.T) {
+		// dialSocket has no fallback: the field is the only dial, and every
+		// other arm replaces it. So what production connects through is decided
+		// by newClient, and that is what this pins. Identity is the claim, not
+		// the shape of what comes back: a substitute dial can imitate any error
+		// the kernel returns for a path with no socket on it, so asserting on
+		// one would pin nothing about which function ran.
+		c := newClient("gc-test", t.TempDir())
+		if c.dialUnix == nil {
+			t.Fatal("newClient left the connect nil; dialSocket would panic on it")
+		}
+		if got, want := reflect.ValueOf(c.dialUnix).Pointer(), reflect.ValueOf(dialUnix).Pointer(); got != want {
+			t.Errorf("newClient installed %s, want dialUnix",
+				runtime.FuncForPC(got).Name())
+		}
+	})
+
+	t.Run("canceling during the connect reaches it", func(t *testing.T) {
+		caller, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		entered := make(chan struct{})
+		go func() {
+			<-entered
+			cancel()
+		}()
+
+		err := dialedUnder(t, caller, func(dctx context.Context) error {
+			close(entered)
+			<-dctx.Done()
+			return dctx.Err()
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("dialSocket error = %v, want context.Canceled", err)
+		}
+	})
+}

--- a/internal/runtime/herdr/events.go
+++ b/internal/runtime/herdr/events.go
@@ -364,10 +364,29 @@ func resyncEvent() runtime.SessionEvent {
 
 // ── socket-native request helpers ────────────────────────────────────────────
 
-// dialSocket connects to this session server's unix socket.
+// dialSocket connects to this session server's unix socket under
+// sessionEventOpTimeout, which that constant's own comment already describes as
+// bounding the dial. The dial was the one op outside it: both callers set the
+// connection deadline only after DialContext returns, and subscribeCycle dials
+// under the stream context, which carries no deadline at all, so a connect that
+// never completed hung the stream loop the bound exists to protect.
 func (c *client) dialSocket(ctx context.Context) (net.Conn, error) {
+	// The bound only tightens. WithTimeout keeps the earlier of the two
+	// deadlines, so a caller that brought a sooner one keeps it, and the
+	// caller's cancellation still reaches the connect.
+	dctx, cancel := context.WithTimeout(ctx, sessionEventOpTimeout)
+	defer cancel()
+	return c.dialUnix(dctx, c.socketPath())
+}
+
+// dialUnix is the production connect, installed on every client by newClient and
+// reached through the field of the same name so a test can observe the context the
+// dial runs under. That context is the one thing no listener-free test can otherwise
+// see: a real unix connect completes or fails at once unless the listener backlog is
+// saturated, so a missing bound looks exactly like a present one.
+func dialUnix(ctx context.Context, path string) (net.Conn, error) {
 	var d net.Dialer
-	return d.DialContext(ctx, "unix", c.socketPath())
+	return d.DialContext(ctx, "unix", path)
 }
 
 // sockSend writes one request line. params must be non-nil — the server


### PR DESCRIPTION
## What broke

`sessionEventOpTimeout` documents itself as the per-op bound on the session
socket:

```go
	// sessionEventOpTimeout bounds each bounded socket op (dial, subscribe
	// ack, agent.list) so a wedged server cannot hang the stream loop; the
	// event stream itself legitimately idles indefinitely and carries no
	// deadline.
	sessionEventOpTimeout = 10 * time.Second
```

It did not bound the dial. Both callers set the connection deadline only after
`DialContext` returns:

```go
	conn, err := s.c.dialSocket(ctx)
	...
	_ = conn.SetDeadline(time.Now().Add(sessionEventOpTimeout))
```

and `subscribeCycle` dials under the stream context, which carries no deadline on
purpose, because the stream itself idles indefinitely. So a connect that never
completed sat outside every bound in the file, in the one loop the bound exists to
protect.

## The fix

`dialSocket` runs the connect under the op bound. It only tightens: a deadline
beyond the bound is reduced, one already sooner survives, an expired one stays
expired, and the caller's cancellation still reaches the connect after it has
started.

## What the test covers

Six cases, each through `dialSocket` itself rather than a helper beside it, by way of
the client's dial field, which a test replaces the way it already replaces `sockPath`
and `settleDelay`. Four pin the bound: applied when the caller brought no deadline, a
later deadline reduced, a sooner one left alone, an expired one left expired. A fifth
pins the cancellation reaching a connect already in flight.

The two arms that check the derived deadline assert that it *is* the bound, within
100ms, measured from a clock read taken immediately before `dialSocket` rather than
after it. Both halves of that matter: "no later than the bound" is also true of a
one-nanosecond bound, and measuring after the dial returns would count the test
goroutine's own descheduling against the bound and fail a correct implementation.

`newClient` installs the production connect, so the field is the only dial and
`dialSocket` needs no fallback for a nil one. A sixth case pins that wiring through
the constructor, by identity. Identity is the only claim a listener-free test can make
about it: a substitute dial can imitate any error the kernel returns for a path with
no socket on it, so an assertion on the error's shape pins nothing about which
function ran, and an assertion on the errno is not even stable, since a socket path
long enough to exceed `sockaddr_un` fails with `EINVAL` rather than `ENOENT`.

Replacing the dial is what makes any of it observable. A real unix connect completes
or fails at once unless the listener's backlog is saturated, so a missing bound looks
exactly like a present one; reaching that case needs live-tier machinery and would
add a tracked listener to this package's resource census. Reading the context the
connect receives costs a field.

Adding the field widened the struct's comment column, which is the alignment churn
in `client.go`; `gofmt` requires it.

## Test plan

```
go build ./... && go vet ./...
go test ./internal/runtime/herdr/
go test -race ./internal/runtime/herdr/
go test ./internal/runtime/ ./internal/runtime/exec/
go test ./cmd/gc/
go test ./internal/testpolicy/... ./test/docsync/
golangci-lint run ./internal/runtime/...
```

All pass at this head, and the test is clean over 20 plain repeats and 5 under
`-race`. Each claim was run against a mutation of the production code
it should catch:

| Mutation | Test that goes red |
| --- | --- |
| the bound dropped (`WithCancel` in place of `WithTimeout`) | the no-deadline case, the tightening case |
| the bound applied only when the caller brought no deadline | the tightening case |
| the connect detached from the caller (`context.WithoutCancel`) | the surviving-deadline, expired and cancellation cases |
| the bound 1% short (9.9s) or 1% long (10.1s) | both deadline cases |
| the bound one nanosecond | four of the six cases |
| the constructor stops installing the connect | the constructor case, and only that one |
| the constructor installs some other dial | the same case, on the identity |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcPXz8AxpyCCoDcK7Bu5W
