### PR TITLE
fix(dolt): keep session identity out of the managed server's environment

### DIFF
--- a/cmd/gc/dolt_scope_watchdog.go
+++ b/cmd/gc/dolt_scope_watchdog.go
@@ -130,6 +130,14 @@ func managedDoltScopeGone(configFile string) bool {
 // observe the same managedDoltStartedProcess shape as a direct spawn plus
 // the supervising WatchdogPID.
 func startManagedDoltSQLServerWithScopeWatchdog(cityPath, configFile, logFilePath string, logFile *os.File) (managedDoltStartedProcess, error) {
+	return startManagedDoltSQLServerWithScopeWatchdogEnv(cityPath, configFile, logFilePath, logFile, os.Environ())
+}
+
+// startManagedDoltSQLServerWithScopeWatchdogEnv is
+// startManagedDoltSQLServerWithScopeWatchdog with the parent environment
+// passed in rather than read from the process, so a test can spawn the real
+// watchdog under a session-stamped environment without mutating its own.
+func startManagedDoltSQLServerWithScopeWatchdogEnv(cityPath, configFile, logFilePath string, logFile *os.File, parentEnv []string) (managedDoltStartedProcess, error) {
 	watchdogExecutable, err := managedDoltWatchdogExecutable()
 	if err != nil {
 		return managedDoltStartedProcess{}, err
@@ -138,7 +146,7 @@ func startManagedDoltSQLServerWithScopeWatchdog(cityPath, configFile, logFilePat
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
 	cmd.SysProcAttr = managedDoltSQLServerSysProcAttr()
-	cmd.Env = doltServerEnv(cityPath, os.Environ())
+	cmd.Env = doltServerEnv(cityPath, parentEnv)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return managedDoltStartedProcess{}, fmt.Errorf("prepare dolt scope watchdog: %w", err)

--- a/cmd/gc/dolt_scope_watchdog_sweep_test.go
+++ b/cmd/gc/dolt_scope_watchdog_sweep_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/runtime/proctable"
+)
+
+// TestSweepProcessTableOrphansLeavesManagedDoltWatchdogAlone runs the real
+// process-table scanner and the real orphan sweep over a procfs shaped like
+// the incident: a scope watchdog reparented to init with its dolt sql-server
+// beneath it, both started from an agent session whose bead has since
+// closed. With the environment doltServerEnv now produces, the sweep sees no
+// root to attribute to that session and reaps nothing. The same tree with the
+// session's environment passed through unchanged is the pre-fix state, and
+// there the sweep reaps the watchdog, which is what took Dolt down about 15
+// seconds after every agent session that had restarted it.
+func TestSweepProcessTableOrphansLeavesManagedDoltWatchdogAlone(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("drives the scanner against a procfs-shaped tree")
+	}
+	cityPath := t.TempDir()
+	sessionEnv := []string{
+		"PATH=/usr/bin",
+		"GC_CITY_PATH=" + cityPath,
+		"GC_SESSION_ID=gc-restarter",
+		"GC_SESSION_NAME=gc__worker-gc-restarter",
+		"GC_AGENT=worker-1",
+		"GC_RUNTIME_EPOCH=1",
+	}
+	store := beads.NewMemStoreFrom(0, []beads.Bead{{ID: "gc-restarter", Status: "closed"}}, nil)
+
+	for _, tc := range []struct {
+		name       string
+		serverEnv  []string
+		wantReaped int
+	}{
+		{name: "scrubbed", serverEnv: doltServerEnv(cityPath, sessionEnv), wantReaped: 0},
+		{name: "inherited", serverEnv: sessionEnv, wantReaped: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFakeProcEntry(t, root, 4100, 1, "gc", tc.serverEnv)
+			writeFakeProcEntry(t, root, 4101, 4100, "dolt", tc.serverEnv)
+			t.Cleanup(proctable.SetScanRootForTesting(root))
+
+			sp := &procfsSweepScanner{Fake: runtime.NewFake()}
+			var stderr bytes.Buffer
+			got := sweepProcessTableOrphans(sp, nil, store, cityPath, &stderr)
+			if got != tc.wantReaped || len(sp.terminated) != tc.wantReaped {
+				t.Fatalf("sweepProcessTableOrphans() = %d reaped, terminated %v, want %d; stderr=%q", got, sp.terminated, tc.wantReaped, stderr.String())
+			}
+			if tc.wantReaped == 1 && sp.terminated[0].PID != 4100 {
+				t.Fatalf("terminated %v, want the watchdog root pid 4100", sp.terminated)
+			}
+		})
+	}
+}
+
+// procfsSweepScanner is the ProcessTableScanner the sweep sees in production,
+// backed by the real proctable scan over the injected root, with termination
+// recorded instead of signaled.
+type procfsSweepScanner struct {
+	*runtime.Fake
+	terminated []runtime.LiveRuntime
+}
+
+func (s *procfsSweepScanner) FindRuntimesBySessionID(id string) ([]runtime.LiveRuntime, error) {
+	return proctable.ScanBySessionID(id)
+}
+
+func (s *procfsSweepScanner) TerminateRuntime(live runtime.LiveRuntime) error { //nolint:unparam // interface compliance; error always nil in the recorder
+	s.terminated = append(s.terminated, live)
+	return nil
+}
+
+// writeFakeProcEntry writes the environ, stat and comm files the Linux scanner
+// reads for one process under a procfs-shaped root.
+func writeFakeProcEntry(t *testing.T, root string, pid, ppid int, comm string, env []string) {
+	t.Helper()
+	dir := filepath.Join(root, strconv.Itoa(pid))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	environ := strings.Join(env, "\x00") + "\x00"
+	if err := os.WriteFile(filepath.Join(dir, "environ"), []byte(environ), 0o644); err != nil {
+		t.Fatalf("write environ: %v", err)
+	}
+	stat := strconv.Itoa(pid) + " (" + comm + ") S " + strconv.Itoa(ppid) + strings.Repeat(" 0", 48)
+	if err := os.WriteFile(filepath.Join(dir, "stat"), []byte(stat), 0o644); err != nil {
+		t.Fatalf("write stat: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "comm"), []byte(comm+"\n"), 0o644); err != nil {
+		t.Fatalf("write comm: %v", err)
+	}
+}

--- a/cmd/gc/dolt_scope_watchdog_test.go
+++ b/cmd/gc/dolt_scope_watchdog_test.go
@@ -344,6 +344,98 @@ func TestManagedDoltScopeWatchdogServerSurvivesScopePresent(t *testing.T) {
 }
 
 // TestRunManagedDoltScopeWatchdogUsage pins the argv contract.
+// TestManagedDoltScopeWatchdogDoesNotInheritSessionIdentity spawns the real
+// watchdog the way `gc dolt restart` does from inside an agent shell, with
+// every session-scoped key stamped on the parent environment, and reads the
+// live environment of both the watchdog and its dolt child. Neither may carry
+// a stamp: the watchdog reparents to init, so a GC_SESSION_ID on it is what
+// the session reconciler's orphan sweep keys on when it reaps the watchdog,
+// and with it the server, once that session's bead closes. PATH is the
+// control that the scrub is targeted rather than a blanket strip.
+func TestManagedDoltScopeWatchdogDoesNotInheritSessionIdentity(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("reads /proc/<pid>/environ")
+	}
+	dir := t.TempDir()
+	fakeDoltDir := writeFakeDoltSQLServer(t)
+	configPath := filepath.Join(dir, "dolt-config.yaml")
+	logPath := filepath.Join(dir, "dolt.log")
+	if err := os.WriteFile(configPath, []byte("log_level: debug\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open log file: %v", err)
+	}
+	defer logFile.Close() //nolint:errcheck
+
+	parentEnv := removeEnvKey(os.Environ(), "PATH")
+	parentEnv = append(parentEnv, "PATH="+fakeDoltDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	for _, key := range managedDoltSessionScopedEnvKeys {
+		parentEnv = append(parentEnv, key+"=stamped")
+	}
+
+	started, err := startManagedDoltSQLServerWithScopeWatchdogEnv("", configPath, logPath, logFile, parentEnv)
+	if err != nil {
+		t.Fatalf("start managed dolt with scope watchdog: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupManagedDoltTestPID(t, started.PID)
+		cleanupManagedDoltTestPID(t, started.WatchdogPID)
+	})
+
+	for _, proc := range []struct {
+		name string
+		pid  int
+	}{
+		{name: "scope watchdog", pid: started.WatchdogPID},
+		{name: "dolt sql-server", pid: started.PID},
+	} {
+		env := waitForProcEnviron(t, proc.pid)
+		for _, key := range managedDoltSessionScopedEnvKeys {
+			if value, ok := env[key]; ok {
+				t.Errorf("%s pid %d inherited %s=%q from the spawning session", proc.name, proc.pid, key, value)
+			}
+		}
+		if !strings.HasPrefix(env["PATH"], fakeDoltDir) {
+			t.Errorf("%s pid %d PATH = %q, want the parent's PATH carried through", proc.name, proc.pid, env["PATH"])
+		}
+	}
+}
+
+// waitForProcEnviron reads /proc/<pid>/environ once the process has settled
+// on its final image. The kernel reports an empty environ for the window
+// inside execve, and the fake dolt execs twice (sh, then sleep), so a read
+// that lands there proves nothing; a settled process always carries a
+// non-empty environ here because the spawn path propagates PATH.
+func waitForProcEnviron(t *testing.T, pid int) map[string]string {
+	t.Helper()
+	path := filepath.Join("/proc", strconv.Itoa(pid), "environ")
+	deadline := time.After(5 * time.Second)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read environ for pid %d: %v", pid, err)
+		}
+		if len(data) > 0 {
+			env := make(map[string]string)
+			for _, entry := range strings.Split(string(data), "\x00") {
+				if key, value, ok := strings.Cut(entry, "="); ok && key != "" {
+					env[key] = value
+				}
+			}
+			return env
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("pid %d environ still empty after 5s", pid)
+		case <-tick.C:
+		}
+	}
+}
+
 func TestRunManagedDoltScopeWatchdogUsage(t *testing.T) {
 	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 	if err != nil {

--- a/cmd/gc/dolt_scope_watchdog_test.go
+++ b/cmd/gc/dolt_scope_watchdog_test.go
@@ -343,7 +343,6 @@ func TestManagedDoltScopeWatchdogServerSurvivesScopePresent(t *testing.T) {
 	}
 }
 
-// TestRunManagedDoltScopeWatchdogUsage pins the argv contract.
 // TestManagedDoltScopeWatchdogDoesNotInheritSessionIdentity spawns the real
 // watchdog the way `gc dolt restart` does from inside an agent shell, with
 // every session-scoped key stamped on the parent environment, and reads the
@@ -436,6 +435,7 @@ func waitForProcEnviron(t *testing.T, pid int) map[string]string {
 	}
 }
 
+// TestRunManagedDoltScopeWatchdogUsage pins the argv contract.
 func TestRunManagedDoltScopeWatchdogUsage(t *testing.T) {
 	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 	if err != nil {

--- a/cmd/gc/dolt_start_managed.go
+++ b/cmd/gc/dolt_start_managed.go
@@ -1257,10 +1257,37 @@ func managedDoltTestParentDone(rawFD string) (<-chan struct{}, func(), error) {
 	return done, func() { _ = parentPipe.Close() }, nil
 }
 
+// managedDoltSessionScopedEnvKeys are the per-session identity variables the
+// session lifecycle injects into an agent runtime
+// (session.RuntimeEnvWithSessionContext), plus the provider's own session id.
+// A managed server started from inside an agent session would otherwise
+// inherit them, and its scope watchdog reparents to init, so the session
+// reconciler's orphan sweep (sweepProcessTableOrphans) would reap the watchdog
+// as that session's process-table root once the session bead closes, taking
+// the server down with it. A managed server is city infrastructure, not part
+// of any session.
+var managedDoltSessionScopedEnvKeys = []string{
+	"GC_SESSION_ID",
+	"GC_SESSION_NAME",
+	"GC_ALIAS",
+	"GC_AGENT",
+	"GC_TEMPLATE",
+	"GC_SESSION_ORIGIN",
+	"GC_RUNTIME_EPOCH",
+	"GC_CONTINUATION_EPOCH",
+	"GC_INSTANCE_TOKEN",
+	"BEADS_HOLDER_TOKEN",
+	"BEADS_ACTOR",
+	"CLAUDE_CODE_SESSION_ID",
+}
+
 // doltServerEnv returns the environment applied to every managed dolt
-// sql-server we launch.
+// sql-server we launch, and to the scope watchdog that supervises it.
 func doltServerEnv(cityPath string, parent []string) []string {
 	env := removeEnvKey(parent, "DOLT_DISABLE_EVENT_FLUSH")
+	for _, key := range managedDoltSessionScopedEnvKeys {
+		env = removeEnvKey(env, key)
+	}
 	if managedDoltDisableEventFlush(cityPath) {
 		// Disable Dolt usage telemetry for managed servers by default. The
 		// `dolt send-metrics` event-flush reporter spawns transient

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -15,6 +16,7 @@ import (
 
 	bdpack "github.com/gastownhall/gascity/examples/bd"
 	"github.com/gastownhall/gascity/internal/processgroup/processgrouptest"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 func TestDoltServerEnv_DoesNotInjectGCSchedulerDefault(t *testing.T) {
@@ -79,6 +81,63 @@ func TestDoltServerEnv_PreservesEmptyUserValue(t *testing.T) {
 	}
 	if !hasTelemetryDisable {
 		t.Fatalf("managed Dolt env should disable telemetry event flush: %v", out)
+	}
+}
+
+// TestDoltServerEnv_ScrubsSessionIdentity pins the fix for a managed Dolt
+// server that died about 15 seconds after the agent session that restarted
+// it exited: the watchdog and server inherited the shell's GC_SESSION_ID, the
+// watchdog reparented to init, and the session reconciler's orphan sweep
+// reaped it as that session's process-table root once the session bead
+// closed. Every session-scoped key must be gone, and keys that are city-scoped
+// or unrelated must survive, so the scrub stays targeted rather than a blanket
+// GC_* strip.
+func TestDoltServerEnv_ScrubsSessionIdentity(t *testing.T) {
+	parent := []string{"PATH=/usr/bin", "GC_CITY_PATH=/srv/city", "HOME=/home/test"}
+	for _, key := range managedDoltSessionScopedEnvKeys {
+		parent = append(parent, key+"=stamped")
+	}
+	out := doltServerEnv("", parent)
+
+	for _, kv := range out {
+		key, value, _ := strings.Cut(kv, "=")
+		if value == "stamped" || containsString(managedDoltSessionScopedEnvKeys, key) {
+			t.Fatalf("managed Dolt env must not carry session identity %s, got %v", key, out)
+		}
+	}
+	for _, want := range []string{"PATH=/usr/bin", "GC_CITY_PATH=/srv/city", "HOME=/home/test"} {
+		if !containsString(out, want) {
+			t.Fatalf("parent entry %q missing from output env %v", want, out)
+		}
+	}
+}
+
+// TestDoltServerEnvScrubCoversSessionRuntimeEnv keeps the scrub list from
+// drifting behind the session lifecycle: a key added to
+// session.RuntimeEnvWithSessionContext reaches every managed server started
+// from an agent shell, so it has to appear in managedDoltSessionScopedEnvKeys
+// too. The Info here populates every optional field so no key is skipped.
+func TestDoltServerEnvScrubCoversSessionRuntimeEnv(t *testing.T) {
+	injected := sessionpkg.RuntimeEnvWithSessionContext(sessionpkg.Info{
+		ID:            "gc-session",
+		SessionName:   "gc__worker-gc-session",
+		Alias:         "worker-1",
+		Template:      "worker",
+		SessionOrigin: "sling",
+	}, 1, 1, "instance-token")
+	if len(injected) == 0 {
+		t.Fatal("session runtime env is empty; the drift guard has nothing to check")
+	}
+
+	var missing []string
+	for key := range injected {
+		if !containsString(managedDoltSessionScopedEnvKeys, key) {
+			missing = append(missing, key)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("session runtime env keys missing from managedDoltSessionScopedEnvKeys: %v", missing)
 	}
 }
 


### PR DESCRIPTION
Fixes #6316.

## What changed

`doltServerEnv` now strips the per-session identity keys before the environment reaches the managed Dolt scope watchdog and the `dolt sql-server` beneath it. The set is what `session.RuntimeEnvWithSessionContext` injects into an agent runtime (`GC_SESSION_ID`, `GC_SESSION_NAME`, `GC_ALIAS`, `GC_AGENT`, `GC_TEMPLATE`, `GC_SESSION_ORIGIN`, `GC_RUNTIME_EPOCH`, `GC_CONTINUATION_EPOCH`, `GC_INSTANCE_TOKEN`, `BEADS_HOLDER_TOKEN`, `BEADS_ACTOR`) plus `CLAUDE_CODE_SESSION_ID`. `startManagedDoltSQLServerWithScopeWatchdog` gains an env-taking inner variant so a test can spawn the real watchdog under a stamped environment without mutating its own.

## Why

A `gc dolt restart` (or any auto-ensure start) from inside an agent session left the watchdog carrying that session's `GC_SESSION_ID`. The watchdog reparents to init, so `sweepProcessTableOrphans` reported it as the session's process-table root and terminated it once the session bead closed; the watchdog's SIGTERM handler then terminated the server. On one city this took Dolt down twice in eleven minutes, each time about 15 seconds after an agent session exited, with the controller's circuit breaker open in between. The timeline and evidence are on the issue. A managed server is city infrastructure, not part of any session, and the supervisor-started watchdog that survived the incident already has this shape.

## Where the risk sits

Only `GC_SESSION_ID` is load-bearing for the reap; the other keys are hygiene, and a drift-guard test fails if the session lifecycle grows a key this list lacks. Nothing in the Dolt start path reads any of the stripped keys, and the test-mode keys (`GC_MANAGED_DOLT_TEST_MODE`, `GC_MANAGED_DOLT_TEST_PARENT_PID`) ride through untouched. The sweep side is deliberately unchanged: `LiveRuntime` carries no argv, and marking the watchdog as infrastructure in the scanner would promote its `dolt sql-server` child to a root through the parent-is-infrastructure rule from #5392. A watchdog stamped before this change stays reapable until its next restart.

<details>
<summary>Test plan, mutation checks and self-audit</summary>

### Tests added

- `TestDoltServerEnv_ScrubsSessionIdentity`: every key in `managedDoltSessionScopedEnvKeys` is gone from the output while `PATH`, `GC_CITY_PATH` and `HOME` survive, so the scrub is targeted rather than a blanket `GC_*` strip.
- `TestDoltServerEnvScrubCoversSessionRuntimeEnv`: every key `session.RuntimeEnvWithSessionContext` produces for a fully populated `Info` is in the scrub list. Dropping `GC_RUNTIME_EPOCH` from the list fails it with `session runtime env keys missing from managedDoltSessionScopedEnvKeys: [GC_RUNTIME_EPOCH]`.
- `TestManagedDoltScopeWatchdogDoesNotInheritSessionIdentity` (Linux): spawns the real watchdog and fake server under a parent environment with every session key stamped, then reads `/proc/<pid>/environ` for both once each has settled on its final image. The kernel reports an empty environ inside `execve`, and the fake dolt execs twice, so the read waits for a non-empty block instead of trusting the first read.
- `TestSweepProcessTableOrphansLeavesManagedDoltWatchdogAlone` (Linux): drives the real `proctable` scanner over a procfs-shaped tree (watchdog root under init, server beneath it, session bead closed) and the real `sweepProcessTableOrphans`. With the environment `doltServerEnv` now produces the sweep reaps nothing; with the session environment passed through unchanged, the pre-fix state, it reaps the watchdog root.

### Mutation checks

Removing the scrub loop fails the first, third and fourth tests and leaves the drift guard passing, as expected; dropping a key from the list fails the drift guard. Restored before commit.

### Runs

- `go test ./cmd/gc/ -run 'ManagedDolt|DoltServerEnv|SweepProcessTableOrphans|DoltScopeWatchdog'`: green.
- `go test ./cmd/gc/...` full package: see the CI result on this PR; the local run is recorded in the review thread if it differs.
- `go test ./internal/runtime/proctable/ ./internal/session/`: green.
- `go test ./internal/testpolicy/resourcecensus/`: green. The new tests add no `exec.Command`, `Setenv` or `Sleep` call sites, so every census row is unchanged.
- `golangci-lint run --new-from-rev=origin/main ./cmd/gc/`, `golangci-lint fmt --diff`, `go vet ./cmd/gc/`: clean. One `//nolint:unparam` on the recorder's `TerminateRuntime`, which exists to satisfy the scanner interface.
- No stray watchdog or fake server after the runs (`ps` shows only the city's own supervisor-started watchdog).

### Not changed

- No `CHANGELOG.md` entry, matching the repo's recent `fix(` commits.
- No docs change: the runbook advice to run `gc dolt restart` from an operator shell was already safe, and with this change it is safe from an agent shell too.

</details>

---
> Generated by the operator's software factory.
> • City: `city` · Agent: `local-core.builder-1`
> • On behalf of: @austinborn
