### PR TITLE
feat(mail,supervisor): send one notification per condition, not one per interval

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1464,6 +1464,7 @@ func newMailSendCmd(stdout, stderr io.Writer) *cobra.Command {
 	var subject string
 	var message string
 	var jsonOut bool
+	var dedupKey string
 	cmd := &cobra.Command{
 		Use:   "send [<to>] [<body>]",
 		Short: "Send a message to a session alias or human",
@@ -1476,22 +1477,28 @@ a non-running recipient. Unread mail alone does not request a wake.
 Use --from to override the sender identity.
 Use --to as an alternative to the positional <to> argument.
 Use -s/--subject for the summary line and -m/--message for the body text.
-Use --all to broadcast to all live sessions (excluding sender and "human").`,
+Use --all to broadcast to all live sessions (excluding sender and "human").
+
+Use --dedup <key> for repeating notifications (patrol and cooldown orders
+that re-detect the same condition every run): the send is suppressed while
+a previous message with the same key is still live (un-archived) in the same
+mailbox, and an alias and the session behind it count as one mailbox.
+Suppression exits 0. Once the recipient archives the message the stream may
+alert again; senders that want a longer re-alert cadence keep their own
+last-sent state. Dedup needs a provider that can query its own message
+history. The built-in provider can; one that cannot sends normally and says
+so on stderr, because a duplicate notification beats a dropped one.`,
 		Example: `  gc mail send mayor "Build is green"
   gc mail send mayor -s "Build is green"
-  gc mail send myrig/witness -s "Need investigation" -m "Attach logs from the last failed run"
+  gc mail send myrig/reviewer -s "Need investigation" -m "Attach logs from the last failed run"
   gc mail send --to mayor "Build is green"
   gc mail send human "Review needed for PR #42"
-  gc mail send polecat "Priority task" --notify
-  gc mail send --all "Status update: tests passing"`,
+  gc mail send worker "Priority task" --notify
+  gc mail send --all "Status update: tests passing"
+  gc mail send worker -s "disk warning" --dedup "disk-warn:hq"`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			code := 0
-			if jsonOut {
-				code = cmdMailSendJSON(args, notify, all, from, to, subject, message, true, stdout, stderr)
-			} else {
-				code = cmdMailSend(args, notify, all, from, to, subject, message, stdout, stderr)
-			}
+			code := cmdMailSendJSON(args, notify, all, from, to, subject, message, dedupKey, jsonOut, stdout, stderr)
 			if code != 0 {
 				return errExit
 			}
@@ -1507,7 +1514,9 @@ Use --all to broadcast to all live sessions (excluding sender and "human").`,
 	cmd.Flags().StringVarP(&subject, "subject", "s", "", "message subject line")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "message body text")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSONL result")
+	cmd.Flags().StringVar(&dedupKey, "dedup", "", "suppress the send while a live message with this dedup key is in the same mailbox (provider permitting)")
 	cmd.MarkFlagsMutuallyExclusive("to", "all")
+	cmd.MarkFlagsMutuallyExclusive("dedup", "all")
 	return cmd
 }
 
@@ -1727,10 +1736,14 @@ The recipient defaults to $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human".`,
 // resolves session mailbox identities, and delegates to doMailSend.
 // The to parameter is the --to flag value (empty if not set).
 func cmdMailSend(args []string, notify bool, all bool, from string, to string, subject string, message string, stdout, stderr io.Writer) int {
-	return cmdMailSendJSON(args, notify, all, from, to, subject, message, false, stdout, stderr)
+	return cmdMailSendJSON(args, notify, all, from, to, subject, message, "", false, stdout, stderr)
 }
 
-func cmdMailSendJSON(args []string, notify bool, all bool, from string, to string, subject string, message string, jsonOut bool, stdout, stderr io.Writer) int {
+// cmdMailSendJSON is cmdMailSend with the dedup key and JSON-output controls
+// exposed. A non-empty dedupKey routes the send through the provider's
+// [mail.DedupSender] capability so a repeating notifier keeps at most one live
+// copy; an empty dedupKey sends unconditionally.
+func cmdMailSendJSON(args []string, notify bool, all bool, from string, to string, subject string, message string, dedupKey string, jsonOut bool, stdout, stderr io.Writer) int {
 	mp, code := openCityMailProvider(stderr, "gc mail send")
 	if mp == nil {
 		return code
@@ -1839,17 +1852,21 @@ func cmdMailSendJSON(args []string, notify bool, all bool, from string, to strin
 	}
 
 	rec := openCityRecorder(stderr)
-	return doMailSendJSON(mp, rec, validRecipients, sender, args, nf, jsonOut, stdout, stderr)
+	return doMailSendJSON(mp, rec, validRecipients, sender, args, nf, dedupKey, jsonOut, stdout, stderr)
 }
 
 // doMailSend creates a message addressed to a recipient. args is [to, subject, body]
 // or [to, body] (subject="" if no -s flag). When nudgeFn is non-nil, the
 // recipient is nudged after message creation (skipped for "human").
 func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, stdout, stderr io.Writer) int {
-	return doMailSendJSON(mp, rec, validRecipients, sender, args, nudgeFn, false, stdout, stderr)
+	return doMailSendJSON(mp, rec, validRecipients, sender, args, nudgeFn, "", false, stdout, stderr)
 }
 
-func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, jsonOut bool, stdout, stderr io.Writer) int {
+// doMailSendJSON is doMailSend with the JSON-output and dedup controls exposed.
+// A non-empty dedupKey routes through the provider's [mail.DedupSender]
+// capability; providers without it fall back to a plain send (fail-open, since
+// a duplicate notification beats a silently dropped one).
+func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, dedupKey string, jsonOut bool, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
 		fmt.Fprintln(stderr, "gc mail send: usage: gc mail send <to> <body>  OR  gc mail send <to> -s <subject> [-m <body>]") //nolint:errcheck // best-effort stderr
 		return 1
@@ -1871,11 +1888,35 @@ func doMailSendJSON(mp mail.Provider, rec events.Recorder, validRecipients map[s
 		return 1
 	}
 
-	m, err := mp.Send(sender, to, subject, body)
+	var (
+		m          mail.Message
+		suppressed bool
+		err        error
+	)
+	if dedupKey != "" {
+		if ds, ok := mp.(mail.DedupSender); ok {
+			m, suppressed, err = ds.SendDeduped(sender, to, subject, body, dedupKey)
+		} else {
+			fmt.Fprintln(stderr, "gc mail send: mail provider does not support --dedup; sending without dedup") //nolint:errcheck // best-effort stderr
+			m, err = mp.Send(sender, to, subject, body)
+		}
+	} else {
+		m, err = mp.Send(sender, to, subject, body)
+	}
 	telemetry.RecordMailOp(context.Background(), "send", err)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc mail send: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	if suppressed {
+		// Nothing was created: no mail.sent event, no nudge — the point of
+		// dedup is that the recipient was already notified by m.
+		if jsonOut {
+			summary := summarizeMailMessage(m)
+			return writeCLIJSONLineOrExit(stdout, stderr, "gc mail send", mailActionResult{SchemaVersion: "1", OK: true, Command: "mail.send", Action: "send", ID: m.ID, Message: &summary, AlreadyDone: true, Count: intRef(0)})
+		}
+		fmt.Fprintf(stdout, "Suppressed duplicate of %s to %s (dedup key %q)\n", m.ID, to, dedupKey) //nolint:errcheck // best-effort stdout
+		return 0
 	}
 	rec.Record(events.Event{
 		Type:    events.MailSent,

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -136,7 +136,7 @@ func TestMailSendJSON(t *testing.T) {
 	recipients := map[string]bool{"human": true, "mayor": true}
 
 	var stdout, stderr bytes.Buffer
-	code := doMailSendJSON(mp, events.Discard, recipients, "human", []string{"mayor", "build is green"}, nil, true, &stdout, &stderr)
+	code := doMailSendJSON(mp, events.Discard, recipients, "human", []string{"mayor", "build is green"}, nil, "", true, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doMailSendJSON = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -155,6 +155,93 @@ func TestMailSendJSON(t *testing.T) {
 	}
 	if got.SchemaVersion != "1" || !got.OK || got.Command != "mail.send" || got.Count != 1 || len(got.Messages) != 1 || got.Messages[0].To != "mayor" {
 		t.Fatalf("payload = %+v", got)
+	}
+}
+
+func TestMailSendDedupSuppressesDuplicate(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	recipients := map[string]bool{"human": true, "mayor": true}
+	rec := events.NewFake()
+
+	var stdout, stderr bytes.Buffer
+	args := []string{"mayor", "quarantine: hq", "marker exists"}
+	code := doMailSendJSON(mp, rec, recipients, "human", args, nil, "dolt-compact-quarantine:hq", false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("first send = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Sent message") {
+		t.Fatalf("first send stdout = %q, want sent confirmation", stdout.String())
+	}
+
+	stdout.Reset()
+	code = doMailSendJSON(mp, rec, recipients, "human", args, nil, "dolt-compact-quarantine:hq", false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("second send = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Suppressed duplicate") {
+		t.Fatalf("second send stdout = %q, want suppression notice", stdout.String())
+	}
+	if got := len(rec.Events); got != 1 {
+		t.Fatalf("recorded %d mail.sent events; want 1 (no event for a suppressed send)", got)
+	}
+	msgs, err := mp.Inbox("mayor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(msgs); got != 1 {
+		t.Fatalf("inbox has %d messages; want 1", got)
+	}
+}
+
+func TestMailSendDedupJSONReportsAlreadyDone(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	recipients := map[string]bool{"human": true, "mayor": true}
+
+	args := []string{"mayor", "quarantine: hq", "marker exists"}
+	var first bytes.Buffer
+	if code := doMailSendJSON(mp, events.Discard, recipients, "human", args, nil, "k1", true, &first, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("first send = %d, want 0", code)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doMailSendJSON(mp, events.Discard, recipients, "human", args, nil, "k1", true, &stdout, &stderr); code != 0 {
+		t.Fatalf("second send = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	var got struct {
+		OK          bool   `json:"ok"`
+		Command     string `json:"command"`
+		ID          string `json:"id"`
+		AlreadyDone bool   `json:"already_done"`
+		Count       int    `json:"count"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if !got.OK || got.Command != "mail.send" || !got.AlreadyDone || got.Count != 0 || got.ID == "" {
+		t.Fatalf("payload = %+v; want ok, already_done, count 0, live-copy id", got)
+	}
+}
+
+// TestMailSendDedupFallsBackWithoutCapability proves the fail-open contract:
+// a provider that does not implement mail.DedupSender still delivers the
+// message (a duplicate notification beats a silently dropped one), with a
+// stderr note.
+func TestMailSendDedupFallsBackWithoutCapability(t *testing.T) {
+	mp := mail.NewFake() // fake provider: no SendDeduped
+	recipients := map[string]bool{"human": true, "mayor": true}
+
+	var stdout, stderr bytes.Buffer
+	args := []string{"mayor", "subject", "body"}
+	if code := doMailSendJSON(mp, events.Discard, recipients, "human", args, nil, "k1", false, &stdout, &stderr); code != 0 {
+		t.Fatalf("send = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "does not support --dedup") {
+		t.Fatalf("stderr = %q, want capability note", stderr.String())
+	}
+	if got := len(mp.Messages()); got != 1 {
+		t.Fatalf("provider has %d messages; want 1 (fallback still sends)", got)
 	}
 }
 
@@ -569,9 +656,9 @@ func TestCmdMailSendDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *testi
 	_ = os.Unsetenv("GC_AGENT")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdMailSend([]string{"recipient", "hello"}, false, false, "", "", "", "", &stdout, &stderr)
+	code := cmdMailSendJSON([]string{"recipient", "hello"}, false, false, "", "", "", "", "", false, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("cmdMailSend() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		t.Fatalf("cmdMailSendJSON() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	storeAfter, err := openCityStoreAt(cityPath)
 	if err != nil {
@@ -641,9 +728,9 @@ func TestCmdMailSendFromControllerCreatesMessage(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdMailSend([]string{"mayor/"}, false, false, "controller", "", "Dolt health advisory [MEDIUM]", "Latency warning", &stdout, &stderr)
+	code := cmdMailSendJSON([]string{"mayor/"}, false, false, "controller", "", "Dolt health advisory [MEDIUM]", "Latency warning", "", false, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("cmdMailSend() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		t.Fatalf("cmdMailSendJSON() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	storeAfter, err := openCityStoreAt(cityPath)
 	if err != nil {
@@ -713,9 +800,9 @@ func TestCmdMailSendToControllerRecipientIsRejected(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdMailSend([]string{"controller/"}, false, false, "human", "", "Subject", "Body", &stdout, &stderr)
+	code := cmdMailSendJSON([]string{"controller/"}, false, false, "human", "", "Subject", "Body", "", false, &stdout, &stderr)
 	if code == 0 {
-		t.Fatalf("cmdMailSend() = 0, want failure; stdout=%s stderr=%s", stdout.String(), stderr.String())
+		t.Fatalf("cmdMailSendJSON() = 0, want failure; stdout=%s stderr=%s", stdout.String(), stderr.String())
 	}
 	if !strings.Contains(stderr.String(), `unknown recipient "controller/"`) {
 		t.Fatalf("stderr = %q, want unknown controller recipient", stderr.String())
@@ -762,9 +849,9 @@ func TestCmdMailSendTrailingSlashHumanRecipientResolvesToHuman(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdMailSend([]string{"human/"}, false, false, "controller", "", "ESCALATION: test", "escalation body", &stdout, &stderr)
+	code := cmdMailSendJSON([]string{"human/"}, false, false, "controller", "", "ESCALATION: test", "escalation body", "", false, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("cmdMailSend(human/) = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		t.Fatalf("cmdMailSendJSON(human/) = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 
 	store, err := openCityStoreAt(cityPath)
@@ -4917,9 +5004,9 @@ func TestCmdMailSendPositionalBodyHonouredWhenSubjectFlagSet(t *testing.T) {
 	cityPath := mailSendTestCity(t, "mayor")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdMailSend([]string{"mayor/", "positional body"}, false, false, "controller", "", "subject", "", &stdout, &stderr)
+	code := cmdMailSendJSON([]string{"mayor/", "positional body"}, false, false, "controller", "", "subject", "", "", false, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("cmdMailSend() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		t.Fatalf("cmdMailSendJSON() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 
 	msg := mailSendTestFindMessage(t, cityPath)
@@ -4936,9 +5023,9 @@ func TestCmdMailSendFlagBodyWinsOverPositional(t *testing.T) {
 	cityPath := mailSendTestCity(t, "mayor")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdMailSend([]string{"mayor/", "positional body"}, false, false, "controller", "", "subject", "flag body", &stdout, &stderr)
+	code := cmdMailSendJSON([]string{"mayor/", "positional body"}, false, false, "controller", "", "subject", "flag body", "", false, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("cmdMailSend() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		t.Fatalf("cmdMailSendJSON() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 
 	msg := mailSendTestFindMessage(t, cityPath)
@@ -4952,9 +5039,9 @@ func TestCmdMailSendNoBodyStillWorks(t *testing.T) {
 	cityPath := mailSendTestCity(t, "mayor")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdMailSend([]string{"mayor/"}, false, false, "controller", "", "subject", "", &stdout, &stderr)
+	code := cmdMailSendJSON([]string{"mayor/"}, false, false, "controller", "", "subject", "", "", false, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("cmdMailSend() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		t.Fatalf("cmdMailSendJSON() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 
 	msg := mailSendTestFindMessage(t, cityPath)
@@ -4971,7 +5058,7 @@ func TestCmdMailSendAllPositionalBodyHonouredWhenSubjectFlagSet(t *testing.T) {
 	cityPath := mailSendTestCity(t, "worker")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdMailSend([]string{"positional body"}, false, true, "controller", "", "subject", "", &stdout, &stderr)
+	code := cmdMailSendJSON([]string{"positional body"}, false, true, "controller", "", "subject", "", "", false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdMailSend --all = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -4990,7 +5077,7 @@ func TestCmdMailSendAllFlagBodyWinsOverPositional(t *testing.T) {
 	cityPath := mailSendTestCity(t, "worker")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdMailSend([]string{"positional body"}, false, true, "controller", "", "subject", "flag body", &stdout, &stderr)
+	code := cmdMailSendJSON([]string{"positional body"}, false, true, "controller", "", "subject", "flag body", "", false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdMailSend --all = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}

--- a/cmd/gc/session_model_phase0_cli_surface_spec_test.go
+++ b/cmd/gc/session_model_phase0_cli_surface_spec_test.go
@@ -63,7 +63,7 @@ func TestPhase0CLISessionTargetingSurfaces_RejectTemplateFactoryTargets(t *testi
 		{
 			name: "gc mail send",
 			run: func(stdout, stderr *bytes.Buffer) int {
-				return cmdMailSend([]string{"template:worker", "hello"}, false, false, "", "", "", "", stdout, stderr)
+				return cmdMailSendJSON([]string{"template:worker", "hello"}, false, false, "", "", "", "", "", false, stdout, stderr)
 			},
 		},
 		{
@@ -149,7 +149,7 @@ func TestPhase0CLISessionTargetingSurfaces_BareConfigNameDoesNotMaterializeOrdin
 		{
 			name: "gc mail send",
 			run: func(stdout, stderr *bytes.Buffer) int {
-				return cmdMailSend([]string{"worker", "hello"}, false, false, "", "", "", "", stdout, stderr)
+				return cmdMailSendJSON([]string{"worker", "hello"}, false, false, "", "", "", "", "", false, stdout, stderr)
 			},
 		},
 		{

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2548,6 +2548,16 @@ Use --to as an alternative to the positional &lt;to&gt; argument.
 Use -s/--subject for the summary line and -m/--message for the body text.
 Use --all to broadcast to all live sessions (excluding sender and "human").
 
+Use --dedup &lt;key&gt; for repeating notifications (patrol and cooldown orders
+that re-detect the same condition every run): the send is suppressed while
+a previous message with the same key is still live (un-archived) in the same
+mailbox, and an alias and the session behind it count as one mailbox.
+Suppression exits 0. Once the recipient archives the message the stream may
+alert again; senders that want a longer re-alert cadence keep their own
+last-sent state. Dedup needs a provider that can query its own message
+history. The built-in provider can; one that cannot sends normally and says
+so on stderr, because a duplicate notification beats a dropped one.
+
 ```
 gc mail send [<to>] [<body>] [flags]
 ```
@@ -2557,16 +2567,18 @@ gc mail send [<to>] [<body>] [flags]
 ```
 gc mail send mayor "Build is green"
 gc mail send mayor -s "Build is green"
-gc mail send myrig/witness -s "Need investigation" -m "Attach logs from the last failed run"
+gc mail send myrig/reviewer -s "Need investigation" -m "Attach logs from the last failed run"
 gc mail send --to mayor "Build is green"
 gc mail send human "Review needed for PR #42"
-gc mail send polecat "Priority task" --notify
+gc mail send worker "Priority task" --notify
 gc mail send --all "Status update: tests passing"
+gc mail send worker -s "disk warning" --dedup "disk-warn:hq"
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--all` | bool |  | broadcast to all live sessions (excludes sender and human) |
+| `--dedup` | string |  | suppress the send while a live message with this dedup key is in the same mailbox (provider permitting) |
 | `--from` | string |  | sender identity (default: $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human") |
 | `--json` | bool |  | emit JSONL result |
 | `-m`, `--message` | string |  | message body text |

--- a/internal/bootstrap/packs/core/assets/scripts/spawn-storm-detect.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/spawn-storm-detect.sh
@@ -61,7 +61,12 @@ while IFS= read -r bead_id; do
     NEW=$((PREV + 1))
     COUNTS=$(echo "$COUNTS" | jq --arg id "$bead_id" --argjson n "$NEW" '.[$id] = $n')
 
-    if [ "$NEW" -ge "$THRESHOLD" ]; then
+    # Edge-triggered (-eq, not -ge): mail once when the count CROSSES the
+    # threshold, not on every 5m sweep for as long as the storm persists.
+    # A new storm on the same bead re-alerts because the ledger prunes the
+    # count once the bead closes. --dedup guards the repeat-crossing case
+    # (ledger reset while the previous mail is still live in the inbox).
+    if [ "$NEW" -eq "$THRESHOLD" ]; then
         TITLE_JSON=$(gc bd show "$bead_id" --json 2>/dev/null || true)
         TITLE=$(echo "$TITLE_JSON" | jq -r 'if type == "array" then (.[0].title // "unknown") else "unknown" end' 2>/dev/null || echo "unknown")
         if ! gc mail send "$ESCALATION_TARGET" \
@@ -73,12 +78,20 @@ Recommended actions:
 - Inspect the bead: gc bd show $bead_id --json
 - Check rejection history: metadata.rejection_reason
 - Consider quarantining the bead or investigating the root cause." \
+            --dedup "spawn-storm:$bead_id" \
             2>/dev/null; then
             # Do not swallow an undeliverable alert — a vanished storm alert
             # is invisible. Surfacing it requires a non-zero exit (see below),
             # so record the failure and keep sweeping the remaining beads.
             echo "spawn-storm-detect: could not mail escalation target '$ESCALATION_TARGET' about $bead_id" >&2
             FAILED=$((FAILED + 1))
+            # Roll this bead's count back so the next sweep crosses the
+            # threshold again. The ledger is saved either way, and with an edge
+            # trigger a count left AT the threshold never equals it again, so a
+            # transient mail failure would lose the alert outright. --dedup
+            # covers the other half: if the mail did land and only the report
+            # failed, the retry is suppressed instead of duplicated.
+            COUNTS=$(echo "$COUNTS" | jq --arg id "$bead_id" --argjson n "$PREV" '.[$id] = $n')
         fi
         STORMS=$((STORMS + 1))
     fi

--- a/internal/bootstrap/packs/core/skills/gc-mail/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-mail/SKILL.md
@@ -17,6 +17,19 @@ gc mail reply <id> -m "reply body"                     # Reply to a message
 gc mail reply <id> -s "Re: topic" -m "reply body"      # Reply with subject
 ```
 
+For repeating notifications (a patrol or cooldown order that re-detects the
+same condition every run), add `--dedup <key>`: the send is suppressed (exit
+0) while a previous message with the same key is still live in the same
+mailbox, so the recipient gets at most one copy per stream instead of one per
+interval. Once they archive it, the stream may alert again. Dedup needs a
+provider that can query its own message history; the built-in one can, and a
+provider that cannot sends normally and says so on stderr, so treat
+suppression as best effort rather than a guarantee.
+
+```
+gc mail send worker -s "disk warning" -m "..." --dedup "disk-warn:hq"
+```
+
 ## Reading
 
 ```
@@ -30,14 +43,15 @@ gc mail thread <id>                    # Show full conversation thread
 ## Managing
 
 ```
-gc mail archive <id>                   # IRRECOVERABLE: deletes the underlying bead, despite the name
+gc mail archive <id>                   # IRRECOVERABLE: closes the underlying bead, despite the name
 gc mail mark-read <id>                 # Mark as read without displaying
 gc mail mark-unread <id>              # Mark as unread
-gc mail delete <id>                    # IRRECOVERABLE: alias for archive; deletes the underlying bead
+gc mail delete <id>                    # IRRECOVERABLE: alias for archive; closes the underlying bead
 gc mail check                          # Check for new mail (used in hooks)
 ```
 
-`archive` and `delete` are the same operation under two names — both delete
-the message's underlying bead outright; neither files it away for later
-reading. There is no reversible "put this away" path. Prefer `mark-read` when
-you want a message out of the unread count without destroying it.
+`archive` and `delete` are the same operation under two names: both close the
+message's underlying bead, which takes it out of every mail view for good.
+Neither files it away for later reading, and there is no reversible "put this
+away" path. Prefer `mark-read` when you want a message out of the unread count
+while it stays readable.

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -155,9 +155,24 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 	if to == "" {
 		return mail.Message{}, fmt.Errorf("beadmail send: recipient is required")
 	}
+	return p.sendWithExtraMetadata(from, to, subject, body, nil)
+}
+
+// sendWithExtraMetadata is the shared body of Send and SendDeduped: resolve
+// the sender route, derive title and thread label, merge extra metadata (the
+// dedup key), and create the message bead.
+func (p *Provider) sendWithExtraMetadata(from, to, subject, body string, extra map[string]string) (mail.Message, error) {
 	from, metadata, err := p.resolveSenderRoute(from)
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail send: %w", err)
+	}
+	if len(extra) > 0 {
+		if metadata == nil {
+			metadata = make(map[string]string, len(extra))
+		}
+		for k, v := range extra {
+			metadata[k] = v
+		}
 	}
 	threadID := generateThreadID()
 	labels := []string{"thread:" + threadID}
@@ -175,6 +190,52 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 		return mail.Message{}, fmt.Errorf("beadmail send: %w", err)
 	}
 	return beadToMessage(b), nil
+}
+
+// SendDeduped implements the optional [mail.DedupSender] capability: it
+// creates the message unless a live (un-archived) message carrying the same
+// dedup key, addressed to the same mailbox, already exists. "Same mailbox" is
+// the inbox's own question, so the probe compares against every route that
+// resolves to the recipient rather than the literal string it was given: an
+// alias and the session id behind it are one mailbox to [Provider.Inbox], and a
+// stream that addresses it both ways must not get two live copies. The probe is
+// one metadata-keyed list; a probe error fails the send rather than risking a
+// silent duplicate. A route resolution that degrades (an ambiguous or
+// unresolvable address) falls back to the literal recipient, exactly as
+// [Provider.Inbox] does, so the probe keeps answering the inbox's question: the
+// effect is a narrower match, which sends rather than suppresses, and a
+// duplicate notification beats a dropped one. The probe reads only open messages, and archiving closes
+// one, so an archived notification no longer matches: the dedup horizon is the
+// previous message's live lifetime by design (see [mail.DedupSender]).
+func (p *Provider) SendDeduped(from, to, subject, body, key string) (mail.Message, bool, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return mail.Message{}, false, fmt.Errorf("beadmail send: dedup key is required")
+	}
+	if to == "" {
+		return mail.Message{}, false, fmt.Errorf("beadmail send: recipient is required")
+	}
+	existing, err := p.store.List(beads.ListQuery{
+		Type:     "message",
+		Status:   "open",
+		Metadata: map[string]string{mail.DedupKeyMetadataKey: key},
+		TierMode: beads.TierBoth,
+		Live:     true,
+	})
+	if err != nil {
+		return mail.Message{}, false, fmt.Errorf("beadmail send: dedup probe for key %q: %w", key, err)
+	}
+	routes := p.recipientRoutes(to)
+	for _, b := range existing {
+		if matchesRecipientRoute(routes, b.Assignee) {
+			return beadToMessage(b), true, nil
+		}
+	}
+	msg, err := p.sendWithExtraMetadata(from, to, subject, body, map[string]string{mail.DedupKeyMetadataKey: key})
+	if err != nil {
+		return mail.Message{}, false, err
+	}
+	return msg, false, nil
 }
 
 // SendHandoff creates a handoff message from a [mail.HandoffIntent]. It speaks

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -2775,10 +2775,6 @@ func TestProviderCached_ExpiredRefreshConcurrentAccessScansOnce(t *testing.T) {
 	}
 }
 
-// --- Compile-time interface check ---
-
-var _ mail.Provider = (*Provider)(nil)
-
 // --- Address contention fixtures ---
 //
 // Six fixtures in which two sessions contend for one address. They are the
@@ -2925,3 +2921,177 @@ func mustCreateSessionBead(t *testing.T, store beads.Store, metadata map[string]
 	}
 	return b
 }
+
+// --- SendDeduped (mail.DedupSender capability) ---
+
+func TestSendDedupedSuppressesWhileLiveCopyExists(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	first, suppressed, err := p.SendDeduped("controller", "mayor", "quarantine: hq", "marker exists", "dolt-compact-quarantine:hq")
+	if err != nil {
+		t.Fatalf("first SendDeduped: %v", err)
+	}
+	if suppressed {
+		t.Fatal("first send suppressed; want sent")
+	}
+	b, err := store.Get(first.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := b.Metadata[mail.DedupKeyMetadataKey]; got != "dolt-compact-quarantine:hq" {
+		t.Fatalf("dedup key metadata = %q, want %q", got, "dolt-compact-quarantine:hq")
+	}
+
+	second, suppressed, err := p.SendDeduped("controller", "mayor", "quarantine: hq", "marker exists", "dolt-compact-quarantine:hq")
+	if err != nil {
+		t.Fatalf("second SendDeduped: %v", err)
+	}
+	if !suppressed {
+		t.Fatal("second send not suppressed; want suppressed while first copy is live")
+	}
+	if second.ID != first.ID {
+		t.Fatalf("suppressed send returned %q; want the live copy %q", second.ID, first.ID)
+	}
+	inbox, err := p.Inbox("mayor")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if got := len(inbox); got != 1 {
+		t.Fatalf("inbox has %d messages; want 1", got)
+	}
+}
+
+func TestSendDedupedReadButUnarchivedStillSuppresses(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	first, _, err := p.SendDeduped("controller", "mayor", "quarantine: hq", "marker exists", "dolt-compact-quarantine:hq")
+	if err != nil {
+		t.Fatalf("SendDeduped: %v", err)
+	}
+	if _, err := p.Read(first.ID); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	_, suppressed, err := p.SendDeduped("controller", "mayor", "quarantine: hq", "marker exists", "dolt-compact-quarantine:hq")
+	if err != nil {
+		t.Fatalf("SendDeduped after read: %v", err)
+	}
+	if !suppressed {
+		t.Fatal("send after read-but-unarchived not suppressed; want suppressed")
+	}
+}
+
+func TestSendDedupedResendsAfterArchive(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	first, _, err := p.SendDeduped("controller", "mayor", "quarantine: hq", "marker exists", "dolt-compact-quarantine:hq")
+	if err != nil {
+		t.Fatalf("SendDeduped: %v", err)
+	}
+	if err := p.Archive(first.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	second, suppressed, err := p.SendDeduped("controller", "mayor", "quarantine: hq", "marker exists", "dolt-compact-quarantine:hq")
+	if err != nil {
+		t.Fatalf("SendDeduped after archive: %v", err)
+	}
+	if suppressed {
+		t.Fatal("send after archive suppressed; want a fresh message (archive ends the dedup horizon)")
+	}
+	if second.ID == first.ID {
+		t.Fatalf("re-send returned the archived message ID %q; want a new message", first.ID)
+	}
+}
+
+func TestSendDedupedScopedByKeyAndRecipient(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	if _, _, err := p.SendDeduped("controller", "mayor", "quarantine: hq", "b", "dolt-compact-quarantine:hq"); err != nil {
+		t.Fatalf("seed SendDeduped: %v", err)
+	}
+
+	// Same key, different recipient — independent stream.
+	_, suppressed, err := p.SendDeduped("controller", "deacon", "quarantine: hq", "b", "dolt-compact-quarantine:hq")
+	if err != nil {
+		t.Fatalf("SendDeduped to other recipient: %v", err)
+	}
+	if suppressed {
+		t.Fatal("send to a different recipient suppressed; want independent per recipient")
+	}
+
+	// Different key, same recipient — independent stream.
+	_, suppressed, err = p.SendDeduped("controller", "mayor", "quarantine: beads", "b", "dolt-compact-quarantine:beads")
+	if err != nil {
+		t.Fatalf("SendDeduped with other key: %v", err)
+	}
+	if suppressed {
+		t.Fatal("send with a different key suppressed; want independent per key")
+	}
+}
+
+// TestSendDedupedSuppressesAcrossRoutesToOneMailbox pins the mailbox-identity
+// half of the dedup contract. An alias and the session id behind it are one
+// mailbox to Inbox, so a stream that addresses the same notification both ways
+// must not leave two live copies in it. Comparing the literal recipient against
+// the stored assignee passes the other four dedup tests and fails this one.
+func TestSendDedupedSuppressesAcrossRoutesToOneMailbox(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "sky",
+			"session_name": "runtime-sky",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+
+	const key = "dolt-compact-quarantine:hq"
+	first, suppressed, err := p.SendDeduped("controller", "sky", "quarantine: hq", "marker exists", key)
+	if err != nil {
+		t.Fatalf("SendDeduped to alias: %v", err)
+	}
+	if suppressed {
+		t.Fatal("first send suppressed; want sent")
+	}
+
+	second, suppressed, err := p.SendDeduped("controller", sessionBead.ID, "quarantine: hq", "marker exists", key)
+	if err != nil {
+		t.Fatalf("SendDeduped to session id: %v", err)
+	}
+	if !suppressed {
+		t.Fatalf("send to %s not suppressed; the alias copy %s is live in the same mailbox", sessionBead.ID, first.ID)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("suppressed send returned %q; want the live copy %q", second.ID, first.ID)
+	}
+
+	inbox, err := p.Inbox("sky")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if got := len(inbox); got != 1 {
+		t.Fatalf("inbox has %d messages; want 1 across both routes", got)
+	}
+}
+
+func TestSendDedupedRequiresKey(t *testing.T) {
+	p := New(beads.NewMemStore())
+	if _, _, err := p.SendDeduped("controller", "mayor", "s", "b", "  "); err == nil {
+		t.Fatal("SendDeduped with blank key succeeded; want error")
+	}
+}
+
+// --- Compile-time interface checks ---
+
+var (
+	_ mail.Provider    = (*Provider)(nil)
+	_ mail.DedupSender = (*Provider)(nil)
+)

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -40,6 +40,10 @@ const (
 	// ("true"/"false"), set alongside the label by MarkRead/MarkUnread. Retention
 	// sweeps query it directly (the label-based query is recipient-scoped).
 	ReadMetadataKey = "mail.read"
+	// DedupKeyMetadataKey stores the caller-supplied dedup key on messages
+	// sent through [DedupSender.SendDeduped]. Repeating notifiers (patrol
+	// orders, maintenance loops) use it to suppress duplicate alerts.
+	DedupKeyMetadataKey = "mail.dedup_key"
 )
 
 // Message represents a mail message between agents or humans.
@@ -82,6 +86,33 @@ type ArchiveResult struct {
 	Err error
 }
 
+// DedupSender is an optional [Provider] capability: send-time suppression of
+// duplicate notifications. Repeating notifiers (cooldown orders, maintenance
+// loops) re-detect the same condition every interval; a provider implementing
+// DedupSender lets them emit at most one live copy per notification stream
+// instead of one message per interval. Suppression is best-effort, not a
+// hard guarantee: the check-then-create is not atomic, so two concurrent
+// senders of the same stream can race past each other and both create a
+// message. The repeating notifiers this serves are single-goroutine loops,
+// where the race does not arise. The dedup horizon is deliberately the
+// message's own live lifetime: archiving closes a message, and only open
+// messages are probed, so an archived notification no longer matches and the
+// stream may re-alert. Callers that want a longer re-alert cadence keep their
+// own last-sent state. Providers that cannot query their own message history
+// simply don't implement the interface and callers fall back to Send.
+type DedupSender interface {
+	// SendDeduped creates a message unless a live (un-archived) message
+	// with the same dedup key addressed to the same recipient already
+	// exists. Key identifies the notification stream (callers embed
+	// whatever distinguishes streams — order name, database, bead ID) and
+	// is matched together with the recipient, so senders must pass the
+	// same canonical recipient address on every send of a stream. When
+	// suppressed it returns the pre-existing message and suppressed=true;
+	// otherwise the newly created message, stamped with key under
+	// [DedupKeyMetadataKey].
+	SendDeduped(from, to, subject, body, key string) (msg Message, suppressed bool, err error)
+}
+
 // Provider is the internal interface for mail backends and the canonical
 // domain seam for mail: every mail caller speaks mail.Message (and
 // [HandoffIntent]) here, never a raw message bead. The translation between mail
@@ -111,7 +142,8 @@ type Provider interface {
 	MarkUnread(id string) error
 
 	// Archive removes a message from all views. Bead-backed implementations
-	// delete the message bead eagerly.
+	// close the message bead, which keeps the row for history while taking it
+	// out of every mail view.
 	Archive(id string) error
 
 	// ArchiveMany archives a batch of messages in one round-trip where the

--- a/internal/supervisor/maintenance.go
+++ b/internal/supervisor/maintenance.go
@@ -194,6 +194,28 @@ type StoreMaintenanceLoop struct {
 
 	lastRunAt time.Time
 	history   []MaintenanceRun
+
+	// Alert dedup state (guarded by mu — written only inside a cycle).
+	// alertFingerprint is the stage+error of the failure last alerted; empty
+	// means the loop is in the healthy state (or alerts were never sent).
+	// Alerts fire on fingerprint CHANGE — a new failure, a different failure,
+	// or recovery — never per interval, so a persistently failing store mails
+	// the operator once, not every run (plus once on recovery). State is
+	// in-memory: a supervisor restart re-alerts a still-failing store once,
+	// which doubles as a liveness reminder.
+	// alertDelivered says whether alertFingerprint's alert reached the
+	// operator; an undelivered one is retried by the next identical run.
+	// alertSince is when the current failing streak began, not when its
+	// latest shape appeared, so the recovery notice can report the outage.
+	// alertSuppressed counts repeats of the latest delivered alert.
+	// recoveryOwed means the store came back but the notice for
+	// alertFingerprint did not go out, so the retained failure is over and
+	// must not suppress a later one.
+	alertFingerprint string
+	alertDelivered   bool
+	recoveryOwed     bool
+	alertSince       time.Time
+	alertSuppressed  int
 }
 
 // MaintenanceInProgressError is returned by TriggerNow when the maintenance
@@ -406,7 +428,7 @@ func (m *StoreMaintenanceLoop) executeCycleLocked(ctx context.Context) Maintenan
 		// attempting a doomed backup that only consumes the last of the disk.
 		// The StoreDiskCritical event informs operators; C1
 		// (hold-on-store-unreachable) handles downstream safety.
-		return m.finishCycleLocked(started, "", nil)
+		return m.finishSkippedCycleLocked(started)
 	}
 	snapshotPath, err := m.runSnapshot(ctx)
 	if err != nil {
@@ -434,17 +456,54 @@ func (m *StoreMaintenanceLoop) finishCycleLocked(started time.Time, snapshotPath
 	} else {
 		run.Stage = "done"
 	}
-	m.lastRunAt = started
+	return m.recordRunLocked(run)
+}
+
+// finishSkippedCycleLocked completes a cycle the disk pre-flight declined to
+// start. The stage stays "done" because the loop did not fail, but the
+// operator-alert state machine is not consulted at all: a cycle that attempted
+// nothing is evidence of nothing, and reading it as a success would close an
+// open alert with a recovery notice for a store nobody has touched. This is the
+// only completion path that skips the alert machinery, which is why it does not
+// go through recordRunLocked. The gc.store.maintenance.done event a skipped
+// cycle emits is long-standing behavior and unchanged here; StoreDiskCritical is
+// what tells operators why the cycle skipped. Caller must hold m.mu.
+func (m *StoreMaintenanceLoop) finishSkippedCycleLocked(started time.Time) MaintenanceRun {
+	run := MaintenanceRun{StartedAt: started, FinishedAt: m.clock(), Stage: "done"}
+	m.lastRunAt = run.StartedAt
 	m.appendHistoryLocked(run)
-	m.emitRunEvent(run)
+	m.recordRunEventLocked(run)
 	return run
 }
 
-// emitRunEvent records the typed gc.store.maintenance.done or
-// gc.store.maintenance.failed event for a completed run. The failed
-// variant fires when run.Err is non-empty; the done variant otherwise.
-// Emission failures are swallowed (the recorder itself is best-effort).
-func (m *StoreMaintenanceLoop) emitRunEvent(run MaintenanceRun) {
+// recordRunLocked is the single run-completion point: it advances lastRunAt,
+// appends to the history ring and fires the completion side effects. Caller must
+// hold m.mu.
+func (m *StoreMaintenanceLoop) recordRunLocked(run MaintenanceRun) MaintenanceRun {
+	m.lastRunAt = run.StartedAt
+	m.appendHistoryLocked(run)
+	m.emitRunEventLocked(run)
+	return run
+}
+
+// emitRunEventLocked is the single run-completion side-effect point: it
+// drives the operator-alert state machine and records the typed
+// gc.store.maintenance.done or gc.store.maintenance.failed event. The
+// failed variant fires when run.Err is non-empty; the done variant
+// otherwise. Emission failures are swallowed (the recorder itself is
+// best-effort). Caller must hold m.mu, which guards the alert-dedup state
+// this mutates. That is the cycle lease, held for the whole maintenance
+// run (finishCycleLocked), so the alert mail send under it adds negligible
+// hold time to a lease that already spans the multi-minute cycle.
+func (m *StoreMaintenanceLoop) emitRunEventLocked(run MaintenanceRun) {
+	m.maybeSendAlertLocked(run)
+	m.recordRunEventLocked(run)
+}
+
+// recordRunEventLocked records the typed gc.store.maintenance.done or
+// gc.store.maintenance.failed event for a completed run, without touching the
+// operator-alert state machine. Caller must hold m.mu.
+func (m *StoreMaintenanceLoop) recordRunEventLocked(run MaintenanceRun) {
 	if m.recorder == nil {
 		return
 	}
@@ -484,9 +543,91 @@ func (m *StoreMaintenanceLoop) emitRunEvent(run MaintenanceRun) {
 		Ts:      run.FinishedAt,
 		Payload: raw,
 	})
+}
+
+// maybeSendAlertLocked drives the operator-alert state machine after each
+// run. Mail fires on failure-fingerprint CHANGE only: entering a failure
+// state (or the failure changing shape) sends one alert; identical repeats
+// are counted but suppressed; the first success after a failure sends one
+// recovery notice.
+//
+// What the loop OBSERVES and what the operator KNOWS are tracked separately,
+// because a mail backend that is down must not cost the streak. alertFingerprint
+// is the failure the store is currently in; alertDelivered says whether its
+// alert reached the operator. Suppression needs both, so an undelivered alert is
+// retried by the next identical run rather than read as a repeat of something
+// never received, and a failure whose alert never went out is still the failure
+// the recovery notice reports when the store comes back.
+//
+// The fingerprint is the stage plus the rendered error, which makes the error
+// text part of the contract: a failure message that carries a per-run value (a
+// clock-derived path, an attempt counter, a temp directory) reads as a new
+// condition every cycle and the suppression is worth nothing. The loop must not
+// put such a value into its own failure text, and does not. Text that an
+// external backup or SQL backend varies per attempt is outside the loop's
+// control and will re-alert. Caller must hold m.mu.
+func (m *StoreMaintenanceLoop) maybeSendAlertLocked(run MaintenanceRun) {
+	fingerprint := ""
 	if run.Err != "" {
-		m.sendFailureAlert(run)
+		fingerprint = run.Stage + "\x00" + run.Err
 	}
+	if fingerprint == "" {
+		if m.alertFingerprint == "" {
+			// Healthy→healthy: nothing owed.
+			return
+		}
+		// Failure→success: recovery notice, then back to the healthy state. A
+		// notice that cannot be sent is owed, not dropped: the state stays so
+		// the next successful run retries it.
+		if !m.sendRecoveryNotice(run) {
+			m.recoveryOwed = true
+			return
+		}
+		m.clearAlertStateLocked()
+		return
+	}
+	if m.recoveryOwed {
+		// The store came back and broke again before the recovery notice could
+		// be sent. That notice is stale now, and the retained failure is over,
+		// so neither may suppress what follows: this run opens a new outage.
+		m.clearAlertStateLocked()
+	}
+	switch fingerprint {
+	case m.alertFingerprint:
+		// The same failure again. Suppress it only if the operator actually got
+		// the alert; otherwise this run is the retry.
+		if m.alertDelivered {
+			m.alertSuppressed++
+			return
+		}
+		if m.sendFailureAlert(run) {
+			m.alertDelivered = true
+			m.alertSuppressed = 0
+		}
+	default:
+		// A new failure, or the failure changed shape mid-streak.
+		if m.alertFingerprint == "" {
+			// Healthy to failing: this run opens the outage. A shape change
+			// later in the same streak does not move the start, so the recovery
+			// notice reports how long the store was actually broken rather than
+			// how long its most recent symptom lasted.
+			m.alertSince = run.StartedAt
+		}
+		m.alertFingerprint = fingerprint
+		m.alertSuppressed = 0
+		m.alertDelivered = m.sendFailureAlert(run)
+	}
+}
+
+// clearAlertStateLocked returns the loop to the healthy state, forgetting the
+// failure it was tracking along with anything still owed about it. Caller must
+// hold m.mu.
+func (m *StoreMaintenanceLoop) clearAlertStateLocked() {
+	m.alertFingerprint = ""
+	m.alertDelivered = false
+	m.recoveryOwed = false
+	m.alertSince = time.Time{}
+	m.alertSuppressed = 0
 }
 
 // checkDiskPreflight checks free space in cityPath's filesystem before the
@@ -559,13 +700,16 @@ func (m *StoreMaintenanceLoop) emitDiskEvent(eventType string, free int64) {
 }
 
 // sendFailureAlert posts one best-effort operator alert mail for a
-// failed maintenance run. It is a no-op when Mail is unset or AlertTo
-// is empty; Send errors are logged to stderr but never propagate. The
-// subject and body shape is stable and documented in the runbook
-// (ga-d5y / ga-sec).
-func (m *StoreMaintenanceLoop) sendFailureAlert(run MaintenanceRun) {
+// failed maintenance run. Callers gate it on fingerprint change (see
+// maybeSendAlertLocked) so it fires once per distinct failure, not per
+// interval. It reports whether this failure is now accounted for: true when
+// the mail went out, and also when there is nothing to send because Mail is
+// unset or AlertTo is empty, since no later run can do better. A Send error
+// returns false, and is logged to stderr rather than propagated. The subject
+// and body shape is stable and documented in the runbook (ga-d5y / ga-sec).
+func (m *StoreMaintenanceLoop) sendFailureAlert(run MaintenanceRun) bool {
 	if m.mail == nil || m.cfg.AlertTo == "" {
-		return
+		return true
 	}
 	duration := run.FinishedAt.Sub(run.StartedAt).Seconds()
 	if duration < 0 {
@@ -587,7 +731,47 @@ func (m *StoreMaintenanceLoop) sendFailureAlert(run MaintenanceRun) {
 
 	if _, err := m.mail.Send(maintenanceActor, m.cfg.AlertTo, subject, body.String()); err != nil {
 		fmt.Fprintf(m.stderr, "store-maintenance: alert mail send failed: %v\n", err) //nolint:errcheck // best-effort stderr
+		return false
 	}
+	return true
+}
+
+// sendRecoveryNotice posts one best-effort operator mail when a run
+// succeeds after a failure streak, closing the loop opened by
+// sendFailureAlert. Caller must hold m.mu (it reads the alert dedup
+// state). Like sendFailureAlert it reports whether the notice is
+// accounted for: true when it went out and when there is nothing to send
+// (Mail unset, AlertTo empty, or there was no failure to close because
+// alertFingerprint is empty), false when Send errored, so the next
+// successful run retries the notice instead of dropping it. When the
+// failure's own alert never went out, the body says so: this notice is the
+// operator's first sight of that failure.
+func (m *StoreMaintenanceLoop) sendRecoveryNotice(run MaintenanceRun) bool {
+	if m.mail == nil || m.cfg.AlertTo == "" || m.alertFingerprint == "" {
+		return true
+	}
+	stage, errMsg, _ := strings.Cut(m.alertFingerprint, "\x00")
+
+	subject := fmt.Sprintf("[RECOVERED] Dolt store maintenance succeeded after failing: %s", stage)
+	var body strings.Builder
+	fmt.Fprintf(&body, "Dolt store maintenance recovered.\n\n")
+	fmt.Fprintf(&body, "Failed stage:  %s\n", stage)
+	fmt.Fprintf(&body, "Last error:    %s\n", errMsg)
+	if !m.alertSince.IsZero() {
+		fmt.Fprintf(&body, "Failing since: %s\n", m.alertSince.UTC().Format(time.RFC3339))
+	}
+	fmt.Fprintf(&body, "Repeats:       %d suppressed after the latest alert\n", m.alertSuppressed)
+	if !m.alertDelivered {
+		fmt.Fprintf(&body, "Note:          the alert for this failure could not be delivered, so this notice is the first you have seen of it.\n")
+	}
+	fmt.Fprintf(&body, "Recovered at:  %s\n", run.FinishedAt.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&body, "City:          %s\n", m.cityPath)
+
+	if _, err := m.mail.Send(maintenanceActor, m.cfg.AlertTo, subject, body.String()); err != nil {
+		fmt.Fprintf(m.stderr, "store-maintenance: recovery mail send failed: %v\n", err) //nolint:errcheck // best-effort stderr
+		return false
+	}
+	return true
 }
 
 // appendHistoryLocked appends r to the history ring buffer, dropping

--- a/internal/supervisor/maintenance.go
+++ b/internal/supervisor/maintenance.go
@@ -44,10 +44,12 @@ const (
 	maintenanceSmokeTable = "issues"
 )
 
-// maintenanceSmokeTimeout caps the post-gc SELECT COUNT(*) probe. It is
-// a var (not const) so tests can shorten it; production keeps the 5 s
-// value mandated by design D5.
-var maintenanceSmokeTimeout = 5 * time.Second
+// maintenanceSmokeTimeout caps the post-gc SELECT COUNT(*) probe: the 5 s
+// value mandated by design D5. It is the default for the per-loop
+// smokeTimeout field rather than the value read at the probe, so a test
+// that shortens it does so on its own loop; a package-level var was read
+// by runDoltGC while a parallel test wrote it, which -race reports.
+const maintenanceSmokeTimeout = 5 * time.Second
 
 // MaintenanceRun summarizes one completed (or failed) maintenance run.
 // Stage is "done" for successful runs and names the failing phase
@@ -192,6 +194,11 @@ type StoreMaintenanceLoop struct {
 	// in the cycle's defer; nil means "no run in flight."
 	runStartedAt atomic.Pointer[time.Time]
 
+	// smokeTimeout caps the post-gc count probe. Per loop, not package
+	// level, so a test can shorten its own loop's without racing the
+	// parallel tests that read it (see maintenanceSmokeTimeout).
+	smokeTimeout time.Duration
+
 	lastRunAt time.Time
 	history   []MaintenanceRun
 
@@ -269,6 +276,7 @@ func NewStoreMaintenanceLoop(deps StoreMaintenanceLoopDeps) *StoreMaintenanceLoo
 		diskFreeBytes:     deps.DiskFreeBytes,
 		diskMinFreeBytes:  deps.DiskMinFreeBytes,
 		diskWarnFreeBytes: deps.DiskWarnFreeBytes,
+		smokeTimeout:      maintenanceSmokeTimeout,
 		lastRunAt:         deps.LastRunAt,
 		history:           make([]MaintenanceRun, 0, maintenanceHistorySize),
 	}
@@ -813,7 +821,7 @@ func (m *StoreMaintenanceLoop) runDoltGC(ctx context.Context) error {
 		return &MaintenanceError{Stage: "gc", Err: err}
 	}
 
-	smokeCtx, cancelSmoke := context.WithTimeout(ctx, maintenanceSmokeTimeout)
+	smokeCtx, cancelSmoke := context.WithTimeout(ctx, m.smokeTimeout)
 	defer cancelSmoke()
 	count, err := ops.SmokeCount(smokeCtx)
 	if err != nil {

--- a/internal/supervisor/maintenance_alert_test.go
+++ b/internal/supervisor/maintenance_alert_test.go
@@ -2,6 +2,10 @@ package supervisor
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -31,7 +35,7 @@ func TestAlert_SentOnFailureWithAlertTo(t *testing.T) {
 
 	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
 	finished := started.Add(2500 * time.Millisecond)
-	loop.emitRunEvent(MaintenanceRun{
+	emitUnderLock(loop, MaintenanceRun{
 		StartedAt:    started,
 		FinishedAt:   finished,
 		Stage:        "gc",
@@ -84,7 +88,7 @@ func TestAlert_NotSentOnSuccess(t *testing.T) {
 	})
 
 	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
-	loop.emitRunEvent(MaintenanceRun{
+	emitUnderLock(loop, MaintenanceRun{
 		StartedAt:  started,
 		FinishedAt: started.Add(100 * time.Millisecond),
 		Stage:      "done",
@@ -113,7 +117,7 @@ func TestAlert_NotSentWithEmptyAlertTo(t *testing.T) {
 	})
 
 	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
-	loop.emitRunEvent(MaintenanceRun{
+	emitUnderLock(loop, MaintenanceRun{
 		StartedAt:  started,
 		FinishedAt: started.Add(time.Second),
 		Stage:      "gc",
@@ -126,7 +130,7 @@ func TestAlert_NotSentWithEmptyAlertTo(t *testing.T) {
 }
 
 // TestAlert_SendFailureDoesNotPropagate ensures a broken mail provider
-// does not panic or propagate an error out of emitRunEvent. The event
+// does not panic or propagate an error out of the completion path. The event
 // is still recorded; the send failure is logged to stderr.
 func TestAlert_SendFailureDoesNotPropagate(t *testing.T) {
 	t.Parallel()
@@ -146,7 +150,7 @@ func TestAlert_SendFailureDoesNotPropagate(t *testing.T) {
 
 	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
 	// Should not panic.
-	loop.emitRunEvent(MaintenanceRun{
+	emitUnderLock(loop, MaintenanceRun{
 		StartedAt:  started,
 		FinishedAt: started.Add(time.Second),
 		Stage:      "gc",
@@ -161,6 +165,273 @@ func TestAlert_SendFailureDoesNotPropagate(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "alert mail") {
 		t.Fatalf("stderr missing 'alert mail' marker; got %q", stderr.String())
+	}
+}
+
+// TestAlert_RepeatFailureSuppressed covers the dedup contract: the same
+// failure fingerprint (stage + error) repeating across runs mails the
+// operator once, not once per interval. A run whose fingerprint CHANGES
+// mid-streak alerts again.
+func TestAlert_RepeatFailureSuppressed(t *testing.T) {
+	t.Parallel()
+	fakeMail := mail.NewFake()
+	loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg: config.DoltMaintenance{
+			Enabled:  true,
+			Interval: "168h",
+			AlertTo:  "gascity/mayor",
+		},
+		CityPath: "/tmp/city",
+		Recorder: events.NewFake(),
+		Mail:     fakeMail,
+	})
+
+	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	fail := func(offset time.Duration, stage, errMsg string) {
+		emitUnderLock(loop, MaintenanceRun{
+			StartedAt:  started.Add(offset),
+			FinishedAt: started.Add(offset + time.Second),
+			Stage:      stage,
+			Err:        errMsg,
+		})
+	}
+
+	fail(0, "gc", "open dolt conn: connection refused")
+	fail(time.Hour, "gc", "open dolt conn: connection refused")
+	fail(2*time.Hour, "gc", "open dolt conn: connection refused")
+	if got := len(fakeMail.Messages()); got != 1 {
+		t.Fatalf("sent %d messages for 3 identical failures; want 1", got)
+	}
+
+	// The failure changing shape is new information — alert again. A different
+	// error in the SAME stage counts: two ways for CALL DOLT_GC() to fail are
+	// two conditions, and a fingerprint built from the stage alone would tell
+	// the operator about only the first.
+	fail(3*time.Hour, "gc", "CALL DOLT_GC() failed: out of disk")
+	msgs := fakeMail.Messages()
+	if got := len(msgs); got != 2 {
+		t.Fatalf("sent %d messages after the error changed within one stage; want 2", got)
+	}
+	if want := "[ALERT] Dolt store maintenance failed: gc"; msgs[1].Subject != want {
+		t.Fatalf("msg.Subject = %q; want %q", msgs[1].Subject, want)
+	}
+	if !strings.Contains(msgs[1].Body, "out of disk") {
+		t.Errorf("msg.Body missing the new error; body=%s", msgs[1].Body)
+	}
+
+	// The stage changing is likewise new.
+	fail(4*time.Hour, "smoke-test", "count query timed out")
+	msgs = fakeMail.Messages()
+	if got := len(msgs); got != 3 {
+		t.Fatalf("sent %d messages after the stage changed; want 3", got)
+	}
+	if want := "[ALERT] Dolt store maintenance failed: smoke-test"; msgs[2].Subject != want {
+		t.Fatalf("msg.Subject = %q; want %q", msgs[2].Subject, want)
+	}
+}
+
+// TestAlert_RecoveryNoticeAfterFailureStreak covers the other half of the
+// state machine: the first successful run after an alerted failure streak
+// sends one recovery notice carrying the resolved failure, the streak
+// start, and the suppressed-repeat count. Further successes stay silent.
+func TestAlert_RecoveryNoticeAfterFailureStreak(t *testing.T) {
+	t.Parallel()
+	fakeMail := mail.NewFake()
+	loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg: config.DoltMaintenance{
+			Enabled:  true,
+			Interval: "168h",
+			AlertTo:  "gascity/mayor",
+		},
+		CityPath: "/tmp/city",
+		Recorder: events.NewFake(),
+		Mail:     fakeMail,
+	})
+
+	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	for i := range 3 {
+		emitUnderLock(loop, MaintenanceRun{
+			StartedAt:  started.Add(time.Duration(i) * time.Hour),
+			FinishedAt: started.Add(time.Duration(i)*time.Hour + time.Second),
+			Stage:      "gc",
+			Err:        "out of disk",
+		})
+	}
+	emitUnderLock(loop, MaintenanceRun{
+		StartedAt:  started.Add(4 * time.Hour),
+		FinishedAt: started.Add(4*time.Hour + time.Second),
+		Stage:      "done",
+	})
+	emitUnderLock(loop, MaintenanceRun{
+		StartedAt:  started.Add(5 * time.Hour),
+		FinishedAt: started.Add(5*time.Hour + time.Second),
+		Stage:      "done",
+	})
+
+	msgs := fakeMail.Messages()
+	if got := len(msgs); got != 2 {
+		t.Fatalf("sent %d messages; want 1 alert + 1 recovery", got)
+	}
+	rec := msgs[1]
+	if want := "[RECOVERED] Dolt store maintenance succeeded after failing: gc"; rec.Subject != want {
+		t.Fatalf("recovery subject = %q; want %q", rec.Subject, want)
+	}
+	for _, want := range []string{
+		"out of disk",
+		started.UTC().Format(time.RFC3339), // failing since the streak start
+		"2 suppressed",                     // runs 2 and 3 were deduped
+	} {
+		if !strings.Contains(rec.Body, want) {
+			t.Errorf("recovery body missing %q; body=%s", want, rec.Body)
+		}
+	}
+}
+
+// TestAlert_RecoveryNoticeReportsTheStreakStartNotTheLatestShape pins what
+// "Failing since" means when the failure changes shape mid-streak. The operator
+// reads that line as the length of the outage, so it has to name the run that
+// opened it, not the run where the symptom last changed: a store broken from
+// 12:00 that starts failing a different way at 13:00 was still broken from 12:00.
+func TestAlert_RecoveryNoticeReportsTheStreakStartNotTheLatestShape(t *testing.T) {
+	t.Parallel()
+	fakeMail := mail.NewFake()
+	loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg: config.DoltMaintenance{
+			Enabled:  true,
+			Interval: "168h",
+			AlertTo:  "gascity/mayor",
+		},
+		CityPath: "/tmp/city",
+		Recorder: events.NewFake(),
+		Mail:     fakeMail,
+	})
+
+	streakStart := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	shapeChange := streakStart.Add(time.Hour)
+	run := func(at time.Time, stage, errMsg string) {
+		emitUnderLock(loop, MaintenanceRun{
+			StartedAt:  at,
+			FinishedAt: at.Add(time.Second),
+			Stage:      stage,
+			Err:        errMsg,
+		})
+	}
+
+	run(streakStart, "backup", "sync target: disk full")
+	run(shapeChange, "gc", "open dolt conn: connection refused")
+	run(streakStart.Add(2*time.Hour), "done", "")
+
+	msgs := fakeMail.Messages()
+	if got := len(msgs); got != 3 {
+		t.Fatalf("sent %d messages; want 2 alerts + 1 recovery", got)
+	}
+	rec := msgs[2]
+	if want := "Failing since: " + streakStart.UTC().Format(time.RFC3339); !strings.Contains(rec.Body, want) {
+		t.Errorf("recovery body missing %q; body=%s", want, rec.Body)
+	}
+	if notWant := "Failing since: " + shapeChange.UTC().Format(time.RFC3339); strings.Contains(rec.Body, notWant) {
+		t.Errorf("recovery body reports %q, the shape change, not the streak start; body=%s", notWant, rec.Body)
+	}
+	// The notice still describes the failure it is closing, which is the last
+	// one alerted.
+	if !strings.Contains(rec.Body, "connection refused") {
+		t.Errorf("recovery body missing the last alerted error; body=%s", rec.Body)
+	}
+}
+
+// TestAlert_DiskCriticalSkipIsNotRecovery pins the one cycle outcome that looks
+// like a success and is not. A disk-critical pre-flight skips the snapshot and
+// CALL DOLT_GC and finishes with no error, so reading the absence of an error as
+// "the store is healthy again" mails the operator a recovery notice for a store
+// nothing has touched. The skipped cycle must leave the alert state exactly where
+// it was, which the suppressed repeat afterwards proves.
+func TestAlert_DiskCriticalSkipIsNotRecovery(t *testing.T) {
+	t.Parallel()
+	fakeMail := mail.NewFake()
+	fakeEvents := events.NewFake()
+	free := int64(1 << 40) // plenty, until the test lowers it
+	loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg: config.DoltMaintenance{
+			Enabled:  true,
+			Interval: "168h",
+			AlertTo:  "gascity/mayor",
+		},
+		CityPath:         t.TempDir(),
+		Recorder:         fakeEvents,
+		Mail:             fakeMail,
+		DiskFreeBytes:    func(string) (int64, error) { return free, nil },
+		DiskMinFreeBytes: 1 << 30,
+	})
+
+	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	fail := func(offset time.Duration) {
+		emitUnderLock(loop, MaintenanceRun{
+			StartedAt:  started.Add(offset),
+			FinishedAt: started.Add(offset + time.Second),
+			Stage:      "gc",
+			Err:        "open dolt conn: connection refused",
+		})
+	}
+
+	fail(0)
+	if got := len(fakeMail.Messages()); got != 1 {
+		t.Fatalf("delivered %d messages for the opening failure; want 1 alert", got)
+	}
+
+	// Disk drops below the floor, so the next cycle attempts nothing.
+	free = 100
+	loop.mu.Lock()
+	skipped := loop.executeCycleLocked(context.Background())
+	loop.mu.Unlock()
+	if skipped.Err != "" || skipped.SnapshotPath != "" {
+		t.Fatalf("run = %+v; want the pre-flight to have skipped both stages without failing", skipped)
+	}
+	if !recorded(fakeEvents, events.StoreDiskCritical) {
+		t.Fatalf("recorded %v; want a StoreDiskCritical event, which is what proves the pre-flight skipped", eventTypes(fakeEvents))
+	}
+	if got := len(fakeMail.Messages()); got != 1 {
+		t.Fatalf("delivered %d messages after a skipped cycle; want no recovery notice for a store nothing ran against", got)
+	}
+
+	// The failure state survived, so the same failure is still a repeat.
+	free = 1 << 40
+	fail(2 * time.Hour)
+	if got := len(fakeMail.Messages()); got != 1 {
+		t.Fatalf("delivered %d messages for a repeat of the alerted failure; want 1, the skip must not have cleared the state", got)
+	}
+}
+
+// TestAlert_NoRecoveryNoticeWithoutAlert ensures success-after-failure
+// stays silent when no failure alert was ever mailed (AlertTo empty for
+// the whole streak): there is no open loop to close.
+func TestAlert_NoRecoveryNoticeWithoutAlert(t *testing.T) {
+	t.Parallel()
+	fakeMail := mail.NewFake()
+	loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg: config.DoltMaintenance{
+			Enabled: true,
+			AlertTo: "",
+		},
+		CityPath: "/tmp/city",
+		Recorder: events.NewFake(),
+		Mail:     fakeMail,
+	})
+
+	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	emitUnderLock(loop, MaintenanceRun{
+		StartedAt:  started,
+		FinishedAt: started.Add(time.Second),
+		Stage:      "gc",
+		Err:        "boom",
+	})
+	emitUnderLock(loop, MaintenanceRun{
+		StartedAt:  started.Add(time.Hour),
+		FinishedAt: started.Add(time.Hour + time.Second),
+		Stage:      "done",
+	})
+
+	if got := len(fakeMail.Messages()); got != 0 {
+		t.Fatalf("sent %d messages with empty AlertTo; want 0", got)
 	}
 }
 
@@ -181,10 +452,402 @@ func TestAlert_NilMailProviderSkips(t *testing.T) {
 
 	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
 	// Must not panic.
-	loop.emitRunEvent(MaintenanceRun{
+	emitUnderLock(loop, MaintenanceRun{
 		StartedAt:  started,
 		FinishedAt: started.Add(time.Second),
 		Stage:      "gc",
 		Err:        "boom",
 	})
+}
+
+// TestAlert_UnchangedConditionSuppressedAcrossCyclesWithAdvancingClock drives
+// real maintenance cycles rather than hand-built MaintenanceRun values, because
+// the fingerprint is the stage plus the rendered error and therefore only
+// suppresses what the failing stage renders identically. The snapshot stage
+// builds its destination path from the clock, so the error text is exactly where
+// a per-run value can leak in and turn one stuck condition into one alert per
+// cycle.
+func TestAlert_UnchangedConditionSuppressedAcrossCyclesWithAdvancingClock(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	const cycles = 3
+
+	cycleStart := func(i int) time.Time { return base.Add(time.Duration(i) * time.Hour) }
+
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, cityPath string) *fakeDoltBackupRunner
+	}{
+		{
+			// The rotation destination is occupied, so rename(2) fails
+			// ENOTEMPTY. Blocking it this way rather than with a read-only
+			// parent keeps the failure independent of file modes, which a root
+			// test runner would ignore.
+			name: "the rotation destination is blocked every cycle",
+			setup: func(t *testing.T, cityPath string) *fakeDoltBackupRunner {
+				t.Helper()
+				successDir := filepath.Join(cityPath, ".beads", "dolt-backups", "success")
+				for i := range cycles {
+					occupied := filepath.Join(successDir, cycleStart(i).UTC().Format(snapshotTimestampFormat))
+					if err := os.MkdirAll(occupied, 0o755); err != nil {
+						t.Fatalf("MkdirAll(%s): %v", occupied, err)
+					}
+					if err := os.WriteFile(filepath.Join(occupied, "occupied"), []byte("x"), 0o644); err != nil {
+						t.Fatalf("WriteFile in %s: %v", occupied, err)
+					}
+				}
+				return &fakeDoltBackupRunner{writeOnSync: true}
+			},
+		},
+		{
+			name: "the backup target cannot be added",
+			setup: func(*testing.T, string) *fakeDoltBackupRunner {
+				return &fakeDoltBackupRunner{addErr: errors.New("target URL duplicate with remote X")}
+			},
+		},
+		{
+			name: "the backup target cannot be synced",
+			setup: func(*testing.T, string) *fakeDoltBackupRunner {
+				return &fakeDoltBackupRunner{syncErr: errors.New("network unreachable")}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cityPath := t.TempDir()
+			runner := tc.setup(t, cityPath)
+			cycle := 0
+			fakeMail := mail.NewFake()
+			var stderr bytes.Buffer
+			loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+				Cfg: config.DoltMaintenance{
+					Enabled:  true,
+					Interval: "168h",
+					AlertTo:  "gascity/mayor",
+				},
+				CityPath: cityPath,
+				Recorder: events.NewFake(),
+				Mail:     fakeMail,
+				Stderr:   &stderr,
+				Clock:    func() time.Time { return cycleStart(cycle) },
+				OpenDoltBackup: func(context.Context) (DoltBackupRunner, error) {
+					return runner, nil
+				},
+			})
+
+			rendered := make([]string, 0, cycles)
+			for cycle = 0; cycle < cycles; cycle++ {
+				loop.mu.Lock()
+				run := loop.executeCycleLocked(context.Background())
+				loop.mu.Unlock()
+				if run.Err == "" {
+					t.Fatalf("cycle %d succeeded; want the configured failure", cycle)
+				}
+				rendered = append(rendered, run.Err)
+			}
+			for i, got := range rendered[1:] {
+				if got != rendered[0] {
+					t.Errorf("cycle %d error = %q, cycle 0 = %q; one unchanged condition must render one text or the fingerprint cannot recognize it", i+1, got, rendered[0])
+				}
+			}
+			if got := len(fakeMail.Messages()); got != 1 {
+				t.Fatalf("delivered %d alerts for one unchanged condition over %d cycles; want 1. Errors: %q", got, cycles, rendered)
+			}
+		})
+	}
+}
+
+// recorded reports whether the fake recorder saw an event of this type.
+func recorded(fake *events.Fake, eventType string) bool {
+	for _, e := range fake.Events {
+		if e.Type == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+// eventTypes lists what the fake recorder saw, for failure messages.
+func eventTypes(fake *events.Fake) []string {
+	types := make([]string, 0, len(fake.Events))
+	for _, e := range fake.Events {
+		types = append(types, e.Type)
+	}
+	return types
+}
+
+// failNthMail delivers every message except the failAt'th, which fails the way a
+// mail backend that is briefly down does. Everything else is the in-memory fake,
+// so Messages() still reports exactly what was delivered.
+type failNthMail struct {
+	*mail.Fake
+	failAt   int
+	attempts int
+}
+
+func (f *failNthMail) Send(from, to, subject, body string) (mail.Message, error) {
+	f.attempts++
+	if f.attempts == f.failAt {
+		return mail.Message{}, errors.New("mail provider unavailable")
+	}
+	return f.Fake.Send(from, to, subject, body)
+}
+
+// TestAlert_FailureAlertRetriedAfterSendFailure pins that a transient mail
+// outage costs the operator one attempt, not the whole streak. The alert state
+// records a fingerprint to suppress repeats of a failure the operator has
+// already been told about; advancing it on a send that failed would suppress
+// every identical run after it, so the operator learns nothing once mail
+// recovers.
+func TestAlert_FailureAlertRetriedAfterSendFailure(t *testing.T) {
+	t.Parallel()
+	failOnce := &failNthMail{Fake: mail.NewFake(), failAt: 1}
+	var stderr bytes.Buffer
+	loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg: config.DoltMaintenance{
+			Enabled:  true,
+			Interval: "168h",
+			AlertTo:  "gascity/mayor",
+		},
+		CityPath: "/tmp/city",
+		Recorder: events.NewFake(),
+		Mail:     failOnce,
+		Stderr:   &stderr,
+	})
+
+	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	fail := func(offset time.Duration) {
+		emitUnderLock(loop, MaintenanceRun{
+			StartedAt:  started.Add(offset),
+			FinishedAt: started.Add(offset + time.Second),
+			Stage:      "gc",
+			Err:        "open dolt conn: connection refused",
+		})
+	}
+
+	fail(0)
+	if got := len(failOnce.Messages()); got != 0 {
+		t.Fatalf("delivered %d messages while mail was down; want 0", got)
+	}
+
+	fail(time.Hour)
+	msgs := failOnce.Messages()
+	if got := len(msgs); got != 1 {
+		t.Fatalf("delivered %d messages after mail recovered; want the retried alert", got)
+	}
+	if want := "[ALERT] Dolt store maintenance failed: gc"; msgs[0].Subject != want {
+		t.Fatalf("msg.Subject = %q; want %q", msgs[0].Subject, want)
+	}
+
+	// The delivered alert is what arms suppression, so the next identical run
+	// is a repeat and stays quiet.
+	fail(2 * time.Hour)
+	if got := len(failOnce.Messages()); got != 1 {
+		t.Fatalf("delivered %d messages for a repeat of a delivered alert; want 1", got)
+	}
+	if failOnce.attempts != 2 {
+		t.Fatalf("attempted %d sends; want 2 (one failed, one delivered, then suppressed)", failOnce.attempts)
+	}
+}
+
+// TestAlert_NewOutageAfterAnUndeliveredRecoveryStillAlerts pins the other half of
+// a lost recovery notice. The store failed, recovered while mail was down, then
+// broke the same way again. Holding the old fingerprint as still-delivered makes
+// the second outage look like a repeat of the first and the operator hears
+// nothing about a store that is down right now.
+func TestAlert_NewOutageAfterAnUndeliveredRecoveryStillAlerts(t *testing.T) {
+	t.Parallel()
+	// Attempt 1 is the opening alert (delivered), attempt 2 is the recovery
+	// notice (lost), attempt 3 is the new outage's alert.
+	failOnce := &failNthMail{Fake: mail.NewFake(), failAt: 2}
+	var stderr bytes.Buffer
+	loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg: config.DoltMaintenance{
+			Enabled:  true,
+			Interval: "168h",
+			AlertTo:  "gascity/mayor",
+		},
+		CityPath: "/tmp/city",
+		Recorder: events.NewFake(),
+		Mail:     failOnce,
+		Stderr:   &stderr,
+	})
+
+	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	const errMsg = "open dolt conn: connection refused"
+	run := func(offset time.Duration, stage, runErr string) {
+		emitUnderLock(loop, MaintenanceRun{
+			StartedAt:  started.Add(offset),
+			FinishedAt: started.Add(offset + time.Second),
+			Stage:      stage,
+			Err:        runErr,
+		})
+	}
+
+	run(0, "gc", errMsg)
+	run(time.Hour, "done", "")
+	run(2*time.Hour, "gc", errMsg)
+
+	msgs := failOnce.Messages()
+	if got := len(msgs); got != 2 {
+		t.Fatalf("delivered %d messages; want the opening alert and the new outage's alert", got)
+	}
+	if failOnce.attempts != 3 {
+		t.Fatalf("attempted %d sends; want 3 (alert, lost recovery, alert)", failOnce.attempts)
+	}
+	want := "[ALERT] Dolt store maintenance failed: gc"
+	for i, m := range msgs {
+		if m.Subject != want {
+			t.Errorf("msgs[%d].Subject = %q; want %q", i, m.Subject, want)
+		}
+	}
+
+	// The new outage started at 14:00, not when the first one did, so a later
+	// recovery reports the outage the operator is actually in.
+	run(3*time.Hour, "done", "")
+	msgs = failOnce.Messages()
+	if got := len(msgs); got != 3 {
+		t.Fatalf("delivered %d messages; want a recovery notice for the second outage", got)
+	}
+	if want := "Failing since: " + started.Add(2*time.Hour).UTC().Format(time.RFC3339); !strings.Contains(msgs[2].Body, want) {
+		t.Errorf("recovery body missing %q; body=%s", want, msgs[2].Body)
+	}
+}
+
+// TestAlert_UndeliveredChangedFailureIsStillTheOneReported pins the case that
+// needs the observed-state and known-state split. Failure A is alerted, the store
+// then starts failing a different way and THAT alert cannot be delivered, and then
+// the store recovers. Tracking only what the operator knows leaves the loop
+// pointed at A, so it closes the streak by naming A and the operator never hears
+// of B at all.
+func TestAlert_UndeliveredChangedFailureIsStillTheOneReported(t *testing.T) {
+	t.Parallel()
+	// Attempt 1 is A's alert (delivered), attempt 2 is B's alert (lost),
+	// attempt 3 is the recovery notice.
+	failOnce := &failNthMail{Fake: mail.NewFake(), failAt: 2}
+	var stderr bytes.Buffer
+	loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg: config.DoltMaintenance{
+			Enabled:  true,
+			Interval: "168h",
+			AlertTo:  "gascity/mayor",
+		},
+		CityPath: "/tmp/city",
+		Recorder: events.NewFake(),
+		Mail:     failOnce,
+		Stderr:   &stderr,
+	})
+
+	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	run := func(offset time.Duration, stage, errMsg string) {
+		emitUnderLock(loop, MaintenanceRun{
+			StartedAt:  started.Add(offset),
+			FinishedAt: started.Add(offset + time.Second),
+			Stage:      stage,
+			Err:        errMsg,
+		})
+	}
+
+	run(0, "gc", "open dolt conn: connection refused")
+	run(time.Hour, "backup", "sync target: disk full")
+	run(2*time.Hour, "done", "")
+
+	msgs := failOnce.Messages()
+	if got := len(msgs); got != 2 {
+		t.Fatalf("delivered %d messages; want A's alert and one recovery notice", got)
+	}
+	if failOnce.attempts != 3 {
+		t.Fatalf("attempted %d sends; want 3 (A alerted, B lost, recovery)", failOnce.attempts)
+	}
+	rec := msgs[1]
+	if want := "[RECOVERED] Dolt store maintenance succeeded after failing: backup"; rec.Subject != want {
+		t.Fatalf("recovery subject = %q; want %q, the failure the store was actually in", rec.Subject, want)
+	}
+	if !strings.Contains(rec.Body, "sync target: disk full") {
+		t.Errorf("recovery body does not name the undelivered failure; body=%s", rec.Body)
+	}
+	if strings.Contains(rec.Body, "connection refused") {
+		t.Errorf("recovery body names the earlier, resolved failure; body=%s", rec.Body)
+	}
+	if !strings.Contains(rec.Body, "could not be delivered") {
+		t.Errorf("recovery body does not say the alert never reached the operator; body=%s", rec.Body)
+	}
+	// The streak started with A, not with the shape change.
+	if want := "Failing since: " + started.UTC().Format(time.RFC3339); !strings.Contains(rec.Body, want) {
+		t.Errorf("recovery body missing %q; body=%s", want, rec.Body)
+	}
+}
+
+// TestAlert_RecoveryNoticeRetriedAfterSendFailure covers the other edge of the
+// same state machine. Clearing the fingerprint on a recovery notice that never
+// went out loses the notice outright: the loop is back in the healthy state, so
+// no later run has anything to report.
+func TestAlert_RecoveryNoticeRetriedAfterSendFailure(t *testing.T) {
+	t.Parallel()
+	// Attempt 1 is the failure alert, so let it through and break attempt 2,
+	// which is the recovery notice.
+	failOnce := &failNthMail{Fake: mail.NewFake(), failAt: 2}
+	var stderr bytes.Buffer
+	loop := NewStoreMaintenanceLoop(StoreMaintenanceLoopDeps{
+		Cfg: config.DoltMaintenance{
+			Enabled:  true,
+			Interval: "168h",
+			AlertTo:  "gascity/mayor",
+		},
+		CityPath: "/tmp/city",
+		Recorder: events.NewFake(),
+		Mail:     failOnce,
+		Stderr:   &stderr,
+	})
+
+	started := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	emitUnderLock(loop, MaintenanceRun{
+		StartedAt:  started,
+		FinishedAt: started.Add(time.Second),
+		Stage:      "gc",
+		Err:        "open dolt conn: connection refused",
+	})
+	if got := len(failOnce.Messages()); got != 1 {
+		t.Fatalf("delivered %d messages for the opening failure; want 1 alert", got)
+	}
+
+	ok := func(offset time.Duration) {
+		emitUnderLock(loop, MaintenanceRun{
+			StartedAt:  started.Add(offset),
+			FinishedAt: started.Add(offset + time.Second),
+			Stage:      "",
+		})
+	}
+
+	ok(time.Hour)
+	if got := len(failOnce.Messages()); got != 1 {
+		t.Fatalf("delivered %d messages while mail was down; want only the earlier alert", got)
+	}
+
+	ok(2 * time.Hour)
+	msgs := failOnce.Messages()
+	if got := len(msgs); got != 2 {
+		t.Fatalf("delivered %d messages after mail recovered; want the retried recovery notice", got)
+	}
+	if want := "[RECOVERED] Dolt store maintenance succeeded after failing: gc"; msgs[1].Subject != want {
+		t.Fatalf("recovery msg.Subject = %q; want %q", msgs[1].Subject, want)
+	}
+
+	// The notice landed, so the loop is healthy again and a further success
+	// owes nothing.
+	ok(3 * time.Hour)
+	if got := len(failOnce.Messages()); got != 2 {
+		t.Fatalf("delivered %d messages for a healthy run after recovery; want 2", got)
+	}
+}
+
+// emitUnderLock drives one run through the completion path the way production
+// does, holding loop.mu: emitRunEventLocked mutates the mu-guarded alert state,
+// and the lock is the cycle lease in production.
+func emitUnderLock(loop *StoreMaintenanceLoop, run MaintenanceRun) {
+	loop.mu.Lock()
+	defer loop.mu.Unlock()
+	loop.emitRunEventLocked(run)
 }

--- a/internal/supervisor/maintenance_events_test.go
+++ b/internal/supervisor/maintenance_events_test.go
@@ -50,7 +50,7 @@ func TestRunOnce_SuccessEmitsExactlyOneDoneEvent(t *testing.T) {
 
 // TestEmitRunEvent_FailureEmitsExactlyOneFailedEvent covers the error
 // path. Downstream beads (ga-74d, ga-zoj) produce failing MaintenanceRun
-// values when a stage errors; this bead's contract is that emitRunEvent
+// values when a stage errors; this bead's contract is that the completion path
 // translates any such run into exactly one gc.store.maintenance.failed
 // event whose payload faithfully reproduces the stage, message, and
 // snapshot path.
@@ -65,7 +65,7 @@ func TestEmitRunEvent_FailureEmitsExactlyOneFailedEvent(t *testing.T) {
 		Recorder: fake,
 	})
 
-	loop.emitRunEvent(MaintenanceRun{
+	emitUnderLock(loop, MaintenanceRun{
 		StartedAt:    started,
 		FinishedAt:   finished,
 		Stage:        "gc",
@@ -114,7 +114,7 @@ func TestEmitRunEvent_SuccessPayloadFieldsMatch(t *testing.T) {
 		Recorder: fake,
 	})
 
-	loop.emitRunEvent(MaintenanceRun{
+	emitUnderLock(loop, MaintenanceRun{
 		StartedAt:    started,
 		FinishedAt:   finished,
 		Stage:        "done",
@@ -145,7 +145,7 @@ func TestEmitRunEvent_SuccessPayloadFieldsMatch(t *testing.T) {
 }
 
 // TestEmitRunEvent_NilRecorderDoesNothing ensures that when the loop
-// has no recorder (Discard default), emitRunEvent is safe to call and
+// has no recorder (Discard default), the completion path is safe to run and
 // does not panic — supervisor boot paths that run without the typed
 // event stream still exercise runOnce during tests.
 func TestEmitRunEvent_NilRecorderDoesNothing(t *testing.T) {
@@ -157,7 +157,7 @@ func TestEmitRunEvent_NilRecorderDoesNothing(t *testing.T) {
 	})
 
 	// Should not panic and has no observable side effect.
-	loop.emitRunEvent(MaintenanceRun{
+	emitUnderLock(loop, MaintenanceRun{
 		StartedAt: time.Now(),
 		Stage:     "done",
 	})

--- a/internal/supervisor/maintenance_gc_test.go
+++ b/internal/supervisor/maintenance_gc_test.go
@@ -168,13 +168,12 @@ func TestRunDoltGC_SmokeSQLError_ReturnsStageSmokeTest(t *testing.T) {
 
 func TestRunDoltGC_SmokeDeadlineExceeded_ReturnsStageSmokeTest(t *testing.T) {
 	t.Parallel()
-	// Override the smoke timeout to something small; smoke takes longer.
-	orig := maintenanceSmokeTimeout
-	maintenanceSmokeTimeout = 10 * time.Millisecond
-	t.Cleanup(func() { maintenanceSmokeTimeout = orig })
-
 	ops := &fakeDoltOps{smokeDelay: 100 * time.Millisecond}
 	loop := newGCTestLoop(t, config.DoltMaintenance{Enabled: true, GCTimeout: "1s"}, ops)
+	// Shorten this loop's smoke timeout to less than the fake's delay. On the
+	// loop, not the package var: the probe reads it from whichever loop is
+	// running, so a package-level write races every parallel test in here.
+	loop.smokeTimeout = 10 * time.Millisecond
 
 	err := loop.runDoltGC(context.Background())
 	var me *MaintenanceError

--- a/internal/supervisor/maintenance_snapshot.go
+++ b/internal/supervisor/maintenance_snapshot.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -155,13 +156,32 @@ func (m *StoreMaintenanceLoop) runSnapshot(ctx context.Context) (string, error) 
 	ts := m.clock().UTC().Format(snapshotTimestampFormat)
 	successPath := filepath.Join(successDir, ts)
 	if err := os.Rename(currentDir, successPath); err != nil {
-		return "", &MaintenanceError{Stage: "backup", Err: fmt.Errorf("rotate current → %s: %w", successPath, err)}
+		// successPath's leaf is this run's own timestamp, and os.Rename reports
+		// an *os.LinkError that renders both paths, so wrapping it verbatim puts
+		// the clock into the failure text twice over. The alert fingerprint is
+		// the stage plus that text, so a rotation that keeps failing would read
+		// as a new condition every cycle and mail the operator every cycle.
+		// Name the destination directory, which does not move, and keep the
+		// errno so errors.Is still reaches it.
+		return "", &MaintenanceError{Stage: "backup", Err: fmt.Errorf("rotate current → %s: %w", successDir, renameCause(err))}
 	}
 
 	m.pruneSnapshotsLog(successDir, snapshotRetainSuccess)
 	m.pruneSnapshotsLog(failedDir, snapshotRetainFailed)
 
 	return successPath, nil
+}
+
+// renameCause reduces an os.Rename failure to the cause underneath it, dropping
+// the *os.LinkError wrapper whose message repeats both paths. The returned error
+// still satisfies errors.Is against the syscall errno; anything that is not a
+// *os.LinkError comes back unchanged.
+func renameCause(err error) error {
+	var linkErr *os.LinkError
+	if errors.As(err, &linkErr) {
+		return linkErr.Err
+	}
+	return err
 }
 
 // recordFailedSnapshot rotates current/ (if present) to


### PR DESCRIPTION
## What broke

A repeating notifier re-detects the same condition on every run. Both notifiers in
this tree mailed on every detection.

The Dolt store-maintenance loop sent one `[ALERT]` per failed cycle:

```go
	if run.Err != "" {
		m.sendFailureAlert(run)
	}
```

So a store that stays broken mails the operator once per interval, forever, and
nothing at all marks the moment it starts working again. The signal that matters (the
state changed) is buried in the signal that does not (it is still in that state).

Orders that notify through `gc mail send` had the same problem with no way to express
it: the command sends unconditionally, so a patrol that re-detects a condition every
run either floods the mailbox or keeps its own side state.

## The fix, part one: a dedup capability for mail

`mail` gains one optional provider capability:

```go
type DedupSender interface {
	SendDeduped(from, to, subject, body, key string) (msg Message, suppressed bool, err error)
}
```

`beadmail` implements it with a single metadata-keyed list: if a live message with the
same key is already in the same mailbox, that message is returned with
`suppressed=true` and nothing is created. A probe error fails the send rather than
risking a silent duplicate. Providers that cannot query their own history do not
implement the interface, and callers fall back to a plain send, because a duplicate
notification beats a dropped one.

"Same mailbox" is the inbox's own question, not a string comparison. An alias and the
session id behind it resolve to one mailbox in `Inbox`, so the probe matches the stored
assignee against every route that resolves to the recipient. A stream that addresses
one mailbox both ways gets one live copy, not two.

`gc mail send --dedup <key>` exposes it and exits 0 when suppressed.

The dedup horizon is deliberately the previous message's live lifetime. The probe reads
only open messages and archiving closes one, so an archived notification no longer
matches and the stream may alert again. A sender that wants a longer re-alert cadence
keeps its own last-sent state; this is the cheap case, not a general scheduler.

`Provider.Archive`'s own doc comment claimed it deleted the message bead. It closes it,
and the comment now says so.

## The fix, part two: one alert per condition in the maintenance loop

The loop does not use the dedup capability, because it already holds state across runs.
It keys alerts on a stage-plus-error fingerprint and mails only when that changes: once
on entering a failure, again if the failure changes shape mid-streak, and once on
recovery. The recovery notice is new, and it carries how long the failure ran and how
many repeats were suppressed. The state is in memory, so a supervisor restart re-alerts
a still-broken store exactly once, which doubles as a liveness reminder rather than
silence.

Three things about that are less obvious than the happy path, and each of them is the
difference between a useful alert and a misleading one.

**What the loop observes and what the operator knows are different.** A mail backend
that is down must not cost the streak. The fingerprint follows the failure the store is
actually in and advances even when the send fails; a separate flag says whether that
alert got out. Suppressing a repeat needs both, so an undelivered alert is retried by
the next identical run instead of reading as a repeat of something never received, and
a failure whose alert was lost is still the failure the recovery notice names, with a
line saying the notice is the first the operator has seen of it. A recovery notice that
cannot be sent is owed rather than dropped, and that owed state is tracked too: without
it, a store that recovers and breaks the same way again matches the retained
fingerprint and is suppressed as a repeat of an outage that had already ended. A
failure arriving with a notice still owed clears the lot and opens a new outage.

**The error text is part of the contract.** Because the fingerprint is the rendered
error, a failure message carrying a per-run value reads as a new condition every cycle
and the suppression is worth nothing. One did: the snapshot stage wrapped `os.Rename`'s
`*os.LinkError` verbatim, and that renders the destination path, whose leaf is the run's
own timestamp. It now names the destination directory and wraps the errno underneath,
so `errors.Is` still reaches it and the text holds still. Text that an external backup
or SQL backend varies per attempt is outside the loop's control and will re-alert.

**A skipped cycle is not a success.** A disk-critical pre-flight skips the snapshot and
`CALL DOLT_GC` and finishes with no error. Read as a success, it closes an open alert
with a recovery notice for a store nothing has touched, which is the opposite of what an
operator needs while the disk is full. The alert state machine is simply not consulted
for it: the skip is the one completion path that records its event and stops there, which
keeps the fact where it is used instead of on `MaintenanceRun`, a value the status and
trigger APIs project onto the wire. The `gc.store.maintenance.done` event a skipped cycle
emits is long-standing behavior and unchanged here; `StoreDiskCritical` is what tells
operators why the cycle skipped.

Two smaller ones: `Failing since` names the run that opened the outage rather than the
run where the failure last changed shape, because an operator reads that line as the
length of the outage; and the suppressed-repeat count stays per shape, with the line it
prints on saying so.

## Lock discipline

`emitRunEvent` now mutates mu-guarded alert state, so it is renamed
`emitRunEventLocked` to say so, and the three pre-existing test call sites go through
the same locked helper the new tests use. Holding the lock across the alert send is not
new contention: it is the cycle lease, already held for the whole multi-minute
maintenance run.

## Two things in here that are not the feature

`go test -race ./internal/supervisor/` reported a data race on every run **before**
this branch, at `ea361ee1b7`: `maintenanceSmokeTimeout` is a package var that one
`t.Parallel()` test writes while others read it through the probe. Both sides are
parallel, so it surfaces and hides with scheduling, which is how a red `-race` run in
this package came to read as noise. The second commit makes the timeout a per-loop
field defaulting to the same constant, so the test shortens its own loop. No production
behavior changes. It is here because this PR adds parallel tests to that package, and
otherwise its own `-race` gate could not be trusted.

The mail examples in the help text and the CLI reference lose their role names. Help
text feeds the generated docs, so a role name there leaks into published documentation.
The `--dedup` help and the `gc-mail` skill both say that dedup needs a provider which can
query its own history, and that one which cannot sends normally, so suppression does not
read as a guarantee. The skill's archive section said the operation deletes the bead; it
closes it, and the section keeps its warning that there is no way back.

`spawn-storm-detect.sh` is the first caller. It mails once when a bead's reset count
crosses the threshold rather than on every sweep for as long as the storm lasts, and
passes `--dedup` so a ledger reset cannot re-alert while the previous mail is still live.
An edge trigger carries the same hazard as the fingerprint above: the count is saved
whether the mail went out or not, and a count left at the threshold never equals it
again, so a failed send rolls that bead's count back and the next sweep crosses again.

## Test plan

```
gofmt -l cmd/gc internal/mail internal/supervisor
go build ./... && go vet ./...
go test ./internal/mail/... ./internal/supervisor/
go test -race ./internal/mail/... ./internal/supervisor/
go test ./cmd/gc/
go test ./internal/testpolicy/... ./test/docsync/
shellcheck internal/bootstrap/packs/core/assets/scripts/spawn-storm-detect.sh
golangci-lint run ./internal/mail/... ./internal/supervisor/... ./cmd/gc/...
```

All pass at this head. The dedup surface is covered case by case: suppression while a
live copy exists, suppression across two routes to one mailbox, a read-but-unarchived
copy still suppressing, a resend after archive, scoping by key and by recipient
separately, a missing key refused, the CLI suppressing, the CLI reporting it in JSON,
and the CLI falling back when the provider lacks the capability.

The alert state machine is covered transition by transition, including the ones that
only appear when mail is unreliable. Each claim was run against a mutation of the
production code it should catch:

| Mutation | Test that goes red |
| --- | --- |
| dedup compares the raw stored assignee | suppression across two routes to one mailbox |
| the state advances on a failed send | the failure alert retried after a send failure |
| suppression ignores whether the alert was delivered | the same |
| the rotation error wraps the `*LinkError` verbatim | one unchanged condition over three real cycles, rotation case only |
| the fingerprint is the stage alone | repeats suppressed, error changed within one stage |
| `alertSince` is reassigned on every shape change | the recovery notice naming the streak start |
| the skipped-cycle guard is deleted | a disk-critical skip treated as recovery |
| the owed-recovery branch is deleted | a new outage after an undelivered recovery |
| the skipped cycle is routed back through the normal completion path | a disk-critical skip treated as recovery |

The cross-cycle case drives real cycles through the snapshot stage rather than
hand-built run values, with an advancing clock and three separate failure modes, so it
pins both that the error text holds still and that the suppression works on it. The
rotation mode blocks `rename(2)` with an occupied destination rather than a read-only
parent, so it does not depend on file modes a root test runner would ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcPXz8AxpyCCoDcK7Bu5W
