### PR TITLE
Bound Dashboard Playwright install retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1405,8 +1405,9 @@ jobs:
       - name: Install Playwright Chromium
         timeout-minutes: 12
         run: |
+          echo 'Acquire::http::Timeout "15";' | sudo tee /etc/apt/apt.conf.d/99-ci-apt-timeout >/dev/null
           for attempt in 1 2 3; do
-            if npm run test:e2e:install:ci; then
+            if timeout 240 npm run test:e2e:install:ci; then
               exit 0
             fi
             if [ "$attempt" = "3" ]; then

--- a/release-gates/ga-29lvns-dashboard-spa-playwright-install-timeouts-gate.md
+++ b/release-gates/ga-29lvns-dashboard-spa-playwright-install-timeouts-gate.md
@@ -1,0 +1,59 @@
+# Release gate: Dashboard SPA Playwright install timeouts
+
+- Deploy bead: `ga-29lvns`
+- Review bead: `ga-luwbo3`
+- Reviewed commit: `dbffcbe02523f13b3a3bdcf7fe31bc0bd7ecedc0`
+- Current base: `origin/main@1be466f69a4c74b7721a36e5978244556396c2d5`
+- Isolated branch: `deploy/ga-29lvns-gate`
+- Gate state: **HOLD — first real Dashboard SPA CI run required**
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | PASS | `ga-luwbo3` records `verdict: pass` for the exact reviewed commit `dbffcbe02523f13b3a3bdcf7fe31bc0bd7ecedc0`; no review carryover was used. |
+| 2 | Acceptance criteria met | PASS | The Playwright install step writes apt HTTP timeout `15` before its three-attempt loop, bounds each `npm run test:e2e:install:ci` invocation with `timeout 240`, retains the 12-minute outer step timeout, and preserves backoff/final failure. The diff-owned policy test and an induced-stall control-flow simulation pass. |
+| 3 | Tests pass | HOLD | Local full-suite, policy, build, vet, actionlint, and diff-owned evidence pass after attribution. Because this diff changes the Dashboard SPA CI job, criterion 3c requires that job's first real PR execution; no such run exists before a PR is opened. `ci_lane_run: not-yet-run`. |
+| 4 | No unresolved HIGH review findings | PASS | Reviewer reported no blockers, majors, or minors; unresolved HIGH count is 0. |
+| 5 | Final branch clean | PASS | The reviewed tree is clean; `git diff --check` and changed-file formatting/lint pass; `.githooks` is configured as `core.hooksPath`. |
+| 6 | Branch diverges cleanly from main | PASS | After a fresh fetch, `git merge-tree --write-tree origin/main dbffcbe02523f13b3a3bdcf7fe31bc0bd7ecedc0` exited 0 and produced tree `908d61961c0ee8af186dbaefa4092da14ded224b`; no self-rebase was needed. |
+| 7 | Single feature theme | PASS | The three-file diff is one CI-hardening theme: workflow time bounds plus the policy implementation and regression test that enforce them. |
+
+## Criterion 2: acceptance evidence
+
+- Exact workflow literals and ordering are enforced by `TestPlaywrightChromiumInstallHardensAgainstHungAptMirror`: apt `Acquire::http::Timeout "15"` is configured before the retry loop, each attempt uses `timeout 240 npm run test:e2e:install:ci`, and the step retains `timeout-minutes: 12`.
+- The existing three-attempt loop, linear 10/20-second backoff, success exit, and final failure exit are unchanged.
+- Induced-stall simulation used a one-second stand-in timeout around a ten-second sleeper and observed attempts 1, 2, and 3 before final failure (`simulation_result=PASS attempts=3 elapsed_seconds=3`). This verifies that a timed-out command advances through the retry loop; the policy test separately locks the production timeout values.
+- `actionlint .github/workflows/ci.yml`: PASS.
+- `make test-ci-policy`: PASS.
+
+## Criterion 3: local test evidence
+
+`test_cmd: make test-local-full-parallel`
+
+`test_cmd_scope: full-suite`
+
+Environment: rootless Podman 5.8.4 via `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`; `TESTCONTAINERS_RYUK_DISABLED=true`. The repository has no Go testcontainers reference or pinned testcontainer image, and this diff adds no container-backed test.
+
+- Raw result: all 40 job logs completed; 29 job-level PASS and 11 job-level FAIL.
+- Top-level counts across preserved verbose logs: 46,467 PASS, 12 FAIL, 210 SKIP.
+- `diff_tests_executed`: `TestPlaywrightChromiumInstallHardensAgainstHungAptMirror` PASS in `unit-core` and PASS again in `integration-packages-core-4-of-4`; 0 diff-owned FAIL and 0 diff-owned SKIP.
+- Skip justification: the 210 skips are suite-declared platform, optional-provider, live-infrastructure, helper-process, or opt-in persistence exclusions. None is diff-owned.
+- Build/static evidence: `go build ./...` PASS; `go vet ./...` PASS; `make fmt-check-changed` PASS; `make lint-changed` PASS for `./scripts/cipolicy`; `git diff --check` PASS; `actionlint .github/workflows/ci.yml` PASS.
+- `policy_lane: make test-ci-policy — PASS`. This is the policy target invoked by `.github/workflows/ci.yml`; the repository has no `ci-pr-policy` target.
+- `waiver_ref: none` — failures below are attributed under the non-diff-owned failure protocol, not waived.
+
+### Failure attribution
+
+Every tracker predates this run, each current sighting was appended and read back, no failing test file overlaps the diff, and `go list -deps -test` confirms the failing `cmd/gc`, `internal/runtime/acp`, `internal/runtime/tmux`, and integration packages do not import `scripts/cipolicy`.
+
+- `TestFreshManagedBdCityInitSeedsPinnedHQDatabaseAndKeepsGCPrefix`, `TestAdoptPRFormulaCompileAndRun`, `TestPersonalWorkFormulaCompileAndRun`, `TestAdoptPRFormulaRetriesTransientReviewerStep`, `TestAdoptPRFormulaSoftFailsGeminiAfterTransientRetries`, `TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash`, `TestHumaBinary_CityCreateAsync`, and `TestGCLiveContract_BeadsAndEvents` -> `ga-esyijp`. Proof: each failed during fixture bootstrap on the exact shared-server pending-schema-migration refusal before scenario behavior ran. The workflow/policy diff cannot affect Dolt schema migration or `bd init`.
+- `TestE2E_SuspendResume_City` -> `ga-dc9utn`. Proof: exact 93.83-second missing `citysus.report` signature; the tracker documents the independently proven reconciler suspend/wake defect and its fix bead. This diff cannot reach that path.
+- `TestIsAgentRunning` -> `ga-vzckwr`. Proof: exact tracked transient setup-shell signature (`current cmd: zsh`, `setup cmd: sh`) in both matching-shell subtests. The open fix bead predates this run; the diff does not touch or reach tmux runtime code.
+- `TestStartSeedsDurableActivity` and `TestDoltStateWaitReadyCmdReturnsReady` -> `ga-vkhfnj`. Proof: both exhausted fixed readiness deadlines under the same 40-job shared-host contention run (5-second ACP initialize and one-second fake-Dolt readiness respectively). Their packages cannot import the only changed Go package and their test paths do not overlap the diff.
+
+The diff adds one ordinary policy test function, not a new suite target and not a resource-census bump. All attributions use affirmative mechanism or import-coverage proof, so the inconclusive added-load guard does not apply.
+
+### CI-config lane evidence
+
+`ci_lane_run: not-yet-run`
+
+The diff modifies `.github/workflows/ci.yml`, specifically the real Dashboard SPA job. Policy/meta-tests can prove the YAML and enforced literals, but cannot prove the changed install command completes on the hosted runner. An isolated draft PR will be opened only to obtain that first real execution. Until the Dashboard SPA job finishes successfully, this gate remains HOLD: no deploy-clearance status, no ready-for-review transition, no bead close, and no merge-request.

--- a/release-gates/ga-29lvns-dashboard-spa-playwright-install-timeouts-gate.md
+++ b/release-gates/ga-29lvns-dashboard-spa-playwright-install-timeouts-gate.md
@@ -5,13 +5,13 @@
 - Reviewed commit: `dbffcbe02523f13b3a3bdcf7fe31bc0bd7ecedc0`
 - Current base: `origin/main@1be466f69a4c74b7721a36e5978244556396c2d5`
 - Isolated branch: `deploy/ga-29lvns-gate`
-- Gate state: **HOLD — first real Dashboard SPA CI run required**
+- Gate state: **PASS**
 
 | # | Criterion | Result | Evidence |
 |---|---|---|---|
 | 1 | Review PASS present | PASS | `ga-luwbo3` records `verdict: pass` for the exact reviewed commit `dbffcbe02523f13b3a3bdcf7fe31bc0bd7ecedc0`; no review carryover was used. |
 | 2 | Acceptance criteria met | PASS | The Playwright install step writes apt HTTP timeout `15` before its three-attempt loop, bounds each `npm run test:e2e:install:ci` invocation with `timeout 240`, retains the 12-minute outer step timeout, and preserves backoff/final failure. The diff-owned policy test and an induced-stall control-flow simulation pass. |
-| 3 | Tests pass | HOLD | Local full-suite, policy, build, vet, actionlint, and diff-owned evidence pass after attribution. Because this diff changes the Dashboard SPA CI job, criterion 3c requires that job's first real PR execution; no such run exists before a PR is opened. `ci_lane_run: not-yet-run`. |
+| 3 | Tests pass | PASS | Local full-suite, policy, build, vet, actionlint, and diff-owned evidence pass after attribution. The changed Dashboard SPA job's first real PR execution also completed successfully; see the linked run below. |
 | 4 | No unresolved HIGH review findings | PASS | Reviewer reported no blockers, majors, or minors; unresolved HIGH count is 0. |
 | 5 | Final branch clean | PASS | The reviewed tree is clean; `git diff --check` and changed-file formatting/lint pass; `.githooks` is configured as `core.hooksPath`. |
 | 6 | Branch diverges cleanly from main | PASS | After a fresh fetch, `git merge-tree --write-tree origin/main dbffcbe02523f13b3a3bdcf7fe31bc0bd7ecedc0` exited 0 and produced tree `908d61961c0ee8af186dbaefa4092da14ded224b`; no self-rebase was needed. |
@@ -54,6 +54,6 @@ The diff adds one ordinary policy test function, not a new suite target and not 
 
 ### CI-config lane evidence
 
-`ci_lane_run: not-yet-run`
+`ci_lane_run: https://github.com/gastownhall/gascity/actions/runs/34691635307/job/103547835124 — PASS`
 
-The diff modifies `.github/workflows/ci.yml`, specifically the real Dashboard SPA job. Policy/meta-tests can prove the YAML and enforced literals, but cannot prove the changed install command completes on the hosted runner. An isolated draft PR will be opened only to obtain that first real execution. Until the Dashboard SPA job finishes successfully, this gate remains HOLD: no deploy-clearance status, no ready-for-review transition, no bead close, and no merge-request.
+The diff modifies `.github/workflows/ci.yml`, specifically the real Dashboard SPA job. Draft PR #6305 supplied the required first real execution on CI run `34691635307` at head `755e45653747019231ece91d2fd36998b05554b1`. Job `103547835124` ran from `2026-09-12T11:40:21Z` through `2026-09-12T11:41:53Z` and concluded `success`; every step passed, including `Install Playwright Chromium` and `Playwright render smoke (Layer B)`.

--- a/scripts/cipolicy/policy.go
+++ b/scripts/cipolicy/policy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -178,6 +179,9 @@ func validate(ci, nightly, action map[string]any) error {
 	if err := validatePRProviderOwnership(ci); err != nil {
 		return err
 	}
+	if err := validatePlaywrightInstallHardening(ci); err != nil {
+		return err
+	}
 	if err := assertWorkflowExecution("CI", ci, expectedCIExecutionHash); err != nil {
 		return err
 	}
@@ -331,6 +335,60 @@ func validateNightlyProviderOwnership(workflow map[string]any) error {
 				match.name,
 			)
 		}
+	}
+	return nil
+}
+
+// validatePlaywrightInstallHardening ensures the Dashboard SPA's Playwright
+// Chromium install step fails fast on a hung apt mirror instead of consuming
+// its whole retry budget on a single stuck attempt: each retry wraps the
+// install command with a per-attempt timeout, and apt itself gets an
+// explicit HTTP timeout so a dead mirror errors instead of hanging.
+func validatePlaywrightInstallHardening(workflow map[string]any) error {
+	job, err := workflowJob(workflow, "dashboard")
+	if err != nil {
+		return err
+	}
+	steps, err := mappingSlice(job["steps"], "dashboard steps")
+	if err != nil {
+		return err
+	}
+	const stepName = "Install Playwright Chromium"
+	var installStep map[string]any
+	for _, candidate := range steps {
+		if candidate["name"] == stepName {
+			installStep = candidate
+			break
+		}
+	}
+	if installStep == nil {
+		return fmt.Errorf("dashboard job is missing the %q step", stepName)
+	}
+	if installStep["timeout-minutes"] != 12 {
+		return fmt.Errorf("%q step must keep its outer timeout-minutes at 12", stepName)
+	}
+	run, ok := installStep["run"].(string)
+	if !ok {
+		return fmt.Errorf("%q step must have a run script", stepName)
+	}
+	aptTimeoutIndex := strings.Index(run, `Acquire::http::Timeout "15"`)
+	if aptTimeoutIndex < 0 {
+		return fmt.Errorf(
+			"%q step must configure an apt HTTP timeout (Acquire::http::Timeout \"15\") so a dead mirror errors instead of hanging",
+			stepName,
+		)
+	}
+	const perAttemptInstall = "timeout 240 npm run test:e2e:install:ci"
+	installIndex := strings.Index(run, perAttemptInstall)
+	if installIndex < 0 {
+		return fmt.Errorf(
+			"%q step must wrap each retry attempt with a per-attempt timeout (%q) so a hung install cannot consume the whole step budget",
+			stepName,
+			perAttemptInstall,
+		)
+	}
+	if aptTimeoutIndex > installIndex {
+		return fmt.Errorf("%q step must configure the apt HTTP timeout before the retry loop runs", stepName)
 	}
 	return nil
 }

--- a/scripts/cipolicy/policy.go
+++ b/scripts/cipolicy/policy.go
@@ -21,7 +21,7 @@ const (
 	// policy review, while workflow, job, step, and input descriptions remain
 	// free to change. A failure prints the projection and candidate digest.
 	expectedCITriggersHash       = "d1a8bcd089019589658d8f154af9c26a70877285d84a384c2dcea299efc9554a"
-	expectedCIExecutionHash      = "ca09ef912d728ae76a05d607148d1aba6e626b49762e47fdf8013eeb1ddc2195"
+	expectedCIExecutionHash      = "330280e18d45b077cb5842e89c79753f47ace535d53a4505a15c62605fb4f837"
 	expectedNightlyTriggersHash  = "0a4400a09ac567e90adf8be1232eef1f14e36efd8dba3e143aa6e36f5b7a36f5"
 	expectedNightlyExecutionHash = "dfe3e40bf2fb461e2f7422ea93b7f9ea769f0e8bf35eb6060690af6f2f361877"
 	expectedSetupActionHash      = "8f2d6b3a57f11d4f33a41211b1d3d5362d1437ba40c7b6db068abb98e731e5ac"

--- a/scripts/cipolicy/policy_test.go
+++ b/scripts/cipolicy/policy_test.go
@@ -23,6 +23,13 @@ func TestCurrentWorkflowsMatchPolicy(t *testing.T) {
 	}
 }
 
+func TestPlaywrightChromiumInstallHardensAgainstHungAptMirror(t *testing.T) {
+	docs := loadPolicyDocuments(t)
+	if err := validatePlaywrightInstallHardening(docs.ci); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMakeTestCIPolicyRunsStaticScopeContracts(t *testing.T) {
 	const want = "\t$(TEST_ENV) GOFLAGS= GOENV=off GOWORK=off go test -count=1 -run '^(TestPreflightStaticScopesOrdinaryPRsWithoutWeakeningProtectedRuns|TestFullStaticLintExplicitlyOwnsConfiguredGolangCIGovet|TestChangedStaticTargetsScopeLintAndFormattingToTheDiff|TestCIStaticScopeClassifierFailsClosedOutsideValidatedPullRequestMerge)$$' ./scripts"
 


### PR DESCRIPTION
## What this changes

Dashboard CI now bounds each Playwright Chromium dependency-install attempt to four minutes and configures apt HTTP operations with a 15-second timeout. A hung package mirror therefore advances through the existing three-attempt retry loop instead of consuming the step's full 12-minute budget inside one attempt.

The outer step timeout, retry count, and 10/20-second backoff remain unchanged. This hardens failure recovery without changing mirrors, dependency versions, browser caching, or the Dashboard application's runtime behavior.

## Review notes

- The apt timeout is installed through a static `/etc/apt/apt.conf.d/99-ci-apt-timeout` drop-in because Playwright's `--with-deps` wrapper does not expose apt command-line flags.
- Each `npm run test:e2e:install:ci` invocation is wrapped by `timeout 240`; the overall step is still capped at 12 minutes.
- Repository policy tests pin the timeout values and ordering so later workflow edits cannot silently remove the bounds.

## Test plan

- [x] Run `actionlint .github/workflows/ci.yml` and `make test-ci-policy`.
- [x] Run the documented full local suite and attribute only independently tracked, non-diff-owned failures.
- [x] Simulate a stalled install with shortened timing and confirm all three attempts execute.
- [x] Confirm the real Dashboard SPA job completes on this PR.
- [x] Release gate: [`release-gates/ga-29lvns-dashboard-spa-playwright-install-timeouts-gate.md`](release-gates/ga-29lvns-dashboard-spa-playwright-install-timeouts-gate.md)
