### PR TITLE
fix(dolt): name read_timeout when compact's full GC is cancelled

### DIFF
--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -101,6 +101,33 @@ reclaiming. Unlike the full `dolt gc --archive-level=1` procedure above,
 the city — though quiescing writers still makes the GC faster and more
 thorough.
 
+### A full GC that fails with `context canceled`
+
+Running against the live managed server has one ceiling of its own. The
+listener's `read_timeout_millis` bounds any statement that produces no rows for
+that long, and `CALL DOLT_GC('--full')` produces none until it finishes, so a
+reclaim that outruns the ceiling is killed by the server and reported as:
+
+```
+compact: db=<database> ... DOLT_GC failed rc=1 duration=21s
+compact: db=<database> error on line 1 for query CALL DOLT_GC('--full'): Error 1105 (HY000): Error in SaveHashes call: SaveHashes, error calling getManyCompressed: context canceled
+compact: db=<database> the managed sql-server ended DOLT_GC at its listener.read_timeout_millis=15000 in <runtime>/packs/dolt/dolt-config.yaml ceiling — ...
+```
+
+`connection was closed` is the other spelling of the same kill. Nothing is
+wrong with the store, and the pending-GC marker will retry into the same
+ceiling on every later run until it moves. Raise the value in `city.toml`:
+
+```toml
+[dolt]
+read_timeout_millis = 120000
+```
+
+then `gc dolt restart` and retry. The tell that you are looking at this and
+not a real disconnect is the server log: the `client connection went away`
+line that precedes the failure carries `i/o timeout`, not `EOF`, and lands
+exactly `read_timeout_millis` after the connection opened.
+
 ## Compacting a city whose Dolt remote is uncredentialed
 
 Before flattening (and again before pushing) the compactor runs

--- a/docs/troubleshooting/dolt-bloat-recovery.md
+++ b/docs/troubleshooting/dolt-bloat-recovery.md
@@ -116,7 +116,11 @@ compact: db=<database> the managed sql-server ended DOLT_GC at its listener.read
 
 `connection was closed` is the other spelling of the same kill. Nothing is
 wrong with the store, and the pending-GC marker will retry into the same
-ceiling on every later run until it moves. Raise the value in `city.toml`:
+ceiling on every later run until it moves. Raise the value in `city.toml`
+past the longest GC you have seen; the failed run's `duration=` is the floor.
+Releases through v1.4.1 ship `15000`, the value in the example above, and
+current builds default to `120000`, so `120000` is the right first value for a
+city still on `15000`. A city already at `120000` needs a larger number.
 
 ```toml
 [dolt]

--- a/examples/bd/dolt/commands/compact/help.md
+++ b/examples/bd/dolt/commands/compact/help.md
@@ -45,6 +45,17 @@ gc dolt compact --gc-only --only-db hq
 gc dolt compact --gc-only --dry-run
 ```
 
+## The full GC and the listener read timeout
+
+`CALL DOLT_GC('--full')` runs as one statement over the managed sql-server, and
+the listener's `read_timeout_millis` caps any statement that produces no rows
+for that long. The GC produces none until it finishes, so a reclaim that needs
+longer than the ceiling fails with `context canceled` or `connection was
+closed` however healthy the store is, and the pending-GC marker retries it into
+the same ceiling on every later run. The compactor names the setting and the
+live value when this happens. Raise it in `city.toml` under `[dolt]
+read_timeout_millis` and run `gc dolt restart` before retrying.
+
 See `docs/troubleshooting/dolt-bloat-recovery.md` for the full bloat-recovery
 runbook, including quarantine marker evidence, the safe marker-clear procedure,
 and when to stop writers and take a safety backup first.

--- a/examples/bd/dolt/commands/compact/run.sh
+++ b/examples/bd/dolt/commands/compact/run.sh
@@ -2059,6 +2059,37 @@ clear_compact_marker() {
   rm -f "$(compact_marker_path "$dir" "$db")"
 }
 
+# explain_full_gc_cancellation DB ERR_FILE
+#   One extra stderr line after a failed CALL DOLT_GC('--full') whose error is
+#   the managed listener's own read deadline. `connection was closed`, `row
+#   read wait bigger than connection timeout` and `context canceled` are how
+#   the managed sql-server reports killing a statement that outran
+#   listener.read_timeout_millis (mol-dog-backup.sh classifies the same family
+#   for `dolt backup sync`). DOLT_GC produces no rows until it finishes, so the
+#   timeout caps the whole reclaim, and nothing in the retry path can outwait it.
+explain_full_gc_cancellation() {
+  db="$1"
+  err_file="$2"
+  [ -s "$err_file" ] || return 0
+  gc_stderr=$(tr '\n' ' ' <"$err_file")
+  case "$gc_stderr" in
+    *"connection was closed"*|*"row read wait bigger than connection timeout"*|*"context canceled"*) ;;
+    *) return 0 ;;
+  esac
+  managed_config="${DOLT_STATE_DIR:-}/dolt-config.yaml"
+  ceiling=""
+  if [ -n "${DOLT_STATE_DIR:-}" ] && [ -r "$managed_config" ]; then
+    ceiling=$(sed -n 's/^[[:space:]]*read_timeout_millis:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$managed_config" | sed -n '1p')
+  fi
+  if [ -n "$ceiling" ]; then
+    ceiling_text="listener.read_timeout_millis=$ceiling in $managed_config"
+  else
+    ceiling_text="listener.read_timeout_millis in the managed server config"
+  fi
+  printf 'compact: db=%s the managed sql-server ended DOLT_GC at its %s ceiling — DOLT_GC produces no rows until it finishes, so that timeout caps the whole reclaim and the pending-GC retry fails the same way every run; raise it via city.toml [dolt] read_timeout_millis, then gc dolt restart\n' \
+    "$db" "$ceiling_text" >&2
+}
+
 run_full_gc() {
   db="$1"
   failure_prefix="$2"
@@ -2075,6 +2106,7 @@ run_full_gc() {
     printf 'compact: db=%s %s DOLT_GC failed rc=%s duration=%ss\n' \
       "$db" "$failure_prefix" "$gc_rc" "$elapsed" >&2
     emit_error_file "$db" "$gc_err_tmp"
+    explain_full_gc_cancellation "$db" "$gc_err_tmp"
     rm -f "$gc_err_tmp"
     return 1
   fi

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -3766,7 +3766,7 @@ func TestCompactScriptSurfacesGCFailureStderr(t *testing.T) {
 // was closed"), which reads like a network fault. The compactor must name the
 // setting, the live value from the rendered config, and the city.toml
 // override, and must still leave the pending-GC marker behind.
-func TestCompactScriptNamesReadTimeoutWhenFullGCIsCancelled(t *testing.T) {
+func TestCompactScriptNamesReadTimeoutWhenFullGCIsCanceled(t *testing.T) {
 	fixture := newCompactScriptFixture(t)
 	stateDir := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt")
 	managedConfig := filepath.Join(stateDir, "dolt-config.yaml")
@@ -3792,7 +3792,7 @@ func TestCompactScriptNamesReadTimeoutWhenFullGCIsCancelled(t *testing.T) {
 	}
 	marker := filepath.Join(stateDir, "compact-pending-gc", "beads")
 	if _, err := os.Stat(marker); err != nil {
-		t.Fatalf("cancelled GC should still write the pending-GC marker: %v", err)
+		t.Fatalf("canceled GC should still write the pending-GC marker: %v", err)
 	}
 }
 

--- a/examples/bd/dolt/dog_exec_scripts_test.go
+++ b/examples/bd/dolt/dog_exec_scripts_test.go
@@ -1283,6 +1283,10 @@ case "$query" in
       printf 'gc exploded\n' >&2
       exit 45
     fi
+    if [ "$mode" = "gc_read_timeout" ]; then
+      printf "error on line 1 for query CALL DOLT_GC('--full'): Error 1105 (HY000): Error in SaveHashes call: SaveHashes, error calling getManyCompressed: context canceled\n" >&2
+      exit 1
+    fi
     rm -rf -- "${GC_DOLT_DATA_DIR:-}/$db/.dolt/noms/oldgen"
     exit 0
     ;;
@@ -3753,6 +3757,71 @@ func TestCompactScriptSurfacesGCFailureStderr(t *testing.T) {
 	marker := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt", "compact-pending-gc", "beads")
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("GC failure should write pending-GC marker: %v", err)
+	}
+}
+
+// The managed listener's read_timeout_millis is a wall-clock cap on any
+// statement that produces no rows, and DOLT_GC produces none until it
+// finishes. The server reports the kill as "context canceled" (or "connection
+// was closed"), which reads like a network fault. The compactor must name the
+// setting, the live value from the rendered config, and the city.toml
+// override, and must still leave the pending-GC marker behind.
+func TestCompactScriptNamesReadTimeoutWhenFullGCIsCancelled(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	stateDir := filepath.Join(fixture.cityPath, ".gc", "runtime", "packs", "dolt")
+	managedConfig := filepath.Join(stateDir, "dolt-config.yaml")
+	if err := os.WriteFile(managedConfig, []byte("listener:\n  port: 3307\n  read_timeout_millis: 15000\n  write_timeout_millis: 300000\n"), 0o644); err != nil {
+		t.Fatalf("write managed dolt config: %v", err)
+	}
+
+	out, err := fixture.run(t, "gc_read_timeout", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite DOLT_GC cancellation:\n%s", out)
+	}
+	if !strings.Contains(out, "context canceled") {
+		t.Fatalf("output missing the server's own error text:\n%s", out)
+	}
+	for _, want := range []string{
+		"the managed sql-server ended DOLT_GC at its listener.read_timeout_millis=15000 in " + managedConfig + " ceiling",
+		"city.toml [dolt] read_timeout_millis",
+		"gc dolt restart",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	marker := filepath.Join(stateDir, "compact-pending-gc", "beads")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("cancelled GC should still write the pending-GC marker: %v", err)
+	}
+}
+
+// Without a readable rendered config the diagnostic still names the setting;
+// it just cannot quote the value.
+func TestCompactScriptNamesReadTimeoutWithoutRenderedConfig(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "gc_read_timeout", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite DOLT_GC cancellation:\n%s", out)
+	}
+	if !strings.Contains(out, "ended DOLT_GC at its listener.read_timeout_millis in the managed server config ceiling") {
+		t.Fatalf("output should name the setting without a value:\n%s", out)
+	}
+	if strings.Contains(out, "read_timeout_millis=") {
+		t.Fatalf("no rendered config, so no value should be quoted:\n%s", out)
+	}
+}
+
+// An ordinary GC failure carries none of the read-deadline signatures and must
+// not be blamed on the listener timeout.
+func TestCompactScriptDoesNotBlameReadTimeoutForOtherGCFailures(t *testing.T) {
+	fixture := newCompactScriptFixture(t)
+	out, err := fixture.run(t, "gc_failure", "GC_DOLT_COMPACT_THRESHOLD_COMMITS=500")
+	if err == nil {
+		t.Fatalf("compact succeeded despite DOLT_GC failure:\n%s", out)
+	}
+	if strings.Contains(out, "read_timeout_millis") {
+		t.Fatalf("plain GC failure must not mention the read timeout:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

The managed listener's `read_timeout_millis` caps any statement that produces no rows for that long. `gc dolt compact` runs `CALL DOLT_GC('--full')` as one such statement: the GC produces nothing until it finishes, so a reclaim that outruns the ceiling is killed by the server and reported as `Error in SaveHashes call ... context canceled` (or `connection was closed`), which reads like a network fault. The pending-GC marker then retries into the same ceiling on every run, and the reclaim stays lost until an operator decodes the error. On one city, 184 compacts had succeeded with GCs under 15s and the eight failures all needed 21–51s against the v1.4.1 default of 15000; decoding that took a server-log investigation.

This mirrors what [#5329](https://github.com/gastownhall/gascity/pull/5329) did for `dolt backup sync`. `run_full_gc` now classifies the failure, names `listener.read_timeout_millis`, quotes the live value from the rendered `dolt-config.yaml` when it is readable, and points at the `city.toml [dolt] read_timeout_millis` override plus `gc dolt restart`. The compact help and the bloat-recovery runbook gain a section on the ceiling and its server-log tell.

The risk sits in the signature list. `context canceled` is broader than the two strings the backup classifier matches, but a client killed by `run_bounded` exits 124 with no server error text, so the diagnostic fires only on an error the server itself sent to a live client. The pending-GC marker and the exit code are unchanged. Related: [#5383](https://github.com/gastownhall/gascity/issues/5383), [#5524](https://github.com/gastownhall/gascity/issues/5524), and [#5414](https://github.com/gastownhall/gascity/pull/5414), which raised the default to 120000 on `main` while v1.4.1 still ships 15000.

<details>
<summary>Test plan and supporting detail</summary>

### Test plan

- `go test ./examples/bd/dolt/ -run 'TestCompactScriptNamesReadTimeout|TestCompactScriptDoesNotBlameReadTimeout|TestCompactScriptSurfacesGCFailureStderr|TestCompactScriptRetriesFullGCForBelowThresholdPendingMarker' -count=1`: five pass. The new fake-dolt mode `gc_read_timeout` returns the exact server error text seen in the field.
- Mutation: with the `explain_full_gc_cancellation` call removed, both positive tests fail and the negative test still passes.
- Full package: `go test ./examples/bd/dolt/ -count=1`: passes (61s).
- `sh -n` and `shellcheck -S warning` on `run.sh`: the three warnings reported are all present on `main` (lines 544, 1103 and 2376 of the base file; 2408 for the third on this branch).

### Field evidence

On a v1.4.1 city with the 15000 default, `select sleep(20)` over the same `dolt sql` client path failed at 15.2s with `row read wait bigger than connection timeout`. After `[dolt] read_timeout_millis = 120000` and `gc dolt restart` it returned in 20.2s, and `gc dolt compact --gc-only` reclaimed the store in 8s (noms 771 MB to 637 MB). The server log at the original failure showed `client connection went away while a query was executing ... i/o timeout` exactly 15s after the GC connection opened, then `error running query ... context canceled`.

</details>

---
> Generated by the operator's software factory.
> • City: `city` · Agent: `local-core.builder-1`
> • On behalf of: @austinborn

