### PR TITLE
Preserve named sessions across suspend and resume

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2963,6 +2963,22 @@ func discoverSessionBeadsWithRoots(
 				tp.InstanceName = sn
 			}
 		}
+		if isNamedSessionInfo(info) {
+			// Rediscovery runs whenever the primary cfg-driven namedSpecs loop
+			// (build_desired_state.go ~1130-1139) did not populate this bead into
+			// desired this tick — e.g. during city suspend, which gates only that
+			// primary build and not this backfill. resolveTemplateForSessionBeadInfo
+			// above recovers identity/work-dir via canonicalSessionIdentityWithConfigInfo,
+			// but never sets these three fields, so without this the named-session
+			// markers session_beads.go and templateParamsSessionOrigin key off go
+			// missing and the bead is wrongly treated as non-named.
+			tp.ConfiguredNamedIdentity = info.ConfiguredNamedIdentity
+			tp.ConfiguredNamedMode = info.ConfiguredNamedMode
+			if tp.Env == nil {
+				tp.Env = make(map[string]string)
+			}
+			tp.Env["GC_SESSION_ORIGIN"] = "named"
+		}
 		installAgentSideEffects(bp, cfgAgent, tp, stderr)
 		desired[sn] = tp
 	}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5288,6 +5288,77 @@ func TestDiscoverSessionBeadsSkipsStaleMaxOneWhenDependencyFloorDesired(t *testi
 	}
 }
 
+// TestDiscoverSessionBeadsBackfillsConfiguredNamedIdentityOutsideDesiredState
+// probes ga-pmafyc step 2: when the primary cfg-driven namedSpecs loop does not
+// run for a tick (e.g. because the city is suspended and buildDesiredState
+// short-circuits to an empty result before reaching that loop),
+// discoverSessionBeadsWithRoots rediscovers an already-open named session bead
+// directly from the live store. It must backfill tp.ConfiguredNamedIdentity /
+// tp.ConfiguredNamedMode / tp.Env["GC_SESSION_ORIGIN"] from the bead's own
+// already-persisted identity, mirroring what the namedSpecs loop
+// (build_desired_state.go ~1130-1139) sets on a normal tick. Without this
+// backfill, session_beads.go's isConfiguredNamed check (keyed on
+// tp.ConfiguredNamedIdentity) sees a false negative and clears the bead's
+// configured_named_* metadata, and templateParamsSessionOrigin falls through
+// to "ephemeral" instead of "named".
+func TestDiscoverSessionBeadsBackfillsConfiguredNamedIdentityOutsideDesiredState(t *testing.T) {
+	store := beads.NewMemStore()
+	named, err := store.Create(beads.Bead{
+		Title:  "gascity/worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity/worker", "template:gascity/worker"},
+		Metadata: map[string]string{
+			"template":                   "gascity/worker",
+			"agent_name":                 "gascity/worker",
+			"session_name":               "s-worker-named",
+			"state":                      "awake",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "worker",
+			namedSessionModeMetadata:     "always",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &sessionBeadSnapshot{}
+	snapshot.addInfo(sessiontest.SeedBead(t, named))
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "gascity",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+	bp := &agentBuildParams{
+		cityPath:     t.TempDir(),
+		city:         cfg,
+		beadStore:    store,
+		sessionBeads: snapshot,
+		agents:       cfg.Agents,
+	}
+	// Empty desired simulates the primary cfg-driven namedSpecs loop not
+	// running this tick.
+	desired := map[string]TemplateParams{}
+
+	discoverSessionBeadsWithRoots(bp, cfg, desired, nil, nil, nil, io.Discard)
+
+	tp, ok := desired["s-worker-named"]
+	if !ok {
+		t.Fatalf("desired state missing rediscovered named session; keys=%v", mapKeys(desired))
+	}
+	if tp.ConfiguredNamedIdentity != "worker" {
+		t.Errorf("ConfiguredNamedIdentity = %q, want %q (rediscovery must backfill from the bead's own persisted identity)", tp.ConfiguredNamedIdentity, "worker")
+	}
+	if tp.ConfiguredNamedMode != "always" {
+		t.Errorf("ConfiguredNamedMode = %q, want %q", tp.ConfiguredNamedMode, "always")
+	}
+	if got := tp.Env["GC_SESSION_ORIGIN"]; got != "named" {
+		t.Errorf(`Env["GC_SESSION_ORIGIN"] = %q, want "named" (else templateParamsSessionOrigin falls through to "ephemeral")`, got)
+	}
+}
+
 func TestNonExpandingPoolIdentitySlotRecognizesOutOfRangeNumericSuffix(t *testing.T) {
 	cfgAgent := &config.Agent{
 		Name:              "refinery",

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -164,6 +164,17 @@ type startCandidate struct {
 	info  sessionpkg.Info
 	tp    TemplateParams
 	order int
+
+	// configured mirrors configuredNames[name()] at the pipeline's true
+	// construction site (reconcileSessionBeadsTracedWithNamedDemand). It
+	// propagates by value through preparedStart.candidate to
+	// startResult.prepared.candidate, letting commitStartFailure tell a
+	// controller-owned named session apart from an orphaned one without
+	// threading configuredNames through the intervening call chain. Left
+	// at its zero value (false) on the two non-pipeline construction sites
+	// (relaunchAgentForLaunchDrift, recoverRunningPendingCreate), which
+	// never produce a startResult and so never read it.
+	configured bool
 }
 
 // name reads the RAW session_name metadata off the typed twin
@@ -2414,7 +2425,16 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 				fmt.Fprintf(stderr, "session reconciler: saving startup-health episode for %s: %v\n", name, saveErr) //nolint:errcheck
 			}
 		}
-		rollbackPendingCreate(info, sessFront, clk.Now().UTC(), stderr)
+		if !result.prepared.candidate.configured {
+			// A configured named session (declared via [[named_session]]) must
+			// survive a single transient start failure mid pending-create (e.g.
+			// a gc suspend/resume cycle) so the reconciler can retry it, instead
+			// of being destructively closed with its session_name cleared — see
+			// TestReconcileSessionBeads_RollsBackPendingCreatePreservesConfiguredNamedSession.
+			// An orphaned (unconfigured) pending-create still rolls back here,
+			// per TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError.
+			rollbackPendingCreate(info, sessFront, clk.Now().UTC(), stderr)
+		}
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, result.err, result.phases)
 		return
 	}

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -257,16 +257,24 @@ type startResult struct {
 	finished        time.Time
 	rollbackPending bool
 	rateLimitScreen bool
-	// diedDuringStartup is true only when the provider's Start() call itself
+	// diedDuringStartup is true when the session started and then died
+	// before it was confirmed alive, detected either of two ways: (1) the
+	// provider/resume layer returns runtime.ErrSessionDiedDuringStartup
+	// directly from Start() — the only path reachable when the session has
+	// no session_key to recover through (e.g. a plain bash-script agent
+	// with no SessionIDFlag configured; see retryFreshStartAfterStaleKey's
+	// decline branch in internal/session/chat.go), or (2) Start() itself
 	// succeeded (startedFresh) and the *post-start* stability/liveness check
-	// then found the session not running/alive (the "session %q died during
-	// startup" synthetic error) — as opposed to Start() itself returning an
-	// error (e.g. a transient provider error mid a gc suspend/resume cycle).
+	// below then found the session not running/alive (the "session %q died
+	// during startup" synthetic error; requires a non-empty SessionKey to
+	// run at all). Either way this is distinct from Start() returning some
+	// other, generic error (e.g. a transient provider error mid a gc
+	// suspend/resume cycle), which leaves diedDuringStartup false.
 	// commitStartFailure uses this to distinguish "this session actually came
 	// up and immediately exited, so its pending-create should roll back and
 	// retry fresh" from "Start() never got the process up at all, so a
 	// configured named session's pending-create should be preserved for a
-	// retry instead of destructively closed" (ga-pmafyc round 4).
+	// retry instead of destructively closed" (ga-pmafyc rounds 4 and 5).
 	diedDuringStartup bool
 	// phases captures sub-phase wall-clock so the lifecycle log can pinpoint
 	// where a slow start spent its time. See gc-67o for context.
@@ -1521,10 +1529,15 @@ func runPreparedStartCandidate(
 	startCallBegin := time.Now()
 	startedFresh, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg, &phases, sessionStaleKeyDetectionWaiter, warmClaim)
 	startCtxErr := startCtx.Err()
-	// diedDuringStartup distinguishes "Start() itself returned an error" from
-	// "Start() succeeded but the post-start liveness check then found the
-	// session dead" — see the startResult.diedDuringStartup doc comment.
-	diedDuringStartup := false
+	// diedDuringStartup starts true when the provider/resume layer already
+	// reported the death directly (runtime.ErrSessionDiedDuringStartup,
+	// e.g. from the tmux adapter or from retryFreshStartAfterStaleKey's
+	// decline in internal/session/chat.go when there is no session_key to
+	// recover through) — see the startResult.diedDuringStartup doc comment.
+	// The local post-start liveness check below can still independently set
+	// it true for the other detection path; neither path ever resets it back
+	// to false.
+	diedDuringStartup := errors.Is(err, runtime.ErrSessionDiedDuringStartup)
 	// Split start_call into provider.Start and the ErrStateSync recovery
 	// branch (gc-9ha). The recovery branch hits the worker observation
 	// API which can dominate start_call when the runtime is wedged.

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -257,6 +257,17 @@ type startResult struct {
 	finished        time.Time
 	rollbackPending bool
 	rateLimitScreen bool
+	// diedDuringStartup is true only when the provider's Start() call itself
+	// succeeded (startedFresh) and the *post-start* stability/liveness check
+	// then found the session not running/alive (the "session %q died during
+	// startup" synthetic error) — as opposed to Start() itself returning an
+	// error (e.g. a transient provider error mid a gc suspend/resume cycle).
+	// commitStartFailure uses this to distinguish "this session actually came
+	// up and immediately exited, so its pending-create should roll back and
+	// retry fresh" from "Start() never got the process up at all, so a
+	// configured named session's pending-create should be preserved for a
+	// retry instead of destructively closed" (ga-pmafyc round 4).
+	diedDuringStartup bool
 	// phases captures sub-phase wall-clock so the lifecycle log can pinpoint
 	// where a slow start spent its time. See gc-67o for context.
 	phases startPhaseTimings
@@ -1510,6 +1521,10 @@ func runPreparedStartCandidate(
 	startCallBegin := time.Now()
 	startedFresh, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg, &phases, sessionStaleKeyDetectionWaiter, warmClaim)
 	startCtxErr := startCtx.Err()
+	// diedDuringStartup distinguishes "Start() itself returned an error" from
+	// "Start() succeeded but the post-start liveness check then found the
+	// session dead" — see the startResult.diedDuringStartup doc comment.
+	diedDuringStartup := false
 	// Split start_call into provider.Start and the ErrStateSync recovery
 	// branch (gc-9ha). The recovery branch hits the worker observation
 	// API which can dominate start_call when the runtime is wedged.
@@ -1557,6 +1572,7 @@ func runPreparedStartCandidate(
 				err = fmt.Errorf("observing session %q after startup: %w", item.candidate.name(), err)
 			} else if !running || !alive {
 				err = fmt.Errorf("session %q died during startup", item.candidate.name())
+				diedDuringStartup = true
 			}
 		}
 		phases.PostStartObserve = time.Since(postStartBegin)
@@ -1567,13 +1583,14 @@ func runPreparedStartCandidate(
 	rateLimitScreen := err != nil && !livenessUnavailable && startupRateLimitScreenDetected(item, cityPath, sp, store, cfg)
 	if err != nil && rollbackPending && !rateLimitScreen && runningSessionMatchesPendingCreateInfo(item.candidate.info, item.candidate.name(), sp) {
 		return startResult{
-			prepared:        item,
-			err:             nil,
-			outcome:         TraceOutcomeStartErrorConverged,
-			started:         started,
-			finished:        finished,
-			rollbackPending: false,
-			phases:          phases,
+			prepared:          item,
+			err:               nil,
+			outcome:           TraceOutcomeStartErrorConverged,
+			started:           started,
+			finished:          finished,
+			rollbackPending:   false,
+			diedDuringStartup: diedDuringStartup,
+			phases:            phases,
 		}
 	}
 	var outcome TraceOutcomeCode
@@ -1617,14 +1634,15 @@ func runPreparedStartCandidate(
 		rateLimitScreen = false
 	}
 	return startResult{
-		prepared:        item,
-		err:             err,
-		outcome:         outcome,
-		started:         started,
-		finished:        finished,
-		rollbackPending: rollbackPending,
-		rateLimitScreen: rateLimitScreen,
-		phases:          phases,
+		prepared:          item,
+		err:               err,
+		outcome:           outcome,
+		started:           started,
+		finished:          finished,
+		rollbackPending:   rollbackPending,
+		rateLimitScreen:   rateLimitScreen,
+		diedDuringStartup: diedDuringStartup,
+		phases:            phases,
 	}
 }
 
@@ -2425,7 +2443,7 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 				fmt.Fprintf(stderr, "session reconciler: saving startup-health episode for %s: %v\n", name, saveErr) //nolint:errcheck
 			}
 		}
-		if !result.prepared.candidate.configured {
+		if !result.prepared.candidate.configured || result.diedDuringStartup {
 			// A configured named session (declared via [[named_session]]) must
 			// survive a single transient start failure mid pending-create (e.g.
 			// a gc suspend/resume cycle) so the reconciler can retry it, instead
@@ -2433,6 +2451,11 @@ func commitStartFailure(result startResult, sessFront *sessionpkg.Store, clk clo
 			// TestReconcileSessionBeads_RollsBackPendingCreatePreservesConfiguredNamedSession.
 			// An orphaned (unconfigured) pending-create still rolls back here,
 			// per TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError.
+			// A configured session that DID start but then died during its
+			// post-start liveness check (diedDuringStartup) still rolls back
+			// here: it actually launched and exited, so the stale pending-create
+			// must clear for a fresh attempt next tick, matching base's fast
+			// recovery — see TestGastown_Reconciler_SessionRestartsAfterExit.
 			rollbackPendingCreate(info, sessFront, clk.Now().UTC(), stderr)
 		}
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, string(result.outcome), result.started, result.finished, result.err, result.phases)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -2261,7 +2261,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 						}
 						result := finalizeDrainAckStoppedSession(
 							cityPath, cfg, store, rigStores, infoByID[id], template,
-							true, dops, dt, clk, rec, stderr,
+							!configuredNames[name], dops, dt, clk, rec, stderr,
 						)
 						// finalizeDrainAckStoppedSession may close the bead in memory; fold
 						// that close onto the snapshot so the cross-session min-floor scan

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1535,6 +1535,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	// Load provider-health snapshot once per tick (ADR-0013 A1 M3a).
 	// All per-session gate checks in Phase 2 use this snapshot — no I/O per session.
 	phSnap := loadProviderHealthSnapshot(cityPath)
+	// Load runtime suspension state once per tick, mirroring phSnap above:
+	// the wake-arm's no-wake-reason fallback (Phase 2) checks city suspension
+	// per session and must not re-read .gc/runtime/suspension-state.json
+	// from disk on every one of them.
+	suspState := loadSuspensionStateBestEffort(cityPath)
 	reconcileOpts := startExecutionOptions{}
 	for _, apply := range startOptions {
 		if apply != nil {
@@ -4082,6 +4087,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				reason = "idle"
 			case eval.ConfigSuppressed:
 				reason = "idle"
+			case configuredNames[name] && citySuspendedWithState(cfg, suspState):
+				// A configured named session with no other wake reason during
+				// a city-wide `gc suspend` is not orphaned or idle — its spec
+				// is just scaled down. Label it like the orphan arm already
+				// labels the equivalent !desired case (line ~2283/2350) so
+				// downstream identity-preservation and drainReasonCancelable
+				// treat this drain as suspend-class/revertible instead of a
+				// generic non-wake close.
+				reason = "suspended"
 			default:
 				reason = "no-wake-reason"
 			}
@@ -4130,7 +4144,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		// keep the same bead so later wake/restart happens in place instead
 		// of minting a fresh canonical owner.
 		hasAssignedWork := false
-		poolFreeable := !shouldWake && !target.alive && isPoolSessionSlotFreeableInfo(info) && isPoolManagedSessionInfo(info)
+		poolFreeable := !shouldWake && !target.alive && isPoolSessionSlotFreeableInfo(info) && isPoolManagedSessionInfo(info) && !isNamedSessionInfo(info)
 		if poolFreeable {
 			var assignedErr error
 			hasAssignedWork, assignedErr = sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, info)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -4008,9 +4008,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			// sanctioned re-reads at prepareStartCandidateForCity / refreshAsyncStartResult
 			// refresh it before the commit decision.
 			startCandidates = append(startCandidates, startCandidate{
-				info:  infoByID[target.info.ID],
-				tp:    target.tp,
-				order: len(startCandidates),
+				info:       infoByID[target.info.ID],
+				tp:         target.tp,
+				order:      len(startCandidates),
+				configured: configuredNames[name],
 			})
 		}
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -6740,6 +6740,47 @@ func TestReconcileSessionBeads_SuspendedSessionDrained(t *testing.T) {
 	}
 }
 
+// TestReconcileSessionBeads_SuspendedNamedSessionInsideDesiredStateDrainsAsSuspended
+// probes ga-pmafyc step 1: discoverSessionBeadsWithRoots backfills a
+// configured named session into desiredState even when the primary
+// cfg-driven build is empty because the city is suspended (fix spec step 2,
+// covered separately by
+// TestDiscoverSessionBeadsBackfillsConfiguredNamedIdentityOutsideDesiredState
+// in build_desired_state_test.go). That backfilled entry routes the session
+// through the WAKE arm (desired == true), not the orphan arm -- unlike the
+// sibling TestReconcileSessionBeads_SuspendedSessionDrained above, which
+// covers the orphan arm's pre-existing "suspended" labeling for a session
+// that is NOT in desiredState. Before this fix, the wake arm's reason-switch
+// had no case for "configured named session, city suspended, no other wake
+// reason", so it fell through to the default "no-wake-reason" label --
+// which drainReasonCancelable treats as a plain non-cancelable close
+// instead of a revertible suspend-class drain, and (combined with the
+// step-2 identity-clearing bug) meant `gc resume` could not revive the
+// session. This asserts the wake arm now labels the drain "suspended".
+func TestReconcileSessionBeads_SuspendedNamedSessionInsideDesiredStateDrainsAsSuspended(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{SuspendedOnStart: true},
+		Agents:        []config.Agent{{Name: "worker"}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	// Simulate discoverSessionBeadsWithRoots's unconditional backfill: "worker"
+	// is present in desiredState (and running) even though the city is
+	// suspended -- the exact shape the wake arm sees in production.
+	env.addDesired("worker", "worker", true)
+	session := env.createSessionBead("worker", "worker")
+
+	env.reconcile([]beads.Bead{session})
+
+	ds := env.dt.get(session.ID)
+	if ds == nil {
+		t.Fatal("expected drain for suspended session present in desiredState")
+	}
+	if ds.reason != "suspended" {
+		t.Errorf("drain reason = %q, want %q (must not fall through to no-wake-reason)", ds.reason, "suspended")
+	}
+}
+
 func TestReconcileSessionBeads_SuspendedNotRunningClosed(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
@@ -6812,6 +6853,66 @@ func TestReconcileSessionBeads_PreservesConfiguredNamedSessionOutsideDesiredStat
 	}
 	if ds := env.dt.get(session.ID); ds != nil {
 		t.Fatalf("unexpected drain for configured named session: %+v", ds)
+	}
+}
+
+// TestReconcileSessionBeads_PoolFreeableIgnoresNamedAlwaysOutsideDesiredState
+// probes ga-pmafyc: a dual-registered session (both pool-managed AND a
+// mode="always" configured named session, matching citysus's shape) that has
+// already been drained (state="drained", target not alive) while its backing
+// agent is suspended must NOT be freed via the poolFreeable path. The
+// poolFreeable gate (session_reconciler.go) checks isPoolManagedSessionInfo
+// and isPoolSessionSlotFreeableInfo but never isNamedSessionInfo, despite the
+// comment above it claiming "singleton/named controller-managed identities
+// must keep the same bead."
+//
+// Agents[0].Suspended=true (rather than desiredState exclusion alone) is what
+// actually drives ComputeAwakeSet's ShouldWake=false for this session, via
+// AwakeAgent.Suspended (isAgentEffectivelySuspendedWith) — the reconciler
+// test harness never calls the real buildDesiredStateWithSessionBeadsAt (it
+// injects env.desiredState directly), so desiredState exclusion alone does
+// not simulate gc suspend for this decision. state="drained" stages the
+// post-drain condition directly (isDrainedSessionInfo triggers purely on
+// state=="drained", independent of which reason produced the drain), rather
+// than simulating the full alive-to-drained multi-tick sequence.
+func TestReconcileSessionBeads_PoolFreeableIgnoresNamedAlwaysOutsideDesiredState(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(1),
+			Suspended:         true,
+		}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	session := env.createSessionBead(sessionName, "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		poolManagedMetadataKey:       "true",
+		"state":                      "drained",
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	t.Logf("post-reconcile bead: status=%q metadata=%#v", b.Status, b.Metadata)
+	if b.Status != "open" {
+		t.Errorf("status = %q, want open (named always-mode session must survive suspend, not be freed as a pool slot)", b.Status)
+	}
+	if got := b.Metadata[namedSessionMetadataKey]; got != "true" {
+		t.Errorf("configured_named_session = %q, want true (must survive)", got)
+	}
+	if got := b.Metadata[namedSessionIdentityMetadata]; got != "worker" {
+		t.Errorf("configured_named_identity = %q, want worker (must survive)", got)
 	}
 }
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -8754,6 +8754,71 @@ func TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError(t *testing.
 	}
 }
 
+// TestReconcileSessionBeads_RollsBackPendingCreatePreservesConfiguredNamedSession
+// probes ga-pmafyc (round 3): unlike TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError
+// above — where "sky" is an ORPHANED named session (not present in
+// cfg.NamedSessions, so configuredNames["sky"] is false) and is correctly
+// destructively closed — a CONFIGURED named session (mode="always", present
+// in cfg.NamedSessions) that hits the exact same single transient provider
+// start error during a pending-create (e.g. a gc suspend/resume cycle: the
+// session bead re-enters pending-create to be woken again, and the resume
+// attempt transiently fails) must NOT be destructively closed with its
+// session_name cleared. commitStartFailure's rollbackPendingCreate call in
+// the rollbackPending branch has no configuredNames[name] guard, unlike the
+// sibling finalizeDrainAckStoppedSession call site fixed for the same bug
+// (mechanism #2, 25798164ae), so a resume-in-progress on a named/configured
+// session currently loses its pending-create bead and identity on a single
+// transient start failure instead of surviving for the reconciler to retry.
+func TestReconcileSessionBeads_RollsBackPendingCreatePreservesConfiguredNamedSession(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "helper",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{Template: "helper", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "helper")
+	env.sp.StartErrors = map[string]error{sessionName: errors.New("start failed")}
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "test-cmd",
+		SessionName:  sessionName,
+		TemplateName: "helper",
+	}
+
+	session := env.createSessionBead(sessionName, "helper")
+	env.setSessionMetadata(&session, map[string]string{
+		"session_name_explicit":      "true",
+		"pending_create_claim":       "true",
+		"state":                      "creating",
+		"continuation_epoch":         "1",
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "helper",
+		namedSessionModeMetadata:     "always",
+	})
+
+	woken := env.reconcileWithPoolDesiredAndDrainOps([]beads.Bead{session}, nil, nil)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	t.Logf("post-reconcile bead: status=%q metadata=%#v", b.Status, b.Metadata)
+	if b.Status != "open" {
+		t.Fatalf("status = %q, want open (configured named session must survive a transient rollback-pending start failure, not be destructively closed)", b.Status)
+	}
+	if got := b.Metadata["session_name"]; got != sessionName {
+		t.Errorf("session_name = %q, want %q (identity must survive a transient rollback-pending start failure)", got, sessionName)
+	}
+	if got := b.Metadata[namedSessionMetadataKey]; got != "true" {
+		t.Errorf("configured_named_session = %q, want true (must survive)", got)
+	}
+}
+
 func TestReconcileSessionBeads_PoolScaleDownOrphansExcess(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2361,6 +2361,71 @@ func TestReconcileSessionBeads_UndesiredDrainAckWithAssignedOpenWorkSleepsInstea
 	}
 }
 
+// TestReconcileSessionBeads_DrainAckPreservesConfiguredNamedSession probes
+// ga-pmafyc: a configured named session (mode="always") that reaches the
+// drain-ack finalize default branch (state="stopped", drain-acked, provider
+// not alive, no assigned work) must NOT be destructively closed the way an
+// ordinary undesired session is in
+// TestReconcileSessionBeads_UndesiredDrainAckStopsAndCloses above.
+// finalizeDrainAckStoppedSession's closeIfUnassigned parameter is a
+// hardcoded true at this call site, missing the configuredNames[name] guard
+// used by the sibling call sites — gc suspend (which drives sessions
+// through this exact path) retires every named session and empties its
+// identity as a result.
+//
+// state="stopped" (rather than simulating the full sp.Start-then-stop-pending
+// multi-tick sequence the ordinary UndesiredDrainAck* tests above use) stages
+// the post-stop condition directly: preserveConfiguredNamedSessionBeadInfo is
+// computed pre-heal from this same fixture state, and only state=="stopped"
+// (or "failed-create") lets a configured named session's preserveNamed gate
+// go false and reach the drain-ack default branch at all — the async
+// stop-pending path would leave an intermediate state that keeps the session
+// protected by preserveNamed==true on the tick that matters.
+func TestReconcileSessionBeads_DrainAckPreservesConfiguredNamedSession(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "worker",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	session := env.createSessionBead(sessionName, "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		"state":                      "stopped",
+	})
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck(sessionName); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := env.reconcileWithPoolDesiredAndDrainOps([]beads.Bead{session}, nil, dops)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	t.Logf("post-reconcile bead: status=%q metadata=%#v", b.Status, b.Metadata)
+	if b.Status != "open" {
+		t.Fatalf("status = %q, want open (configured named session must survive drain-ack finalize, not be destructively closed)", b.Status)
+	}
+	if got := b.Metadata[namedSessionMetadataKey]; got != "true" {
+		t.Errorf("configured_named_session = %q, want true (must survive)", got)
+	}
+	if got := b.Metadata[namedSessionIdentityMetadata]; got != "worker" {
+		t.Errorf("configured_named_identity = %q, want worker (must survive)", got)
+	}
+}
+
 // TestReconcileSessionBeads_DrainAckUsesLiveStoreQuery is the regression
 // guard for the stuck-pool-worker bug on ga-ttn5z. Pool workers close
 // their own work bead with `bd close` BEFORE calling `gc runtime

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -8819,6 +8819,93 @@ func TestReconcileSessionBeads_RollsBackPendingCreatePreservesConfiguredNamedSes
 	}
 }
 
+// TestReconcileSessionBeads_RollsBackConfiguredNamedSessionThatDiedDuringStartup
+// probes ga-pmafyc (round 4): the flip side of
+// TestReconcileSessionBeads_RollsBackPendingCreatePreservesConfiguredNamedSession
+// above. There, Start() itself returns an error, and a configured named
+// session's pending-create must be PRESERVED so the reconciler can retry it.
+// Here, Start() SUCCEEDS but the post-start stability/liveness check then
+// finds the session not running (diedDuringStartup) — the session actually
+// launched and immediately exited, a legitimate fast exit-then-restart cycle,
+// not a transient provider hiccup mid pending-create. This is the unit-level
+// guard for TestGastown_Reconciler_SessionRestartsAfterExit (the integration
+// regression this whole round fixes): a configured named session in this
+// state must still roll back exactly like an orphaned one
+// (TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError), not be
+// preserved — preserving it would make the reconciler treat "started and
+// immediately exited" as "still creating," starving the session of a restart.
+func TestReconcileSessionBeads_RollsBackConfiguredNamedSessionThatDiedDuringStartup(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "helper",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{Template: "helper", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "helper")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "test-cmd",
+		SessionName:  sessionName,
+		TemplateName: "helper",
+	}
+
+	session := env.createSessionBead(sessionName, "helper")
+	env.setSessionMetadata(&session, map[string]string{
+		"session_name_explicit": "true",
+		"pending_create_claim":  "true",
+		"state":                 "creating",
+		"continuation_epoch":    "1",
+		// session_key must be non-empty for the post-start stale-key
+		// liveness check to run at all (TestExecutePreparedStartWave_NoStaleCheckWithoutSessionKey);
+		// without it, startedFresh's post-start observation never fires and
+		// diedDuringStartup can never become true.
+		"session_key":                "stale-key-abc",
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "helper",
+		namedSessionModeMetadata:     "always",
+	})
+
+	// dieAfterStartProvider (defined in session_lifecycle_parallel_test.go)
+	// makes Start() succeed and then immediately removes the session, so the
+	// post-start liveness check observes it as not running — exercising
+	// diedDuringStartup=true, unlike the sibling "preserves" test above whose
+	// sp.StartErrors makes Start() itself fail (diedDuringStartup stays false).
+	sp := &dieAfterStartProvider{Fake: env.sp}
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	woken := reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, sp,
+		env.store, nil, nil, nil, env.dt, nil, false, nil, "",
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+		env.startOptions...,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	t.Logf("post-reconcile bead: status=%q metadata=%#v", b.Status, b.Metadata)
+	if b.Status != "closed" {
+		t.Fatalf("status = %q, want closed (a configured named session that died during its post-start liveness check must roll back, not be preserved as if still creating)", b.Status)
+	}
+	if got := b.Metadata["session_name"]; got != "" {
+		t.Errorf("session_name = %q, want empty after rollback", got)
+	}
+	if got := b.Metadata["pending_create_claim"]; got != "" {
+		t.Errorf("pending_create_claim = %q, want empty after rollback", got)
+	}
+	if want := sessionpkg.CanonicalCloseReason("failed-create"); b.Metadata["close_reason"] != want {
+		t.Errorf("close_reason = %q, want %q", b.Metadata["close_reason"], want)
+	}
+	if b.Metadata["state"] != "failed-create" {
+		t.Errorf("state = %q, want %q", b.Metadata["state"], "failed-create")
+	}
+}
+
 func TestReconcileSessionBeads_PoolScaleDownOrphansExcess(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -8906,6 +8906,102 @@ func TestReconcileSessionBeads_RollsBackConfiguredNamedSessionThatDiedDuringStar
 	}
 }
 
+// TestReconcileSessionBeads_RollsBackSessionThatDiedDuringStartupWithoutSessionKey
+// probes ga-pmafyc (round 5): the generalized, non-SessionKey-gated twin of
+// TestReconcileSessionBeads_RollsBackConfiguredNamedSessionThatDiedDuringStartup
+// above. That test's diedDuringStartup=true is only reachable through the
+// LOCAL post-start liveness check inside runPreparedStartCandidate, which
+// itself requires a non-empty session_key to run at all
+// (TestExecutePreparedStartWave_NoStaleCheckWithoutSessionKey) — so it never
+// fires for a session with no SessionIDFlag, like a plain bash-script agent.
+//
+// Here the provider's Start() call returns runtime.ErrSessionDiedDuringStartup
+// directly (as the tmux adapter does when the pane exits before the post-spawn
+// liveness check runs — internal/runtime/tmux/adapter.go). With no session_key
+// and no resume shape to strip, retryFreshStartAfterStaleKey correctly declines
+// to retry (internal/session/chat.go, pinned by
+// TestStartRuntimeOnly_EmptySessionKeyWithoutResumeShapeDoesNotRelaunch) and
+// the sentinel-wrapped error propagates up as "resuming session: %w" — but
+// runPreparedStartCandidate currently has no case that recognizes this
+// propagated sentinel, so diedDuringStartup stays false and the configured
+// named session is incorrectly PRESERVED instead of rolled back. That leaves
+// pending_create_claim stuck "true" forever, which makes
+// pendingCreateStartInFlightInfo keep reporting start_in_flight on every
+// subsequent tick — starving the session of any further restart attempt. This
+// is the actual path TestGastown_Reconciler_SessionRestartsAfterExit hits
+// (its "shortlived" agent has no SessionIDFlag, hence no session_key), and why
+// that integration test still bimodally flakes despite the round-4 fix above.
+func TestReconcileSessionBeads_RollsBackSessionThatDiedDuringStartupWithoutSessionKey(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "helper",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{Template: "helper", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "helper")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "test-cmd",
+		SessionName:  sessionName,
+		TemplateName: "helper",
+	}
+
+	// No session_key, no resume_flag, no session_id_flag: matches a plain
+	// bash-script agent (no SessionIDFlag configured), exactly like the
+	// integration test's "shortlived" agent.
+	session := env.createSessionBead(sessionName, "helper")
+	env.setSessionMetadata(&session, map[string]string{
+		"session_name_explicit":      "true",
+		"pending_create_claim":       "true",
+		"state":                      "creating",
+		"continuation_epoch":         "1",
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "helper",
+		namedSessionModeMetadata:     "always",
+	})
+
+	// The provider reports the death directly from Start(), the way the tmux
+	// adapter does when the pane's process exits before the post-spawn
+	// liveness probe runs — not via the separate post-start liveness check
+	// that dieAfterStartProvider simulates in the sibling test above.
+	env.sp.StartErrors = map[string]error{
+		sessionName: fmt.Errorf("%w: session %q", runtime.ErrSessionDiedDuringStartup, sessionName),
+	}
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	woken := reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames, env.cfg, env.sp,
+		env.store, nil, nil, nil, env.dt, nil, false, nil, "",
+		nil, env.clk, env.rec, 0, 0, &env.stdout, &env.stderr,
+		env.startOptions...,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+
+	b, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	t.Logf("post-reconcile bead: status=%q metadata=%#v", b.Status, b.Metadata)
+	if b.Status != "closed" {
+		t.Fatalf("status = %q, want closed (a configured named session whose provider reports died-during-startup directly from Start(), with no session_key to recover through, must roll back — not be preserved as if still creating)", b.Status)
+	}
+	if got := b.Metadata["session_name"]; got != "" {
+		t.Errorf("session_name = %q, want empty after rollback", got)
+	}
+	if got := b.Metadata["pending_create_claim"]; got != "" {
+		t.Errorf("pending_create_claim = %q, want empty after rollback", got)
+	}
+	if want := sessionpkg.CanonicalCloseReason("failed-create"); b.Metadata["close_reason"] != want {
+		t.Errorf("close_reason = %q, want %q", b.Metadata["close_reason"], want)
+	}
+	if b.Metadata["state"] != "failed-create" {
+		t.Errorf("state = %q, want %q", b.Metadata["state"], "failed-create")
+	}
+}
+
 func TestReconcileSessionBeads_PoolScaleDownOrphansExcess(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/release-gates/ga-9atyeu-named-session-suspend-resume-gate.md
+++ b/release-gates/ga-9atyeu-named-session-suspend-resume-gate.md
@@ -1,0 +1,119 @@
+# Release Gate: Preserve named sessions across suspend and resume
+
+Bead: ga-9atyeu  
+Implementation bead: ga-pmafyc  
+Review bead: ga-4htypx  
+Reviewed commit: b046d172e6f32988358b1919c7f42f91b5f942f1  
+Reviewed merge-base: 1b991d75c3a2464296f939acd3dd712a25b0d89d  
+Gate base: origin/main@63c2ad893a36708ebfb089c755bf45adf467e1ce  
+Gate date: 2026-09-12
+
+`docs/PROJECT_MANIFEST.md` is not present in this repository. This checklist
+uses the deployer release criteria, `TESTING.md`, and
+`engdocs/contributors/release-gate-criteria-conventions.md`.
+
+## Gate results
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead ga-4htypx is closed with `verdict: pass` on the exact reviewed commit. The SHA resolves locally to b046d172e6f32988358b1919c7f42f91b5f942f1. |
+| 2 | Acceptance criteria met | PASS | Configured named sessions retain their identity through suspend, drain acknowledgement, and transient start rollback; genuine startup deaths still roll back with or without a session key. All seven diff-owned regression tests passed twice in the full suite. `TestE2E_SuspendResume_City` passed in the full suite and in two additional independent runs (34.52s, 36.59s, 36.57s). `TestGastown_Reconciler_SessionRestartsAfterExit` passed in the full suite and five additional candidate processes, each observing 2-3 restarts. |
+| 3 | Tests pass | PASS | The documented full local CI sweep ran all 40 job logs: 50,003 PASS, 2 FAIL, 210 SKIP. Both failures occurred during fixture `gc init` on the shared-server pending-schema-migration refusal before either test's scenario could run; they are non-diff-owned and attributed to pre-existing tracker ga-esyijp under all four attribution proofs below. All required `cmd_gc_process` shards passed, all diff-owned tests executed, and no diff-owned test failed or skipped. |
+| 4 | No high-severity review findings open | PASS | Review bead ga-4htypx records no style, security, specification, or other HIGH findings. Unresolved HIGH count: 0. |
+| 5 | Final branch is clean | PASS | `git status --short` was empty at the reviewed commit before this gate file was created. The gate file is the only deploy-only addition and will be committed as the isolated branch tip. |
+| 6 | Branch diverges cleanly from main | PASS | After refreshing `origin/main`, `git merge-tree --write-tree origin/main b046d172e6f32988358b1919c7f42f91b5f942f1` succeeded and produced tree 623ee83da4d484f3b0d2ce396ba8ab1ad98f51c9. No self-rebase was required. The deploy ancestry scope guard also passed for ga-9atyeu/ga-pmafyc/ga-wwnbvk. |
+| 7 | Single feature theme | PASS | The ten TDD commits change one subsystem and one behavior: the session reconciler's handling of configured named-session identity around suspend/resume and startup rollback. |
+
+## Acceptance evidence
+
+- `TestDiscoverSessionBeadsBackfillsConfiguredNamedIdentityOutsideDesiredState`:
+  PASS twice.
+- `TestReconcileSessionBeads_DrainAckPreservesConfiguredNamedSession`: PASS
+  twice.
+- `TestReconcileSessionBeads_SuspendedNamedSessionInsideDesiredStateDrainsAsSuspended`:
+  PASS twice.
+- `TestReconcileSessionBeads_PoolFreeableIgnoresNamedAlwaysOutsideDesiredState`:
+  PASS twice.
+- `TestReconcileSessionBeads_RollsBackPendingCreatePreservesConfiguredNamedSession`:
+  PASS twice.
+- `TestReconcileSessionBeads_RollsBackConfiguredNamedSessionThatDiedDuringStartup`:
+  PASS twice.
+- `TestReconcileSessionBeads_RollsBackSessionThatDiedDuringStartupWithoutSessionKey`:
+  PASS twice.
+- `TestE2E_SuspendResume_City`: PASS three deployer-controlled runs (34.52s,
+  36.59s, 36.57s).
+- `TestGastown_Reconciler_SessionRestartsAfterExit`: PASS in the full sweep
+  (2.04s, four restarts), then PASS in five independent candidate processes
+  (2.06s-2.33s, two or three restarts each). The reviewed merge-base also
+  passed five independent processes (1.80s-8.59s, two or three restarts),
+  confirming the narrowed startup-death signal preserves the existing prompt
+  normal-exit restart behavior.
+
+## Test evidence integrity
+
+- `test_cmd_scope: full-suite`
+- `test_cmd:`
+
+  ```text
+  DOCKER_HOST=unix:///run/user/1000/podman/podman.sock \
+  TESTCONTAINERS_RYUK_DISABLED=true \
+  EXTRA_TEST_ENV='DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true' \
+  GOFLAGS=-v LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=6 GO_TEST_TIMEOUT=30m \
+  LOCAL_TEST_LOG_DIR=/var/tmp/ga-9atyeu-full.g22FdB \
+  make test-local-full-parallel
+  ```
+
+- `test_counts: 50003 PASS, 2 FAIL, 210 SKIP` across 40 job logs. Thirty-eight
+  job logs were green; the two red logs contain only the attributed failures
+  below.
+- `diff_tests_executed:` all seven tests listed in Acceptance evidence ran in
+  both the `cmd-gc-process` and `integration-packages-cmd-gc` required lanes;
+  14 PASS observations, 0 FAIL, 0 SKIP.
+- `skip_justification:` 210 suite-declared platform, optional/live,
+  persistence, or helper skips; none is added or modified by this diff.
+- `waiver_ref: none`
+- `ci_lane_run: n/a (no CI-config change)`
+- `policy_lane: make test-ci-policy — PASS`
+- The `cmd_gc_process` path filter applies because this diff changes
+  `cmd/gc/**`. All six configured process shards completed successfully in
+  the full sweep; this includes the coverage that the default fast tier omits.
+
+## Pre-existing failure attribution
+
+`failure_attribution:`
+
+- `TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash -> ga-esyijp`
+  (mechanism proof): fixture `gc init` refused 32 pending schema migrations on
+  the shared server (v34 to v66), before the managed-worker recovery scenario
+  began.
+- `TestHumaBinary_CityCreateAsync -> ga-esyijp` (mechanism proof): city
+  creation failed while fixture `gc init` refused 30 pending schema migrations
+  on the shared server (v36 to v66), before the API scenario could run.
+
+All four attribution requirements hold for both sightings:
+
+1. Neither failure is diff-owned. Their test files are
+   `test/integration/review_formula_test.go` and
+   `test/integration/huma_binary_test.go`; the candidate changes only five
+   `cmd/gc` reconciler files.
+2. Open `gate-tracker` bead ga-esyijp covers this shared-server schema
+   condition and predates this run (created 2026-08-29). This run's sightings
+   were appended to that tracker.
+3. The landed mechanism proof is the exact fixture-init refusal above. It
+   occurs before either failing test can reach candidate behavior.
+4. There is no path overlap between either failing test and the candidate
+   diff.
+
+## Additional static gates
+
+```text
+make test-ci-policy
+go build ./...
+go vet ./...
+LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=1b991d75c3a2464296f939acd3dd712a25b0d89d make fmt-check-changed
+LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=1b991d75c3a2464296f939acd3dd712a25b0d89d make lint-changed
+make lint-new LINT_BASE=1b991d75c3a2464296f939acd3dd712a25b0d89d
+git diff --check origin/main...HEAD
+```
+
+All commands passed. `git config core.hooksPath` reports `.githooks`.


### PR DESCRIPTION
## What this changes

`gc suspend` now parks configured named sessions without erasing their identity, so `gc resume` can revive the same sessions instead of the reconciler retiring them during drain finalization.

The reconciler also distinguishes a transient provider start error from a session that genuinely died during startup. Transient failures preserve configured named-session state, while confirmed startup deaths still roll back promptly so the normal restart path can recover.

## Review notes

- The change is confined to desired-state construction and session-reconciler lifecycle handling under `cmd/gc`.
- Configured named sessions are preserved across suspend, drain acknowledgement, and transient start rollback; sessions confirmed dead during startup are removed with or without a session key.
- There are no configuration, API, wire-format, dependency, or migration changes.

## Test plan

- [x] Run the complete documented local CI sweep, including every `cmd_gc_process` shard.
- [x] Exercise full-city suspend/resume repeatedly and verify the named session returns with its identity intact.
- [x] Repeatedly exercise prompt normal-exit restart and verify the narrowed startup-death signal preserves that behavior.
- [x] Verify every new reconciler regression test executes without failure or skip.
- [x] Release gate: [`release-gates/ga-9atyeu-named-session-suspend-resume-gate.md`](release-gates/ga-9atyeu-named-session-suspend-resume-gate.md)