### PR TITLE
Prevent assigned city work from starving routed rig work

### DIFF
--- a/cmd/gc/hook_claim_assigned_federation_test.go
+++ b/cmd/gc/hook_claim_assigned_federation_test.go
@@ -20,10 +20,17 @@ import (
 
 // assignedGraphRow is the split-city shape the federated assigned tier serves:
 // an OPEN graph step assigned to this worker, living in a store the claim's bd
-// context cannot reach.
-const assignedGraphRow = `[{"id":"gcg-abc123","status":"open","assignee":"worker-1","metadata":{"gc.kind":"wisp"}}]`
+// context cannot reach. priority 0 is explicit, not incidental: since
+// ga-t922vm, hookTierAssigned and hookTierRouted tie at equal priority for
+// CROSS-store selection (see crossStoreRank) — tier alone no longer decides
+// across stores — so this fixture needs a strictly better priority than
+// routedWorkRow's default for the tests pairing the two to deterministically
+// select this store first, regardless of #5491 tie-break rotation state.
+const assignedGraphRow = `[{"id":"gcg-abc123","status":"open","assignee":"worker-1","priority":0,"metadata":{"gc.kind":"wisp"}}]`
 
-// routedWorkRow is ordinary claimable routed work in a DIFFERENT store.
+// routedWorkRow is ordinary claimable routed work in a DIFFERENT store, left at
+// the default priority so assignedGraphRow's explicit priority 0 above always
+// wins the pairing.
 const routedWorkRow = `[{"id":"hw-riga","status":"open","metadata":{"gc.routed_to":"worker"}}]`
 
 func assignedFederationClaimOpts() hookClaimOptions {
@@ -37,9 +44,9 @@ func assignedFederationClaimOpts() hookClaimOptions {
 }
 
 // TestClaimHookWorkAssignedTierUnresolvableBeadDoesNotStrandLaterStore is the
-// load-bearing case. bestStoreWithWork RANKS an assigned row ahead of a routed
-// one (hookTierAssigned < hookTierRouted), so the store holding the unclaimable
-// graph step is SELECTED ahead of the store holding genuinely claimable work. If
+// load-bearing case. assignedGraphRow's explicit priority 0 (see its doc
+// comment) keeps bestStoreWithWork selecting the store holding the unclaimable
+// graph step ahead of the store holding genuinely claimable routed work. If
 // the assigned tier answers a not-found claim with a terminal exit 1, the
 // federated drop-and-retry loop never runs and every other store's work is
 // stranded behind one permanently unclaimable id.

--- a/cmd/gc/hook_cross_store.go
+++ b/cmd/gc/hook_cross_store.go
@@ -283,6 +283,19 @@ func rigScopedHookRig(cfg *config.City, agentIdentity string) string {
 //     Reordering on a comparison we could not actually make would be worse than
 //     the behavior it replaces.
 //
+// Ranking is applied in two passes, grouped by store dir (see
+// bestRankedCandidate): raw tier stays meaningful WITHIN a dir — more than one
+// hookStore entry can share a dir when they are different query legs over the
+// SAME backing store (e.g. the claim-time class-routing front door's assigned
+// and routed legs), and there the assigned tier must still win deterministically
+// or a relocated graph step flip-flops onto a consolation bead every other tick,
+// recreating the re-serve/re-skip treadmill ga-601v2 closed. Only ACROSS
+// distinct dirs does tier collapse so priority decides (crossStoreRank) — that
+// cross-dir collapse is what ga-t922vm fixed. In real deployments every
+// hookWorkQueryStores entry already has a distinct dir, so the two passes
+// coincide with a flat cross-store comparison; the dir grouping only matters for
+// same-dir multi-leg callers like the class-routing front door's test harness.
+//
 // When no store has ready work, an error on the agent's OWN store (identified by
 // primary, not by slice position) is surfaced so emitCityWorkQueryFailure can
 // classify it — preserving the single-store emit-on-timeout contract (a
@@ -303,9 +316,7 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 	firstHit := false
 	unrankable := false
 
-	var bestRank hookCandidateRank
-	var bestTied []hookRankedStore
-	haveBest := false
+	var ranked []hookRankedCandidate
 
 	// When the federated reader is pinned to the primary leg, that leg is the
 	// only one whose answer covers the whole city; the extras run the
@@ -354,21 +365,10 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 		if rank.tier == hookTierInProgress && sameHookStore(st, primary) {
 			return out, st, nil
 		}
-		switch {
-		case !haveBest || rank.less(bestRank):
-			bestRank, haveBest = rank, true
-			bestTied = append(bestTied[:0], hookRankedStore{out: out, store: st, id: id})
-		case rank == bestRank && !hookTiedIDSeen(bestTied, id):
-			// A migrated bead (`gc storage migrate` copies, never deletes) can be
-			// ready from more than one store under the SAME id: the same row, not
-			// two tied pieces of work. Rotating across a duplicate would put a
-			// later store ahead of the primary for no reason — nothing about the
-			// work differs — and breaks the rig-first-city-last fan-out order the
-			// class-escalation claim loop depends on. An empty id (unidentifiable
-			// row) is never treated as a duplicate, so unranked-id fixtures keep
-			// rotating exactly as before.
-			bestTied = append(bestTied, hookRankedStore{out: out, store: st, id: id})
-		}
+		// Collected raw (uncollapsed) so bestRankedCandidate can compare same-dir
+		// candidates on full tier before collapsing across dirs. See its doc
+		// comment and the package doc comment above.
+		ranked = append(ranked, hookRankedCandidate{out: out, store: st, id: id, rank: rank})
 	}
 
 	// A failed federated primary is terminal for the invocation: the surviving
@@ -383,11 +383,7 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 	if unrankable && firstHit {
 		return firstHitOut, firstHitStore, nil
 	}
-	if haveBest {
-		winner := bestTied[0]
-		if len(bestTied) > 1 {
-			winner = bestTied[hookTieBreakIndex(len(bestTied), hookTieBreakClock())]
-		}
+	if winner, ok := bestRankedCandidate(ranked); ok {
 		return winner.out, winner.store, nil
 	}
 	if firstHit {
@@ -397,6 +393,77 @@ func bestStoreWithWork(command string, stores []hookStore, primary hookStore, ru
 		return ownStoreOut, hookStore{}, ownStoreErr
 	}
 	return lastOut, hookStore{}, nil
+}
+
+// hookRankedCandidate is one store's best candidate together with its RAW
+// (uncollapsed) rank, gathered by bestStoreWithWork's per-store loop before
+// bestRankedCandidate's dir-grouped reduction.
+type hookRankedCandidate struct {
+	out   string
+	store hookStore
+	id    string
+	rank  hookCandidateRank
+}
+
+// bestRankedCandidate reduces every store's ranked candidate to the one
+// bestStoreWithWork should return. See bestStoreWithWork's doc comment for
+// why this is a two-pass reduction rather than a flat cross-store comparison:
+// candidates are grouped by store dir first, reduced to one winner per dir
+// using RAW (uncollapsed) rank — the same comparison bestHookCandidateRank
+// already applies within one store's row array, because a shared dir means
+// these ARE, in effect, rows of the same store — and only then compared
+// ACROSS dirs via crossStoreRank, where an exact tie rotates using
+// hookTieBreakClock rather than always keeping the first tied dir (ga-kbbg9a).
+//
+// Reports ok=false when ranked is empty (no store had a rankable candidate),
+// letting the caller fall through to its first-hit/own-error/last-output
+// fallbacks.
+func bestRankedCandidate(ranked []hookRankedCandidate) (hookRankedStore, bool) {
+	groups := make(map[string][]hookRankedCandidate, len(ranked))
+	var dirOrder []string
+	for _, c := range ranked {
+		if _, seen := groups[c.store.dir]; !seen {
+			dirOrder = append(dirOrder, c.store.dir)
+		}
+		groups[c.store.dir] = append(groups[c.store.dir], c)
+	}
+
+	var bestRank hookCandidateRank
+	var bestTied []hookRankedStore
+	haveBest := false
+	for _, dir := range dirOrder {
+		group := groups[dir]
+		winner := group[0]
+		for _, c := range group[1:] {
+			if c.rank.less(winner.rank) {
+				winner = c
+			}
+		}
+		crossRank := winner.rank.crossStoreRank()
+		switch {
+		case !haveBest || crossRank.less(bestRank):
+			bestRank, haveBest = crossRank, true
+			bestTied = append(bestTied[:0], hookRankedStore{out: winner.out, store: winner.store, id: winner.id})
+		case crossRank == bestRank && !hookTiedIDSeen(bestTied, winner.id):
+			// A migrated bead (`gc storage migrate` copies, never deletes) can be
+			// ready from more than one store under the SAME id: the same row, not
+			// two tied pieces of work. Rotating across a duplicate would put a
+			// later store ahead of the primary for no reason — nothing about the
+			// work differs — and breaks the rig-first-city-last fan-out order the
+			// class-escalation claim loop depends on. An empty id (unidentifiable
+			// row) is never treated as a duplicate, so unranked-id fixtures keep
+			// rotating exactly as before.
+			bestTied = append(bestTied, hookRankedStore{out: winner.out, store: winner.store, id: winner.id})
+		}
+	}
+	if !haveBest {
+		return hookRankedStore{}, false
+	}
+	winner := bestTied[0]
+	if len(bestTied) > 1 {
+		winner = bestTied[hookTieBreakIndex(len(bestTied), hookTieBreakClock())]
+	}
+	return winner, true
 }
 
 // hookRankedStore pairs one store's work-query output with the store it came
@@ -524,6 +591,25 @@ func (r hookCandidateRank) less(other hookCandidateRank) bool {
 		return r.tier < other.tier
 	}
 	return r.priority < other.priority
+}
+
+// crossStoreRank collapses r for comparison AGAINST A DIFFERENT STORE. Tier
+// alone is not comparable across stores: hookTierAssigned only means "this
+// agent's identity is already on the row" — a bookkeeping fact of the store
+// that happens to hold it — not that the work is more urgent than routed
+// work sitting in another store. Left uncollapsed, an assigned-but-open row
+// in the primary store permanently outranked every routed rig row on tier
+// alone regardless of priority, and #5491's tie rotation never got a chance
+// to fire because the two candidates were never at equal rank (ga-t922vm).
+// hookTierInProgress is different: it is a live, unconditional resume claim
+// (see the short-circuit in bestStoreWithWork below), so it passes through
+// unchanged. Within a single store, tier stays fully meaningful — this is
+// only for ranks being compared against a rank from another store.
+func (r hookCandidateRank) crossStoreRank() hookCandidateRank {
+	if r.tier == hookTierInProgress {
+		return r
+	}
+	return hookCandidateRank{tier: hookTierRouted, priority: r.priority}
 }
 
 // bestHookCandidateRank returns the rank of the most urgent candidate in one

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -294,10 +294,10 @@ func TestBestStoreWithWorkRanksTierAheadOfPriority(t *testing.T) {
 			wantDir: "riga",
 		},
 		{
-			name:    "assigned beats routed at worse priority",
+			name:    "assigned in one store does not beat routed at better priority in another",
 			cityRow: `[{"id":"ci-1","priority":0}]`,
 			rigRow:  `[{"id":"va-1","priority":3,"assignee":"me"}]`,
-			wantDir: "riga",
+			wantDir: "city",
 		},
 		{
 			name:    "within the routed tier, priority decides",

--- a/cmd/gc/hook_cross_store_test.go
+++ b/cmd/gc/hook_cross_store_test.go
@@ -325,6 +325,39 @@ func TestBestStoreWithWorkRanksTierAheadOfPriority(t *testing.T) {
 	}
 }
 
+// TestBestStoreWithWorkTreatsAssignedTierAsRoutedAcrossStores is the direct
+// regression test for ga-t922vm. TestBestStoreWithWorkRanksTierAheadOfPriority
+// above correctly pins that tier dominates priority WITHIN a single store's
+// ranking (that mirrors bd's own three-tier work_query order). But
+// bestStoreWithWork was reusing that exact same tier comparison ACROSS
+// stores too — so a merely assigned-but-open bead in the primary store
+// permanently outranked routed rig work at any priority, and #5491's tie
+// rotation never got a chance to fire because the two candidates were never
+// at equal rank. Confirmed live: gm-j3o0fo (tier=assigned, priority=1) beat
+// ga-4twfqq (tier=routed, priority=1) on 10 consecutive gc hook runs even
+// though the rig bead was P0-equivalent urgent and routed specifically to
+// this agent's rig.
+//
+// Here the primary store's assigned bead is P3 and the rig's routed bead is
+// P0 — the rig bead must win once assigned and routed are tie-equivalent
+// across stores.
+func TestBestStoreWithWorkTreatsAssignedTierAsRoutedAcrossStores(t *testing.T) {
+	stores := []hookStore{{dir: "city"}, {dir: "riga"}}
+	run := func(_, dir string, _ []string) (string, error) {
+		if dir == "city" {
+			return `[{"id":"ci-1","priority":3,"assignee":"x"}]`, nil
+		}
+		return `[{"id":"va-1","priority":0}]`, nil
+	}
+	_, gotStore, err := bestStoreWithWork("q", stores, stores[0], run)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if gotStore.dir != "riga" {
+		t.Fatalf("store.dir = %q, want riga (routed P0 in a rig store must not lose to an assigned-but-open P3 in the primary store)", gotStore.dir)
+	}
+}
+
 // TestBestStoreWithWorkShortCircuitsOwnInProgress pins the resume carve-out:
 // this session's own interrupted work is unconditional, so the primary store's
 // in_progress row is taken without consulting any federated store at all.

--- a/release-gates/ga-tzvat3-hook-cross-store-ranking-gate.md
+++ b/release-gates/ga-tzvat3-hook-cross-store-ranking-gate.md
@@ -1,0 +1,64 @@
+# Release gate: cross-store hook ranking
+
+- Bead: `ga-tzvat3`
+- Build bead: `ga-t922vm`
+- Review bead: `ga-u7rfgy`
+- Reviewed commit: `f0f427aa3f08c92af48ac51b710ffb31e386ae77`
+- Base: `origin/main@dca75312bdf571e9be33752d10260ec5c3e30b2b`
+- Merge base: `09bae7ad1706aced67a72775d2b1d11549002cd0`
+- Deploy mode: `remote`
+- Gate result: **PASS**
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Review PASS present | **PASS** | Review bead `ga-u7rfgy` is closed with `verdict: pass` at the exact reviewed commit. The SHA resolves to a commit in this repository. No review carryover was used. |
+| 2 | Acceptance criteria met | **PASS** | The diff implements cross-directory comparison that treats assigned and routed tiers as tie-equivalent while retaining raw tier ranking within one store directory. `TestBestStoreWithWorkTreatsAssignedTierAsRoutedAcrossStores`, `TestBestStoreWithWorkRanksTierAheadOfPriority`, `TestBestStoreWithWorkShortCircuitsOwnInProgress`, and the existing tie-rotation tests all passed twice in the full suite. The repaired fleet checker (`packs/actual/all/scripts/hook-coverage.sh --check`, gc-management `42ecf64bc3da08b57d3dac9c71a9b7d59064c1d0`) reports `pack-author: 2 bead(s) exist, all 2 reachable`; its exit 2 is solely the unrelated `deep-investigator`/`ga-rv0rh9` condition, which exact `origin/main` reproduces and the candidate's direct hook call returns. `failure_attribution: hook-coverage deep-investigator/ga-rv0rh9 -> ga-f6brbc; proof: clause 3(d), exact BASE_REF reproduction; no path overlap or added test load.` |
+| 3 | Tests pass | **PASS** | Required full-scope command: `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true EXTRA_TEST_ENV='DOCKER_HOST=unix:///run/user/1000/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true' GOFLAGS=-v LOCAL_TEST_JOBS=4 CMD_GC_PROCESS_TOTAL=6 GO_TEST_TIMEOUT=30m LOCAL_TEST_LOG_DIR=/var/tmp/ga-tzvat3-full.5d6Qqa make test-local-full-parallel`. `test_cmd_scope: full-suite`. Raw counts: **46,977 PASS, 8 FAIL, 201 SKIP**. All eight raw failures are attributed below; no waiver was used. All six `cmd-gc-process` jobs passed, satisfying the required `cmd_gc_process` coverage for `cmd/gc/**`. `ci_lane_run: n/a (no CI-config change)`. |
+| 3a | Pre-existing failures attributed | **PASS** | See the failure-attribution table below. Every failure is not diff-owned, has a pre-run open tracker for its root condition, has causal proof independent of this diff, and has no changed-path overlap. The candidate adds no test target or declared load. |
+| 3b | Policy/lint lane | **PASS** | `policy_lane: make test-ci-policy — PASS` (runner policy, CI suite coverage, `scripts/cipolicy`, PR watchdog, and static-scope policy). Also PASS: `go build ./...`, `go vet ./...`, `make fmt-check-changed LINT_CHANGED_SCOPE=tracked LINT_CHANGED_REF=09bae7ad1706aced67a72775d2b1d11549002cd0`, `make lint-changed` with the same scope/ref, `make lint-new LINT_BASE=09bae7ad1706aced67a72775d2b1d11549002cd0`, and `git diff --check`. `core.hooksPath=.githooks`. |
+| 4 | No high-severity review findings open | **PASS** | Review records `style_findings: none`, `security_findings: none`, no blockers/majors/minors, and `uncovered_criteria: none`; unresolved HIGH count is 0. |
+| 5 | Final branch is clean | **PASS** | Before adding this gate artifact, `git status --short` produced no output at the exact reviewed commit. The gate file is the only deployer-authored change and is committed separately on the isolated deploy branch. |
+| 6 | Branch diverges cleanly from main | **PASS** | Checked first and rechecked after the full suite. `git merge-tree --write-tree origin/main f0f427aa3f08c92af48ac51b710ffb31e386ae77` exited 0 and produced tree `367e2db6a8da6c2bcef1f5333384e925474467b8`. No self-rebase was needed. |
+| 7 | Single feature theme | **PASS** | Two TDD commits touch only `cmd/gc` cross-store hook candidate ranking and its tests: 3 files, 157 insertions, 31 deletions. The same-directory invariant, cross-directory comparison, and fallback/claim tests are one coherent hook-selection subsystem. |
+
+## Full-suite failure attribution
+
+| Failing test | Raw occurrences | Tracker | Proof and path-overlap check |
+|---|---:|---|---|
+| `TestCatalogMatchesProductionWiringAndDocumentation` | 2 | `ga-cojd80` | The reviewed ancestry carries expired provider-waiver dates. The feature commits do not touch `internal/testutil/providerledger`, its catalog, provider constructors, or waiver dates. Current main passes after a later date refresh; attribution is by the explicit date-expiry mechanism, not a claimed base reproduction. No path overlap. |
+| `TestBdFlagManifestCurrent` | 1 | `ga-f0uceo` | The installed `bd` executable exposes flags absent from the inherited source manifest. This diff cannot change the installed executable and does not touch `internal/bdflags`. No path overlap. |
+| `TestGetKeyBinding_CapturesDefaultBinding`; `TestGetKeyBinding_CapturesDefaultBindingWithArgs` | 2 | `ga-k3fxvj` | Both return the tracker’s known empty ambient tmux default binding. The diff does not touch `internal/runtime/tmux` or host tmux configuration. No path overlap. |
+| `TestRetryManagedPooledWorkerRecoversClaimedAttemptAfterCrash`; `TestGraphWorkflowSuccessPath` | 2 | `ga-esyijp` | Both fixtures fail during `gc init` on the tracked beads#4566 dirty-schema migration refusal, before either test scenario executes. The diff does not touch Beads schema/bootstrap behavior and adds no test target. No path overlap. |
+| `TestE2E_SuspendResume_City` | 1 | `ga-dc9utn` | Exact proven ~94-second missing `citysus.report` signature from the reconciler suspend/wake bug. The diff does not touch that reconciler path. No path overlap. |
+
+`skip_justification: 201 non-diff-owned tests intentionally skipped behind explicit opt-in, platform, runtime, fixture, or live-infrastructure guards; the rootless Podman socket was configured before the run, so no container-backed coverage was silently lost. None of the 23 diff-owned tests skipped.`
+
+## Diff-owned tests
+
+`diff_tests_executed: 23 tests, each observed twice as PASS; 46 PASS observations, 0 FAIL, 0 SKIP.`
+
+- `TestClaimHookWorkAssignedTierUnresolvableBeadDoesNotStrandLaterStore` — PASS x2
+- `TestClaimHookWorkAssignedTierUnresolvableBeadDrainsClaimsErrored` — PASS x2
+- `TestClaimHookWorkAssignedTierOperationalErrorStaysTerminal` — PASS x2
+- `TestRigScopedHookRig` — PASS x2
+- `TestAppendOneRigHookStoreSkipsUnknownInput` — PASS x2
+- `TestBestStoreWithWorkReturnsTheOnlyStoreThatHasWork` — PASS x2
+- `TestBestStoreWithWorkPrefersHigherPriorityInALaterStore` — PASS x2
+- `TestBestStoreWithWorkDoesNotInvertTheBug` — PASS x2
+- `TestBestStoreWithWorkRotatesExactTies` — PASS x2
+- `TestBestStoreWithWorkRepeatedTiesVisitEveryStoreOverTime` — PASS x2
+- `TestHookTieBreakIndex` — PASS x2
+- `TestBestStoreWithWorkRanksTierAheadOfPriority` — PASS x2
+- `TestBestStoreWithWorkTreatsAssignedTierAsRoutedAcrossStores` — PASS x2
+- `TestBestStoreWithWorkShortCircuitsOwnInProgress` — PASS x2
+- `TestBestStoreWithWorkDegradesToFirstHitOnUnrankableOutput` — PASS x2
+- `TestBestHookCandidateRank` — PASS x2
+- `TestBestStoreWithWorkReturnsLastWhenNoneHasWork` — PASS x2
+- `TestBestStoreWithWorkSurfacesOwnStoreErrorWhenNoWork` — PASS x2
+- `TestBestStoreWithWorkIgnoresRigStoreErrorWhenOwnStoreHasNoWork` — PASS x2
+- `TestBestStoreWithWorkSkipsStoreWithOnlyUnreadyRows` — PASS x2
+- `TestClaimStoreWithFallbackFallsBackWhenSelectedStoreRerunsEmpty` — PASS x2
+- `TestClaimStoreWithFallbackUsesSelectedStoreWhenStillReady` — PASS x2
+- `TestBestStoreWithWorkDoesNotRotateOnACoResidentDuplicateID` — PASS x2
+
+`waiver_ref: none`


### PR DESCRIPTION
## What this changes

`gc hook` now compares assigned and routed candidates at the same tier when they come from different store directories. A lower-priority assigned city bead can no longer permanently hide higher-priority routed rig work before the existing cross-store tie rotation gets a chance to run.

Within one store directory, the existing raw tier ordering remains intact. A session's own in-progress work also keeps its unconditional resume path.

## Review notes

- The change is confined to cross-store hook candidate ranking in `cmd/gc`; it does not change work-query parsing, claim semantics, configuration, APIs, or storage schemas.
- The implementation first selects the raw winner within each store directory, then applies the normalized cross-store rank. This preserves same-directory federation behavior while fixing starvation across distinct stores.
- Exact-rank ties continue through the existing rotation mechanism; no new scheduler or persistence mechanism is introduced.

## Test plan

- [x] Run the documented 40-job local CI-equivalent suite, including all six `cmd/gc` process shards.
- [x] Resolve every changed hook-ranking test by name: 23 tests, each observed twice as PASS, with no changed test skipped or failed.
- [x] Run the repaired fleet hook-coverage checker and verify the formerly starved `pack-author` work is reachable across repeated draws.
- [x] Run policy, build, vet, formatting, and changed/new lint lanes.
- [x] Release gate: [`release-gates/ga-tzvat3-hook-cross-store-ranking-gate.md`](release-gates/ga-tzvat3-hook-cross-store-ranking-gate.md)
