### PR TITLE
fix(wisp): autoclose probes the input-convoy tracks edge across BOTH class stores (split-city spawn churn)

### DIFF
--- a/cmd/gc/wisp_autoclose.go
+++ b/cmd/gc/wisp_autoclose.go
@@ -98,7 +98,7 @@ func doWispAutocloseWith(store beads.Store, beadID string, stdout io.Writer, gra
 	for _, attached := range attachments {
 		seen[attached.ID] = true
 	}
-	attachments = append(attachments, collectInputConvoyWorkflowRoots(graphStore, parent, seen)...)
+	attachments = append(attachments, collectInputConvoyWorkflowRoots(store, graphStore, parent, seen)...)
 	if err == nil || len(attachments) > 0 {
 		for _, attached := range attachments {
 			if attachedMoleculeIsParked(graphStore, attached) {
@@ -166,14 +166,39 @@ func attachedMoleculeIsParked(store beads.Store, attached beads.Bead) bool {
 // attachedMoleculeIsParked guard, so an orchestrated workflow whose step beads
 // are still in flight stays open and closes later via its workflow-finalize
 // control instead.
-func collectInputConvoyWorkflowRoots(store beads.Store, parent beads.Bead, seen map[string]bool) []beads.Bead {
-	convoys, err := convoycore.TrackingConvoysForItem(store, parent.ID)
+func collectInputConvoyWorkflowRoots(workStore, graphStore beads.Store, parent beads.Bead, seen map[string]bool) []beads.Bead {
+	// The tracks edge is co-resident with the tracking convoy, and the two
+	// owning candidates differ on a split city: every convoy is WORK class
+	// (coordclass), minted co-resident with the issue it tracks, so a
+	// post-split launch leaves the convoy + edge in the work store — while a
+	// store migrated from the single-store era can hold them on the graph
+	// side. TrackingConvoysForItem is single-store by contract, so probe both.
+	// On a single-store city graphStore == workStore and this collapses to
+	// the pre-split single read.
+	convoys, err := convoycore.TrackingConvoysForItem(workStore, parent.ID)
 	if err != nil {
 		return nil
 	}
+	if graphStore != workStore {
+		graphConvoys, gerr := convoycore.TrackingConvoysForItem(graphStore, parent.ID)
+		if gerr != nil {
+			// Fail closed, matching the workStore posture above: a partial view
+			// must not decide "no wisp to reap" and leak an open root. This is
+			// also the refused-binding arm — a city whose split this build must
+			// not serve delivers the refusal AS the graph store
+			// (cli_storage_routes.go), so every probe errors here. The refusal
+			// itself was printed once when the verdict was taken; narrowing this
+			// read to the work leg would be the looks-like-success answer that
+			// file exists to close.
+			return nil
+		}
+		convoys = dedupeConvoysByID(convoys, graphConvoys)
+	}
 	var roots []beads.Bead
 	for _, convoy := range convoys {
-		matches, err := store.ListByMetadata(
+		// Roots are graph-class, so the root lookup stays on the graph store
+		// regardless of which store owned the tracking convoy.
+		matches, err := graphStore.ListByMetadata(
 			map[string]string{beadmeta.InputConvoyIDMetadataKey: convoy.ID},
 			0, beads.WithBothTiers,
 		)
@@ -200,6 +225,25 @@ func collectInputConvoyWorkflowRoots(store beads.Store, parent beads.Bead, seen 
 		}
 	}
 	return roots
+}
+
+// dedupeConvoysByID merges tracking-convoy lists from the work and graph
+// stores, keeping the first occurrence of each convoy id. A convoy lives in
+// exactly one store, so overlap only happens when the two probes read the same
+// handle — the dedupe keeps the union honest there too.
+func dedupeConvoysByID(lists ...[]beads.Bead) []beads.Bead {
+	seen := make(map[string]bool)
+	var out []beads.Bead
+	for _, list := range lists {
+		for _, c := range list {
+			if seen[c.ID] {
+				continue
+			}
+			seen[c.ID] = true
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func closeAttachedWispSubtree(store beads.Store, attached beads.Bead) (int, error) {

--- a/cmd/gc/wisp_autoclose_test.go
+++ b/cmd/gc/wisp_autoclose_test.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beadmeta"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/splittest"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/coordclass"
 )
 
 func TestWispAutocloseClosesOpenMolecule(t *testing.T) {
@@ -604,6 +607,188 @@ func TestWispAutocloseClosesRootOnlyWispViaInputConvoy(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Auto-closed workflow "+root.ID+" on "+issue.ID) {
 		t.Fatalf("stdout = %q, want workflow auto-close message", stdout.String())
+	}
+}
+
+// TestWispAutocloseClosesRootOnlyWispViaInputConvoyAcrossStores runs the
+// root-only reap over both store topologies through the splitEnv fixture. On a
+// split city the two halves of the input-convoy link live in DIFFERENT stores:
+// the synthetic input convoy is WORK class (coordclass classifies EVERY convoy
+// as work, and convoy.TrackItemIn keeps it co-resident with the issue it
+// tracks), so the convoy + its tracks edge land in the work store — while the
+// graph.v2 workflow root it launched is graph class and lives in the relocated
+// binding. A reap that probes only the graph store for the tracking convoy
+// finds no tracks edge, silently no-ops, and the open root outlives its closed
+// issue — re-routing to the pool and churning a fresh worker (the review-pool
+// spawn-churn finalize-gap, reopened for every split city).
+func TestWispAutocloseClosesRootOnlyWispViaInputConvoyAcrossStores(t *testing.T) {
+	forEachTopology(t, func(t *testing.T, e splitEnv) {
+		issue, err := e.work.Create(beads.Bead{Title: "work issue", Type: "task"})
+		if err != nil {
+			t.Fatalf("create work issue: %v", err)
+		}
+		convoy, err := e.work.Create(beads.Bead{
+			Title:    "synthetic input convoy",
+			Type:     "convoy",
+			Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"},
+		})
+		if err != nil {
+			t.Fatalf("create synthetic input convoy in the work store: %v", err)
+		}
+		if err := e.work.DepAdd(convoy.ID, issue.ID, "tracks"); err != nil {
+			t.Fatalf("DepAdd(tracks) in the work store: %v", err)
+		}
+		root, err := e.graphStore().Create(beads.Bead{
+			Title: "mol-focus-review",
+			Type:  "task",
+			Metadata: map[string]string{
+				beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+				beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+				beadmeta.InputConvoyIDMetadataKey:   convoy.ID,
+				beadmeta.RoutedToMetadataKey:        "review-pool/worker",
+			},
+		})
+		if err != nil {
+			t.Fatalf("create root-only workflow root through the graph front door: %v", err)
+		}
+		if !coordclass.Classify(root).IsInfrastructure() {
+			t.Fatalf("root %s classifies as work, want infrastructure; the cross-store premise is not staged", root.ID)
+		}
+
+		if err := e.work.Close(issue.ID); err != nil {
+			t.Fatalf("close issue: %v", err)
+		}
+
+		var stdout bytes.Buffer
+		doWispAutocloseWith(e.work, issue.ID, &stdout, beads.GraphStore{Store: e.graphStore()})
+
+		rootAfter, err := e.graphStore().Get(root.ID)
+		if err != nil {
+			t.Fatalf("Get(root): %v", err)
+		}
+		if rootAfter.Status != "closed" {
+			t.Fatalf("root-only wisp status = %q, want closed (reaped via the work-store input convoy)", rootAfter.Status)
+		}
+		if !strings.Contains(stdout.String(), "Auto-closed workflow "+root.ID+" on "+issue.ID) {
+			t.Fatalf("stdout = %q, want workflow auto-close message", stdout.String())
+		}
+	})
+}
+
+// TestWispAutocloseClosesRootOnlyWispViaGraphResidentInputConvoy guards against
+// a "swap" fix instead of a union: a store migrated from the single-store era
+// can hold the tracking convoy + its tracks edge on the GRAPH side (migrated
+// beads keep their pre-split residence, and SQLite records the dangling edge
+// rather than refusing it), while the issue stays in the work store. The reap
+// must still find that convoy through the graph leg after it learns to probe
+// the work leg.
+func TestWispAutocloseClosesRootOnlyWispViaGraphResidentInputConvoy(t *testing.T) {
+	forEachTopology(t, func(t *testing.T, e splitEnv) {
+		issue, err := e.work.Create(beads.Bead{Title: "work issue", Type: "task"})
+		if err != nil {
+			t.Fatalf("create work issue: %v", err)
+		}
+		convoy, err := e.graphStore().Create(beads.Bead{
+			Title:    "migrated input convoy",
+			Type:     "convoy",
+			Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"},
+		})
+		if err != nil {
+			t.Fatalf("create migrated convoy through the graph front door: %v", err)
+		}
+		if err := e.graphStore().DepAdd(convoy.ID, issue.ID, "tracks"); err != nil {
+			t.Fatalf("DepAdd(tracks) in the graph store: %v", err)
+		}
+		if e.split {
+			// Claiming the recorded violation is the assertion: the class store
+			// ACCEPTED the cross-store tracks edge, which is what SQLite does with
+			// migrated-era data — this row is the production corruption the union
+			// probe must still reap through.
+			violations := splittest.TakeResidenceViolations(e.class)
+			if len(violations) != 1 || violations[0].Op != "dep-add" {
+				t.Fatalf("class store recorded violations %v, want exactly the one accepted cross-store tracks edge", violations)
+			}
+		}
+		root, err := e.graphStore().Create(beads.Bead{
+			Title: "mol-focus-review",
+			Type:  "task",
+			Metadata: map[string]string{
+				beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+				beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+				beadmeta.InputConvoyIDMetadataKey:   convoy.ID,
+				beadmeta.RoutedToMetadataKey:        "review-pool/worker",
+			},
+		})
+		if err != nil {
+			t.Fatalf("create root-only workflow root through the graph front door: %v", err)
+		}
+
+		if err := e.work.Close(issue.ID); err != nil {
+			t.Fatalf("close issue: %v", err)
+		}
+
+		var stdout bytes.Buffer
+		doWispAutocloseWith(e.work, issue.ID, &stdout, beads.GraphStore{Store: e.graphStore()})
+
+		rootAfter, err := e.graphStore().Get(root.ID)
+		if err != nil {
+			t.Fatalf("Get(root): %v", err)
+		}
+		if rootAfter.Status != "closed" {
+			t.Fatalf("migrated-convoy root-only wisp status = %q, want closed (reaped via the graph-store input convoy)", rootAfter.Status)
+		}
+	})
+}
+
+// TestWispAutocloseFailsClosedOnRefusedGraphBinding pins the refusal posture of
+// the union probe. A city whose [storage] split this build must not serve gets
+// its graph class delivered AS a store that refuses every operation
+// (refusedClassStore, cli_storage_routes.go); the refusal itself is printed
+// once to stderr when the verdict is taken, so the probe's whole job here is to
+// fail CLOSED — reap nothing — rather than silently narrow to the work store.
+// The decoy is the discriminator: a work-resident bead carrying the root shape
+// (gc.kind=workflow, graph.v2, gc.input_convoy_id) that a narrowed implementation
+// — one that falls back to the work store when the graph leg refuses — would
+// find via the work-found convoy and force-close. It must stay open, and no
+// looks-like-success auto-close line may be written.
+func TestWispAutocloseFailsClosedOnRefusedGraphBinding(t *testing.T) {
+	store := beads.NewMemStore()
+	issue, _ := store.Create(beads.Bead{Title: "work issue", Type: "task"}) // gc-1
+	convoy, _ := store.Create(beads.Bead{
+		Title:    "synthetic input convoy",
+		Type:     "convoy",
+		Metadata: map[string]string{beadmeta.SyntheticMetadataKey: "true"},
+	}) // gc-2
+	if err := store.DepAdd(convoy.ID, issue.ID, "tracks"); err != nil {
+		t.Fatalf("DepAdd(tracks): %v", err)
+	}
+	decoy, _ := store.Create(beads.Bead{
+		Title: "work-resident decoy root",
+		Type:  "task",
+		Metadata: map[string]string{
+			beadmeta.KindMetadataKey:            beadmeta.KindWorkflow,
+			beadmeta.FormulaContractMetadataKey: beadmeta.FormulaContractGraphV2,
+			beadmeta.InputConvoyIDMetadataKey:   convoy.ID,
+		},
+	}) // gc-3
+	_ = store.Close(issue.ID)
+
+	refused := refusedClassStore{err: standingStorageRefusal{
+		err: errors.New("storage: this city's [storage] binding has not converged; run `gc storage migrate`"),
+	}}
+
+	var stdout bytes.Buffer
+	doWispAutocloseWith(store, issue.ID, &stdout, beads.GraphStore{Store: refused})
+
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want no auto-close output on a refused graph binding; a success line here is the looks-like-success answer the refusal exists to close", stdout.String())
+	}
+	decoyAfter, err := store.Get(decoy.ID)
+	if err != nil {
+		t.Fatalf("Get(decoy): %v", err)
+	}
+	if decoyAfter.Status != "open" {
+		t.Fatalf("work-resident decoy root status = %q, want open; the reap silently narrowed the graph leg to the work store instead of failing closed on the refusal", decoyAfter.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary

On a split city, wisp-autoclose probed the input-convoy `tracks` edge in one store only, so a root-only wisp whose tracking convoy lives in the other class store never matched — the wisp outlived its closed source issue and re-spawned forever (live spawn-churn class).

The probe now unions the owning work store and the relocated graph class store (resolved via the existing class-binding machinery, not a hand-built leg list), keeps the root `ListByMetadata` on the graph store, and **fails loud on a refused binding** (never silently narrows to the work store — the root fail-open pattern this family of bugs shares).

Port of landmine #10 from the cross-store split audit (`feat/domain-infra-store-split` reference impl re-done on main idioms). RED-then-GREEN: cross-store tracks-edge autoclose (fails on main), refused-binding fails loud, single-store city inert. Fable-council reviewed: sound, zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)