### PR TITLE
Bound supervisor shutdown when a city runtime hangs

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1166,18 +1166,34 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 			stopErr = fmt.Errorf("city %q did not exit within %s after cancel", mc.name, timeout)
 		}
 	}
+	forceTimeout := managedCityForcedStopTimeout(mc)
 	if mc.cr != nil {
 		if mc.cr.forceStopShutdown != nil {
 			mc.cr.forceStopShutdown.Store(true)
 		}
+		// forceDeadline bounds the *combined* time spent inside
+		// runCityShutdownBounded and the wait below by forceTimeout, not
+		// forceTimeout each: runCityShutdownBounded can return early (its
+		// shutdownDone fires as soon as mc.cr.shutdown() itself returns,
+		// which says nothing about whether mc.done has closed yet), so the
+		// remaining wait for mc.done must shrink by however long that
+		// already took rather than restart a fresh full-length timeout.
+		forceDeadline := time.Now().Add(forceTimeout)
 		runCityShutdownBounded(mc)
-	}
-	forceTimeout := managedCityForcedStopTimeout(mc)
-	if forceTimeout > 0 {
+		if forceTimeout > 0 {
+			select {
+			case <-mc.done:
+				// Forced shutdown completed within its budget — the city
+				// is out. Clear the pending error so we report success.
+				stopErr = nil
+			case <-time.After(time.Until(forceDeadline)):
+				fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after forced shutdown\n", mc.name, forceTimeout) //nolint:errcheck
+				stopErr = fmt.Errorf("city %q did not exit within %s after forced shutdown", mc.name, forceTimeout)
+			}
+		}
+	} else if forceTimeout > 0 {
 		select {
 		case <-mc.done:
-			// Forced shutdown completed before the second timeout — the
-			// city is out. Clear the pending error so we report success.
 			stopErr = nil
 		case <-time.After(forceTimeout):
 			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after forced shutdown\n", mc.name, forceTimeout) //nolint:errcheck
@@ -1214,14 +1230,24 @@ func stopManagedCityPreservingSessions(mc *managedCity, _ string, stderr io.Writ
 		}
 	}
 	if waitForRuntimeShutdown && mc.cr != nil {
+		forceTimeout := managedCityForcedStopTimeout(mc)
+		// forceDeadline bounds the *combined* time spent inside
+		// runCityShutdownBounded and the wait below by forceTimeout, not
+		// forceTimeout each — see stopManagedCity for the full rationale:
+		// runCityShutdownBounded can return early (its shutdownDone fires as
+		// soon as mc.cr.shutdown() itself returns, which says nothing about
+		// whether mc.done has closed yet), so the remaining wait for mc.done
+		// must shrink by however long that already took rather than restart
+		// a fresh full-length timeout.
+		forceDeadline := time.Now().Add(forceTimeout)
 		runCityShutdownBounded(mc)
-		if timeout > 0 {
+		if forceTimeout > 0 {
 			select {
 			case <-mc.done:
 				stopErr = nil
-			case <-time.After(timeout):
-				fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after preserve-mode shutdown wait\n", mc.name, timeout) //nolint:errcheck
-				stopErr = fmt.Errorf("city %q did not exit within %s after preserve-mode shutdown wait", mc.name, timeout)
+			case <-time.After(time.Until(forceDeadline)):
+				fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after preserve-mode shutdown wait\n", mc.name, forceTimeout) //nolint:errcheck
+				stopErr = fmt.Errorf("city %q did not exit within %s after preserve-mode shutdown wait", mc.name, forceTimeout)
 			}
 		}
 	}

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1113,6 +1113,31 @@ func managedCityForcedStopTimeout(mc *managedCity) time.Duration {
 	return timeout * 5
 }
 
+// runCityShutdownBounded runs mc.cr.shutdown() in its own goroutine and waits
+// for it to finish, bounded by the forced-stop timeout (or mc.done closing
+// first). shutdown() is idempotent (guarded by sync.Once), so if it is
+// genuinely hung — e.g. on a beads/session call with no context of its own —
+// abandoning the goroutine past the bound is safe: it either completes later
+// on its own or blocks harmlessly forever without doing further work. This
+// keeps a hung shutdown() from blocking the caller's own bounded wait for
+// mc.done (#5256).
+func runCityShutdownBounded(mc *managedCity) {
+	if mc == nil || mc.cr == nil {
+		return
+	}
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer func() { recover() }() //nolint:errcheck
+		defer close(shutdownDone)
+		mc.cr.shutdown()
+	}()
+	select {
+	case <-shutdownDone:
+	case <-mc.done:
+	case <-time.After(managedCityForcedStopTimeout(mc)):
+	}
+}
+
 // stopManagedCity cancels a city's context, waits up to its configured
 // grace period for it to exit, forces shutdown if it doesn't, and then
 // closes the bead provider and file recorder. It returns a non-nil error
@@ -1145,10 +1170,7 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 		if mc.cr.forceStopShutdown != nil {
 			mc.cr.forceStopShutdown.Store(true)
 		}
-		func() {
-			defer func() { recover() }() //nolint:errcheck
-			mc.cr.shutdown()
-		}()
+		runCityShutdownBounded(mc)
 	}
 	forceTimeout := managedCityForcedStopTimeout(mc)
 	if forceTimeout > 0 {
@@ -1192,10 +1214,7 @@ func stopManagedCityPreservingSessions(mc *managedCity, _ string, stderr io.Writ
 		}
 	}
 	if waitForRuntimeShutdown && mc.cr != nil {
-		func() {
-			defer func() { recover() }() //nolint:errcheck
-			mc.cr.shutdown()
-		}()
+		runCityShutdownBounded(mc)
 		if timeout > 0 {
 			select {
 			case <-mc.done:

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -4763,8 +4763,14 @@ func TestStopManagedCityBoundsForcedShutdownWhenRuntimeHangs(t *testing.T) {
 
 	select {
 	case err := <-result:
-		if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
-			t.Fatalf("stopManagedCity took %s, want bounded even when CityRuntime.shutdown hangs", elapsed)
+		// ShutdownTimeout is 20ms, so the forced-stop timeout (5x) is
+		// 100ms: the promised ceiling is grace(20ms) + forced(100ms) =
+		// 120ms. A double wait on the forced timeout — the regression
+		// this test guards against — pushes that to ~220ms, so the bound
+		// here must sit strictly below that, not at the old, much looser
+		// 500ms that a doubled wait still passed.
+		if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+			t.Fatalf("stopManagedCity took %s, want bounded near grace+forced (~120ms) even when CityRuntime.shutdown hangs", elapsed)
 		}
 		if err == nil {
 			t.Fatal("stopManagedCity err = nil, want non-nil because city never exited and shutdown hung")

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -4714,6 +4714,75 @@ func TestStopManagedCityDoesNotUseStartupOrDriftTimeouts(t *testing.T) {
 	assertSingleStopWithBenignNoise(t, ops)
 }
 
+// hangingListProvider wraps a runtime.Provider but makes ListRunning block
+// forever. This simulates a session/beads dependency call inside
+// CityRuntime.shutdown that never returns (#5256) — ListRunning has no
+// context argument, so nothing can bound or cancel it from outside.
+type hangingListProvider struct {
+	runtime.Provider
+}
+
+func (hangingListProvider) ListRunning(string) ([]string, error) {
+	select {}
+}
+
+func TestStopManagedCityBoundsForcedShutdownWhenRuntimeHangs(t *testing.T) {
+	cityPath := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "ops.log")
+	script := writeSpyScript(t, logFile)
+	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+
+	closer := &closerSpy{}
+	forceStop := &atomic.Bool{}
+	mc := &managedCity{
+		name:   "bright-lights",
+		cancel: func() {},
+		done:   make(chan struct{}), // never closes: city never exits on its own
+		closer: closer,
+		cr: &CityRuntime{
+			cfg: &config.City{
+				Daemon: config.DaemonConfig{
+					ShutdownTimeout: "20ms",
+				},
+			},
+			sp:                hangingListProvider{Provider: runtime.NewFake()},
+			rec:               events.Discard,
+			stdout:            io.Discard,
+			stderr:            io.Discard,
+			forceStopShutdown: forceStop,
+		},
+	}
+
+	var stderr bytes.Buffer
+	result := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		result <- stopManagedCity(mc, cityPath, &stderr)
+	}()
+
+	select {
+	case err := <-result:
+		if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+			t.Fatalf("stopManagedCity took %s, want bounded even when CityRuntime.shutdown hangs", elapsed)
+		}
+		if err == nil {
+			t.Fatal("stopManagedCity err = nil, want non-nil because city never exited and shutdown hung")
+		}
+		if !strings.Contains(err.Error(), "did not exit") {
+			t.Fatalf("stopManagedCity err = %q, want 'did not exit' detail", err.Error())
+		}
+		if !forceStop.Load() {
+			t.Fatal("expected forced cleanup to request force-stop shutdown")
+		}
+		if !closer.closed {
+			t.Fatal("expected closer to be closed even though CityRuntime.shutdown never returned")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopManagedCity did not return within 2s: forced shutdown is not bounded when CityRuntime.shutdown hangs (issue #5256)")
+	}
+}
+
 func TestCityRuntimeShutdownPreservesSessionsWhenRequested(t *testing.T) {
 	sp := runtime.NewFake()
 	if err := sp.Start(context.Background(), "agent-one", runtime.Config{}); err != nil {

--- a/release-gates/ga-hjkv6q-supervisor-stop-bounded-gate.md
+++ b/release-gates/ga-hjkv6q-supervisor-stop-bounded-gate.md
@@ -1,0 +1,86 @@
+# Release gate: bounded supervisor stop
+
+- Deploy bead: `ga-hjkv6q`
+- Build beads: `ga-0plp2i`, `ga-y0reyu`
+- Review bead: `ga-iyp1jk`
+- Reviewed source: `8796af0e97e8258b75958387288e29921f49de0f`
+- Base checked: `origin/main@175059246d40a5223748e01ee5c5772727772a74`
+- Target issue: `gastownhall/gascity#5256`
+- Decision: **PASS**
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `ga-iyp1jk` is closed with an explicit round-4 PASS on the exact reviewed source. The reviewer recorded zero high-severity findings. |
+| 2 | Acceptance criteria met | PASS | Both ordinary and preserve-sessions supervisor shutdown now bound a blocking city-runtime shutdown with the configured forced-stop deadline. The same deadline covers the shutdown call and the subsequent wait, so the budget cannot be consumed twice. A never-exiting city still returns a non-nil error, while the normal clean path is unchanged. `TestStopManagedCityBoundsForcedShutdownWhenRuntimeHangs` independently exercised the combined grace-plus-forced ceiling in both full-suite cmd/gc lanes and passed. |
+| 3 | Tests pass | PASS | The documented full-scope 40-job suite ran twice on the exact reviewed source, with the second run verbose for exact test counts. The diff-owned hanging-runtime regression passed in both relevant shards in both runs. All raw failures are non-diff-owned, have exact pre-existing trackers, have mechanism or reachability proof, and have no path overlap; attribution is recorded below. |
+| 4 | No high-severity review findings open | PASS | The reviewer recorded no HIGH findings, no security blocker, and no unresolved spec finding. |
+| 5 | Final branch is clean | PASS | The reviewed source was clean through the full-suite and static lanes; this checklist is the sole release-evidence addition. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main 8796af0e97e8258b75958387288e29921f49de0f` succeeded at the refreshed base above and produced tree `804a29195cc22bf6be657d504a1874f4fa83637a`; no self-rebase was required. |
+| 7 | Single feature theme | PASS | Four commits and two `cmd/gc` files implement and test one supervisor-shutdown theme. The ancestry is deliberately scoped to the deploy bead and its two same-feature build beads; no unrelated or `.claude/**` path is present. |
+
+## Test evidence
+
+`test_cmd_scope: full-suite`
+
+The mandatory fresh full-suite run used the repository's documented local CI-equivalent target:
+
+```text
+DOCKER_HOST=unix:///run/user/1000/podman/podman.sock \
+TESTCONTAINERS_RYUK_DISABLED=true \
+LOCAL_TEST_LOG_DIR=/var/tmp/gascity-ga-hjkv6q.rOay7B \
+make test-local-full-parallel
+```
+
+- `job_counts: 33 PASS, 7 attributed FAIL, 0 SKIP out of 40 jobs`
+- `initial_raw_failures: 9 top-level FAIL, all attributed below`
+
+After the host load returned to the tracked safe start band, a second unchanged full-scope run enabled verbose Go output so the gate could record exact per-test counts:
+
+```text
+DOCKER_HOST=unix:///run/user/1000/podman/podman.sock \
+TESTCONTAINERS_RYUK_DISABLED=true \
+EXTRA_TEST_ENV='DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true' \
+GOFLAGS=-v LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=6 GO_TEST_TIMEOUT=30m \
+LOCAL_TEST_LOG_DIR=/var/tmp/gascity-ga-hjkv6q-verbose.Os6CAJ \
+make test-local-full-parallel
+```
+
+- `test_counts: 45662 PASS, 8 attributed FAIL, 200 SKIP`
+- `diff_tests_executed: TestStopManagedCityBoundsForcedShutdownWhenRuntimeHangs PASS` in `cmd-gc-process-1-of-6` and `integration-packages-cmd-gc-3-of-6` in both full-suite runs
+- `skip_justification: the 200 SKIPs are pre-existing platform, helper-process, optional-provider, live-service, or explicitly gated real-infrastructure cases. The diff-owned regression did not skip and passed twice in each of its two full-suite lanes.`
+- `waiver_ref: none`
+- `ci_lane_run: n/a (no CI-config change)`
+
+### Failure attribution
+
+| Raw result | Tracker | Attribution |
+|---|---|---|
+| FAIL: `TestCatalogMatchesProductionWiringAndDocumentation` twice per run | `ga-cojd80` | Clause 3(a), mechanism plus reachability: the reviewed checkout's provider-ledger waiver rows expired before these runs. The provider-ledger package cannot import or execute `cmd/gc`, and paths do not overlap. |
+| FAIL: `TestBdFlagManifestCurrent` once per run | `ga-f0uceo` | Clause 3(a), mechanism plus reachability: the installed `bd` flag surface has drifted from this older reviewed checkout's manifest. The manifest package cannot import or execute `cmd/gc`, and paths do not overlap. |
+| FAIL: `TestProviderLiveClaudeKindPath` twice | `ga-iepsvr` | Clause 3(a), mechanism plus reachability: the herdr probe reported the exact tracked `agent_pane_busy` host condition. The herdr package cannot import or execute `cmd/gc`, and paths do not overlap. |
+| FAIL: `TestGetKeyBinding_CapturesDefaultBinding` and `TestGetKeyBinding_CapturesDefaultBindingWithArgs` once per run | `ga-k3fxvj` | Clause 3(a), mechanism plus reachability: the host tmux returned the tracked empty filtered default bindings. Runtime/tmux cannot import or execute `cmd/gc`, and paths do not overlap. |
+| FAIL: `TestGraphWorkflowSuccessPath` and `TestCleanInstallTutorialPath` in the initial run | `ga-vkhfnj` | Clause 3(a), mechanism: both failed during `gc init`, before the changed supervisor-stop path could execute, because concurrent use left shared Dolt tables dirty. The diff does not touch the integration tests or the init path. |
+| FAIL: `TestAdoptPRFormulaRetriesTransientReviewerStep` and `TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries` in the verbose run | `ga-vkhfnj` | Clause 3(a), mechanism: both failed during `gc init` on the tracked shared-Dolt dirty-table migration refusal, before formula execution or supervisor shutdown. Paths do not overlap. |
+| FAIL: `TestCleanInstallTutorialPath` in the verbose run | `ga-vkhfnj` | Clause 3(a), mechanism: a shared circuit-breaker cleanup message contaminated `bd config` stdout before any supervisor-stop path ran. The candidate does not touch config output, circuit-breaker handling, or this test. |
+
+`failure_attribution: TestCatalogMatchesProductionWiringAndDocumentation -> ga-cojd80 | clause 3(a) mechanism/reachability — expired provider-ledger waiver rows; changed cmd/gc path unreachable`
+
+`failure_attribution: TestBdFlagManifestCurrent -> ga-f0uceo | clause 3(a) mechanism/reachability — installed-bd manifest drift; changed cmd/gc path unreachable`
+
+`failure_attribution: TestProviderLiveClaudeKindPath -> ga-iepsvr | clause 3(a) mechanism/reachability — tracked herdr pane contention; changed cmd/gc path unreachable`
+
+`failure_attribution: TestGetKeyBinding_CapturesDefaultBinding{,WithArgs} -> ga-k3fxvj | clause 3(a) mechanism/reachability — tracked host tmux keytable behavior; changed cmd/gc path unreachable`
+
+`failure_attribution: TestGraphWorkflowSuccessPath,TestCleanInstallTutorialPath,TestAdoptPRFormulaRetriesTransientReviewerStep,TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries -> ga-vkhfnj | clause 3(a) mechanism — shared-Dolt setup/output condition occurs before the changed supervisor-stop path`
+
+No failure is diff-owned, no failing-test path overlaps the diff, and the change adds no test target or resource-census load. Sightings from both runs were appended to all five trackers and read back from the bead store.
+
+## Required lanes
+
+- `policy_lane: make test-ci-policy — PASS`
+- `go vet ./...` — PASS
+- `make lint-changed LINT_CHANGED_REF=$(git merge-base origin/main HEAD)` with a fresh `/var/tmp` analyzer cache — PASS (`0 issues` in `./cmd/gc`)
+- `make fmt-check-changed LINT_CHANGED_REF=origin/main` — PASS
+- `git diff --check origin/main...HEAD` — PASS
+
+One supplemental full-repository lint attempt was discarded as invalid evidence: a shared analyzer cache returned 54 diagnostics rooted in a missing, unrelated `/var/tmp/ga-xc19j7-gate.4zcJEG` worktree and generated assets. The authoritative merge-base-scoped rerun used a fresh cache and reported zero issues.


### PR DESCRIPTION
## What this changes

`gc supervisor stop` now completes within the configured grace-plus-forced-shutdown budget even when a managed city's runtime shutdown blocks on an unresponsive dependency such as Dolt. Ordinary shutdown and preserve-sessions shutdown use the same bounded path, and timeout errors continue through the existing supervisor error reporting.

## Review notes

- Runtime shutdown runs asynchronously and is abandoned only after the forced-stop deadline; the underlying shutdown operation remains idempotent.
- One shared deadline covers both the shutdown call and the subsequent exit wait, so the forced budget cannot be consumed twice.
- This does not change Dolt or session APIs, provider timeouts, or clean-shutdown behavior.

## Test plan

- [x] Run the full local unit, process, product-metrics, and integration suite.
- [x] Verify the hanging-runtime regression returns inside the combined grace-plus-forced ceiling and still reports a timeout.
- [x] Release gate: [`release-gates/ga-hjkv6q-supervisor-stop-bounded-gate.md`](release-gates/ga-hjkv6q-supervisor-stop-bounded-gate.md)

## Credit

@ThePlenkov diagnosed this bug first, in #5282 (opened Aug 14): the forced branch of `stopManagedCity` called `mc.cr.shutdown()` synchronously, so once the run loop's shutdown was wedged the forced-stop timeout could never fire. This PR landed the same core fix later without crediting him. Added after merge, with thanks.
