### PR TITLE
feat(dispatch): stamp failed-DAG diagnostics on the domain parent + federate the retry required-artifact read (split-store landmines #5/#14)

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -294,6 +294,15 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 				opts.MemberStores = []beads.Store{store}
 			}
 		case "retry-eval":
+			// A retry-eval validating a required artifact resolves the
+			// artifact worktree through the workflow's source bead or input
+			// convoy, which are work class; when the graph class relocated,
+			// supply the work leg as the member tail so that read crosses the
+			// class boundary. Route-gated exactly like the drain: on every
+			// other city graphStore IS store and the tail stays empty.
+			if graphStore != store {
+				opts.MemberStores = []beads.Store{store}
+			}
 			sp, err := dispatchControlSessionProvider()
 			if err != nil {
 				return err
@@ -306,6 +315,11 @@ func runControlDispatcherWithStoreAndConfig(cityPath, storePath string, store be
 			}
 		case "retry", "ralph":
 			opts.FormulaSearchPaths = workflowFormulaSearchPaths(cfg, bead)
+			// Same cross-store required-artifact source resolution as
+			// retry-eval above.
+			if graphStore != store {
+				opts.MemberStores = []beads.Store{store}
+			}
 			sp, err := dispatchControlSessionProvider()
 			if err != nil {
 				return err

--- a/internal/dispatch/drain_residency.go
+++ b/internal/dispatch/drain_residency.go
@@ -49,7 +49,9 @@ func drainInfrastructureClasses() []coordclass.Class {
 }
 
 // resolveDrainMember answers which store holds a member the drain reads but did
-// not mint, and what that store's row says.
+// not mint, and what that store's row says. The retry lane's required-artifact
+// gate shares it (resolveRequiredArtifactSourceBead) for the same shape: a
+// work-class bead a graph-store control kind reads but did not mint.
 //
 // The intent is ByID, not RoutedWork: a member's class is not statically known,
 // so a binding copy is the live relocated bead and the work store's copy is the

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -458,7 +458,7 @@ func classifyRetryAttemptWithPostconditions(store beads.Store, subject beads.Bea
 	if result.Outcome != "pass" {
 		return result, nil
 	}
-	reason, err := validateRequiredArtifacts(store, subject, opts.RequiredArtifactStat)
+	reason, err := validateRequiredArtifacts(store, subject, opts)
 	if err != nil {
 		return retryEvalResult{}, err
 	}
@@ -468,12 +468,13 @@ func classifyRetryAttemptWithPostconditions(store beads.Store, subject beads.Bea
 	return result, nil
 }
 
-func validateRequiredArtifacts(store beads.Store, subject beads.Bead, stat func(string) (os.FileInfo, error)) (string, error) {
+func validateRequiredArtifacts(store beads.Store, subject beads.Bead, opts ProcessOptions) (string, error) {
+	stat := opts.RequiredArtifactStat
 	if stat == nil {
 		stat = os.Stat
 	}
 	for _, rawPath := range requiredArtifactTemplates(subject.Metadata) {
-		path, worktree, reason, err := resolveRequiredArtifactPath(store, subject, rawPath)
+		path, worktree, reason, err := resolveRequiredArtifactPath(store, subject, rawPath, opts)
 		if err != nil {
 			return "", err
 		}
@@ -548,14 +549,14 @@ func requiredArtifactWorkDir(meta map[string]string) string {
 // steps of one loop iteration is named by {iteration}; only {attempt} advances
 // when a single step retries. Any token left unexpanded fails the template
 // loudly rather than resolving to a partial path.
-func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath string) (string, string, string, error) {
+func resolveRequiredArtifactPath(store beads.Store, subject beads.Bead, rawPath string, opts ProcessOptions) (string, string, string, error) {
 	rootID := strings.TrimSpace(subject.Metadata[beadmeta.RootBeadIDMetadataKey])
 	attempt := strings.TrimSpace(subject.Metadata[beadmeta.AttemptMetadataKey])
 	iteration := strings.TrimSpace(subject.Metadata[beadmeta.IterationMetadataKey])
 	worktree := requiredArtifactWorkDir(subject.Metadata)
 
 	if worktree == "" {
-		resolvedWorktree, reason, err := resolveRequiredArtifactWorktree(store, rootID)
+		resolvedWorktree, reason, err := resolveRequiredArtifactWorktree(store, rootID, opts)
 		if err != nil {
 			return "", "", "", err
 		}
@@ -644,7 +645,7 @@ func requiredArtifactTargetInWorktree(worktree, path string) (bool, error) {
 	return requiredArtifactPathInWorktree(resolvedWorktree, resolvedPath)
 }
 
-func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, string, error) {
+func resolveRequiredArtifactWorktree(store beads.Store, rootID string, opts ProcessOptions) (string, string, error) {
 	if rootID == "" {
 		return "", "missing_required_artifact_context", nil
 	}
@@ -664,24 +665,88 @@ func resolveRequiredArtifactWorktree(store beads.Store, rootID string) (string, 
 		return worktree, "", nil
 	}
 	sourceID := strings.TrimSpace(root.Metadata[beadmeta.SourceBeadIDMetadataKey])
+	fromSourceBead := sourceID != ""
 	if sourceID == "" {
 		sourceID = strings.TrimSpace(root.Metadata[beadmeta.InputConvoyIDMetadataKey])
 	}
 	if sourceID == "" {
 		return "", "missing_required_artifact_context", nil
 	}
-	source, err := store.Get(sourceID)
-	if errors.Is(err, beads.ErrNotFound) {
-		return "", "missing_required_artifact_context", nil
-	}
+	source, found, err := resolveRequiredArtifactSourceBead(store, root, sourceID, fromSourceBead, opts)
 	if err != nil {
-		return "", "", fmt.Errorf("loading required artifact source bead %s: %w", sourceID, markTransientControllerBoundaryError(err))
+		return "", "", err
+	}
+	if !found {
+		return "", "missing_required_artifact_context", nil
 	}
 	worktree := requiredArtifactWorkDir(source.Metadata)
 	if worktree == "" {
 		return "", "missing_required_artifact_context", nil
 	}
 	return worktree, "", nil
+}
+
+// resolveRequiredArtifactSourceBead reads the worktree-bearing source bead a
+// workflow root points at, across store boundaries. The root lives in the
+// subject's own (graph) store, but on a split city the bead it points at does
+// not: a gc.source_bead_id source lives in the scope named by
+// gc.source_store_ref, and a gc.input_convoy_id convoy is a work bead in the
+// work store. Reading either through the ambient store gets a clean
+// ErrNotFound and misclassifies a genuinely-passing attempt as transient
+// missing_required_artifact_context, burning attempts until exhaustion. Two
+// doors, matching the finalize lane's walkSourceBeadChain:
+//
+//   - A non-empty gc.source_store_ref names another scope's store; resolve it
+//     via opts.ResolveStoreRef and read there. A ref with no resolver wired
+//     fails LOUD rather than silently narrowing to the ambient store.
+//   - With no ref, resolve over the same residency frame the drain uses
+//     (opts.MemberStores as the work leg). With no member stores — every
+//     single-store caller — this is byte-identical to the ambient store.Get
+//     it replaces.
+//
+// found=false is a clean not-found on every probed store; the caller maps it
+// to missing_required_artifact_context exactly as before.
+func resolveRequiredArtifactSourceBead(store beads.Store, root beads.Bead, sourceID string, fromSourceBead bool, opts ProcessOptions) (beads.Bead, bool, error) {
+	if fromSourceBead {
+		if ref := strings.TrimSpace(root.Metadata[beadmeta.SourceStoreRefMetadataKey]); ref != "" {
+			if opts.ResolveStoreRef == nil {
+				return beads.Bead{}, false, fmt.Errorf("resolving required artifact source bead %s (ref %s): no store-ref resolver provided", sourceID, ref)
+			}
+			resolved, err := opts.ResolveStoreRef(ref)
+			if err != nil {
+				return beads.Bead{}, false, fmt.Errorf("resolving required artifact source store %q: %w", ref, markTransientControllerBoundaryError(err))
+			}
+			if resolved == nil {
+				return beads.Bead{}, false, fmt.Errorf("resolving required artifact source store %q: nil store", ref)
+			}
+			source, err := resolved.Get(sourceID)
+			if errors.Is(err, beads.ErrNotFound) {
+				return beads.Bead{}, false, nil
+			}
+			if err != nil {
+				return beads.Bead{}, false, fmt.Errorf("loading required artifact source bead %s in %s: %w", sourceID, ref, markTransientControllerBoundaryError(err))
+			}
+			return source, true, nil
+		}
+	}
+	if len(opts.MemberStores) == 0 {
+		source, err := store.Get(sourceID)
+		if errors.Is(err, beads.ErrNotFound) {
+			return beads.Bead{}, false, nil
+		}
+		if err != nil {
+			return beads.Bead{}, false, fmt.Errorf("loading required artifact source bead %s: %w", sourceID, markTransientControllerBoundaryError(err))
+		}
+		return source, true, nil
+	}
+	owner, found, err := resolveDrainMember(store, sourceID, opts)
+	if err != nil {
+		return beads.Bead{}, false, fmt.Errorf("loading required artifact source bead %s: %w", sourceID, markTransientControllerBoundaryError(err))
+	}
+	if !found {
+		return beads.Bead{}, false, nil
+	}
+	return owner.Bead, true, nil
 }
 
 func retryFailureReason(subject beads.Bead) string {

--- a/internal/dispatch/retry_artifact_iteration_test.go
+++ b/internal/dispatch/retry_artifact_iteration_test.go
@@ -48,7 +48,7 @@ func TestResolveRequiredArtifactPathResolvesIterationSeparatelyFromAttempt(t *te
 	}
 
 	got, _, reason, err := resolveRequiredArtifactPath(store, subject,
-		".gc/reviews/{root}/attempt-{iteration}/synthesis.md")
+		".gc/reviews/{root}/attempt-{iteration}/synthesis.md", ProcessOptions{})
 	if err != nil {
 		t.Fatalf("resolveRequiredArtifactPath error = %v, want nil", err)
 	}
@@ -64,7 +64,7 @@ func TestResolveRequiredArtifactPathResolvesIterationSeparatelyFromAttempt(t *te
 		// The two placeholders must genuinely diverge; a template that asks for
 		// the retry attempt still gets it.
 		got, _, reason, err := resolveRequiredArtifactPath(store, subject,
-			".gc/reviews/{root}/attempt-{attempt}/synthesis.md")
+			".gc/reviews/{root}/attempt-{attempt}/synthesis.md", ProcessOptions{})
 		if err != nil || reason != "" {
 			t.Fatalf("resolveRequiredArtifactPath = (%v, %q), want success", err, reason)
 		}
@@ -99,7 +99,7 @@ func TestResolveRequiredArtifactPathRefusesToGuessAMissingIteration(t *testing.T
 			"gc.root_bead_id": root.ID,
 			"gc.attempt":      "3",
 		},
-	}, ".gc/reviews/{root}/attempt-{iteration}/synthesis.md")
+	}, ".gc/reviews/{root}/attempt-{iteration}/synthesis.md", ProcessOptions{})
 	if err != nil {
 		t.Fatalf("resolveRequiredArtifactPath error = %v, want nil", err)
 	}
@@ -129,7 +129,7 @@ func TestResolveRequiredArtifactWorktreePrefersCanonicalWorkDir(t *testing.T) {
 				"gc.root_bead_id": root.ID,
 				"gc.work_dir":     worktree,
 			},
-		}, "synthesis.md")
+		}, "synthesis.md", ProcessOptions{})
 		if err != nil || reason != "" {
 			t.Fatalf("resolveRequiredArtifactPath = (%v, %q), want success", err, reason)
 		}
@@ -146,7 +146,7 @@ func TestResolveRequiredArtifactWorktreePrefersCanonicalWorkDir(t *testing.T) {
 			Type:     "task",
 			Metadata: map[string]string{"gc.work_dir": worktree},
 		})
-		got, reason, err := resolveRequiredArtifactWorktree(store, root.ID)
+		got, reason, err := resolveRequiredArtifactWorktree(store, root.ID, ProcessOptions{})
 		if err != nil || reason != "" {
 			t.Fatalf("resolveRequiredArtifactWorktree = (%v, %q), want success", err, reason)
 		}
@@ -168,7 +168,7 @@ func TestResolveRequiredArtifactWorktreePrefersCanonicalWorkDir(t *testing.T) {
 			Type:     "task",
 			Metadata: map[string]string{"gc.source_bead_id": source.ID},
 		})
-		got, reason, err := resolveRequiredArtifactWorktree(store, root.ID)
+		got, reason, err := resolveRequiredArtifactWorktree(store, root.ID, ProcessOptions{})
 		if err != nil || reason != "" {
 			t.Fatalf("resolveRequiredArtifactWorktree = (%v, %q), want success", err, reason)
 		}
@@ -187,7 +187,7 @@ func TestResolveRequiredArtifactWorktreePrefersCanonicalWorkDir(t *testing.T) {
 			Type:     "task",
 			Metadata: map[string]string{"work_dir": worktree},
 		})
-		got, reason, err := resolveRequiredArtifactWorktree(store, root.ID)
+		got, reason, err := resolveRequiredArtifactWorktree(store, root.ID, ProcessOptions{})
 		if err != nil || reason != "" {
 			t.Fatalf("resolveRequiredArtifactWorktree = (%v, %q), want success", err, reason)
 		}

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -2422,3 +2422,140 @@ func TestProcessScopeCheckSkipsOpenRalphIterationDescendantsOnAbort(t *testing.T
 		}
 	}
 }
+
+// writeRequiredRetryArtifact creates a non-empty artifact file inside worktree
+// and returns its basename for use as a gc.required_artifact template.
+func writeRequiredRetryArtifact(t *testing.T, worktree, name string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(worktree, name), []byte("artifact\n"), 0o644); err != nil {
+		t.Fatalf("write required artifact: %v", err)
+	}
+	return name
+}
+
+// TestClassifyRetryAttemptWithPostconditionsResolvesSourceBeadAcrossStores pins
+// the split-city required-artifact source read: the workflow root lives in the
+// graph store, but the source bead carrying work_dir lives in another scope's
+// store named by gc.source_store_ref. Reading the source through the ambient
+// graph store gets a clean ErrNotFound and misclassifies a genuinely-passing
+// attempt as transient missing_required_artifact_context, burning retries.
+func TestClassifyRetryAttemptWithPostconditionsResolvesSourceBeadAcrossStores(t *testing.T) {
+	t.Parallel()
+
+	workStore := &beads.MemStore{IDPrefix: "hq"}
+	graphStore := &beads.MemStore{IDPrefix: "gcg"}
+	worktree := t.TempDir()
+	artifact := writeRequiredRetryArtifact(t, worktree, "codex-review.md")
+
+	source := mustCreateWorkflowBead(t, workStore, beads.Bead{
+		Title:    "source",
+		Type:     "task",
+		Metadata: map[string]string{"work_dir": worktree},
+	})
+	root := mustCreateWorkflowBead(t, graphStore, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.source_bead_id":   source.ID,
+			"gc.source_store_ref": "city:foo",
+		},
+	})
+
+	var resolverRef string
+	opts := ProcessOptions{ResolveStoreRef: func(ref string) (beads.Store, error) {
+		resolverRef = ref
+		return workStore, nil
+	}}
+	got, err := classifyRetryAttemptWithPostconditions(graphStore, beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.root_bead_id":      root.ID,
+			"gc.required_artifact": artifact,
+		},
+	}, opts)
+	if err != nil {
+		t.Fatalf("classifyRetryAttemptWithPostconditions: %v", err)
+	}
+	if want := (retryEvalResult{Outcome: "pass"}); got != want {
+		t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v (cross-store source misclassified?)", got, want)
+	}
+	if resolverRef != "city:foo" {
+		t.Fatalf("resolver called with ref %q, want city:foo", resolverRef)
+	}
+}
+
+// TestClassifyRetryAttemptWithPostconditionsCrossStoreSourceWithoutResolverFailsLoud:
+// a gc.source_store_ref present but no resolver wired must fail loud, not
+// silently burn a retry attempt with a fabricated
+// missing_required_artifact_context reason.
+func TestClassifyRetryAttemptWithPostconditionsCrossStoreSourceWithoutResolverFailsLoud(t *testing.T) {
+	t.Parallel()
+
+	graphStore := &beads.MemStore{IDPrefix: "gcg"}
+	root := mustCreateWorkflowBead(t, graphStore, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.source_bead_id":   "hq-source", // deliberately absent from graphStore
+			"gc.source_store_ref": "city:foo",
+		},
+	})
+
+	_, err := classifyRetryAttemptWithPostconditions(graphStore, beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.root_bead_id":      root.ID,
+			"gc.required_artifact": "codex-review.md",
+		},
+	}, ProcessOptions{}) // nil ResolveStoreRef
+	if err == nil {
+		t.Fatal("want a loud error when a cross-store source ref has no resolver, got nil (silent transient)")
+	}
+	if !strings.Contains(err.Error(), "no store-ref resolver provided") {
+		t.Fatalf("error = %v, want it to mention the missing resolver", err)
+	}
+}
+
+// TestClassifyRetryAttemptWithPostconditionsResolvesInputConvoyViaMemberStores:
+// the gc.input_convoy_id hop carries no store ref on the root — a convoy is a
+// work bead, so on a split city it lives in the work store while the root and
+// the retry control run in the graph store. The read must federate through
+// opts.MemberStores (the work-store tail), exactly like the drain lane.
+func TestClassifyRetryAttemptWithPostconditionsResolvesInputConvoyViaMemberStores(t *testing.T) {
+	t.Parallel()
+
+	workStore := &beads.MemStore{IDPrefix: "hq"}
+	graphStore := &beads.MemStore{IDPrefix: "gcg"}
+	worktree := t.TempDir()
+	artifact := writeRequiredRetryArtifact(t, worktree, "codex-review.md")
+
+	convoy := mustCreateWorkflowBead(t, workStore, beads.Bead{
+		Title:    "input convoy",
+		Type:     "convoy",
+		Metadata: map[string]string{"work_dir": worktree},
+	})
+	root := mustCreateWorkflowBead(t, graphStore, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":            "workflow",
+			"gc.input_convoy_id": convoy.ID,
+		},
+	})
+
+	got, err := classifyRetryAttemptWithPostconditions(graphStore, beads.Bead{
+		Metadata: map[string]string{
+			"gc.outcome":           "pass",
+			"gc.root_bead_id":      root.ID,
+			"gc.required_artifact": artifact,
+		},
+	}, ProcessOptions{MemberStores: []beads.Store{workStore}})
+	if err != nil {
+		t.Fatalf("classifyRetryAttemptWithPostconditions: %v", err)
+	}
+	if want := (retryEvalResult{Outcome: "pass"}); got != want {
+		t.Fatalf("classifyRetryAttemptWithPostconditions() = %+v, want %+v (input convoy not resolved via MemberStores?)", got, want)
+	}
+}

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -973,9 +973,24 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 	// request that spawned a rig-scope mol-adopt-pr-v2 workflow) don't accumulate
 	// as orphans. Failures intentionally leave parent sources open so a human
 	// can investigate via list - the bead IS the audit handle.
-	if outcome == beadmeta.OutcomePass {
+	switch outcome {
+	case beadmeta.OutcomePass:
 		if err := preflightSourceBeadChain(store, rootID, opts); err != nil {
 			return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: preflighting source bead chain: %w", rootID, err))
+		}
+	case beadmeta.OutcomeFail:
+		// Failures leave the domain parent OPEN (a human investigates via the
+		// human-visible queue and can redispatch), but on a split city the
+		// parent otherwise gets NO signal at all — the DAG closes in the graph
+		// store and nothing crosses the store boundary, leaving the parent
+		// indistinguishable from never-run. Stamp the failing step's
+		// diagnostics onto the still-open parent so it is visibly failed.
+		// Stamped here, in the pass-path preflight's slot, for the same
+		// reason the preflight exists: an error past this point strands the
+		// finalizer closed-as-skipped by the subtree close below. The stamp
+		// is metadata-only and idempotent, so re-running it on retry is safe.
+		if err := annotateSourceBeadFailure(store, rootID, resolveFinalizeFailureDiagnostics(store, bead), opts); err != nil {
+			return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: marking failed source bead: %w", rootID, err))
 		}
 	}
 	// Close the root BEFORE the finalize bead. If the root close fails and
@@ -1051,6 +1066,60 @@ func preflightSourceBeadChain(rootStore beads.Store, rootID string, opts Process
 // disappear from the human-visible queue once the rig-scope workflow merges.
 func closeSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptions) error {
 	return walkSourceBeadChain(rootStore, rootID, opts, true)
+}
+
+// annotateSourceBeadFailure stamps failure diagnostics onto the domain parent
+// of a failed workflow (the first gc.source_bead_id hop from the root),
+// resolving a cross-store gc.source_store_ref via opts.ResolveStoreRef. It
+// leaves the parent OPEN and redispatchable — no close, no gc.outcome. A
+// cross-store ref with no resolver fails LOUD rather than silently narrowing:
+// the parent would otherwise never learn its DAG failed. An empty ref
+// (same-store parent), a missing root, or a deleted parent is a traced no-op.
+// The stamped keys are all gc.*-namespaced, so they stay disjoint from the
+// pass path's propagateSourceBeadTerminalMetadata, which copies only non-gc
+// metadata.
+func annotateSourceBeadFailure(rootStore beads.Store, rootID string, failure map[string]string, opts ProcessOptions) error {
+	root, err := rootStore.Get(rootID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("loading root %s for failure annotation: %w", rootID, err)
+	}
+	parentID := strings.TrimSpace(root.Metadata[beadmeta.SourceBeadIDMetadataKey])
+	if parentID == "" {
+		opts.tracef("annotate-source-failure root=%s stop reason=no_source", rootID)
+		return nil
+	}
+	ref := strings.TrimSpace(root.Metadata[sourceworkflow.SourceStoreRefMetadataKey])
+	parentStore := rootStore
+	if ref != "" {
+		if opts.ResolveStoreRef == nil {
+			return fmt.Errorf("annotate-source-failure root=%s: cannot mark cross-store source bead %s (ref %s): no store-ref resolver provided", rootID, parentID, sourceChainStoreLabel(ref))
+		}
+		resolved, err := opts.ResolveStoreRef(ref)
+		if err != nil {
+			return fmt.Errorf("resolving source store %q: %w", ref, err)
+		}
+		if resolved == nil {
+			return fmt.Errorf("resolving source store %q: nil store", ref)
+		}
+		parentStore = resolved
+	}
+	apply := func() error {
+		if _, err := parentStore.Get(parentID); err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				opts.tracef("annotate-source-failure root=%s stop reason=deleted_parent source=%s ref=%s", rootID, parentID, sourceChainStoreLabel(ref))
+				return nil
+			}
+			return fmt.Errorf("getting source bead %s in %s: %w", parentID, sourceChainStoreLabel(ref), err)
+		}
+		return parentStore.SetMetadataBatch(parentID, failure)
+	}
+	if opts.SourceWorkflowLock != nil {
+		return opts.SourceWorkflowLock(ref, parentID, apply)
+	}
+	return apply()
 }
 
 func walkSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptions, mutate bool) error {
@@ -1711,6 +1780,41 @@ func resolveFinalizeOutcome(store beads.Store, finalizer beads.Bead) (string, er
 		}
 	}
 	return outcome, nil
+}
+
+// resolveFinalizeFailureDiagnostics returns the failure metadata to stamp on
+// the domain parent when a workflow finalizes FAILED: the first failed
+// blocker's gc.failure_reason / gc.failure_class, with gc.failure_subject
+// naming that blocker. The root itself only carries gc.outcome=fail — the
+// reason lives on the blocker. Best-effort: a read error or a fail with no
+// failed blocker (e.g. an abort-scope member failure) still yields a generic
+// workflow_failed reason so the parent always carries a marker. Additive over
+// the shared resolveBlockedOutcome/resolveFinalizeOutcome, which stay as they
+// are.
+func resolveFinalizeFailureDiagnostics(store beads.Store, finalizer beads.Bead) map[string]string {
+	failure := map[string]string{beadmeta.FailureReasonMetadataKey: "workflow_failed"}
+	deps, err := store.DepList(finalizer.ID, "down")
+	if err != nil {
+		return failure
+	}
+	for _, dep := range deps {
+		if dep.Type != "blocks" {
+			continue
+		}
+		blocker, err := store.Get(dep.DependsOnID)
+		if err != nil || !beadOutcomeFailed(blocker) {
+			continue
+		}
+		failure[beadmeta.FailureSubjectMetadataKey] = blocker.ID
+		if reason := strings.TrimSpace(blocker.Metadata[beadmeta.FailureReasonMetadataKey]); reason != "" {
+			failure[beadmeta.FailureReasonMetadataKey] = reason
+		}
+		if class := strings.TrimSpace(blocker.Metadata[beadmeta.FailureClassMetadataKey]); class != "" {
+			failure[beadmeta.FailureClassMetadataKey] = class
+		}
+		return failure
+	}
+	return failure
 }
 
 func resolveBlockedOutcome(store beads.Store, beadID string) (string, error) {

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -127,6 +127,10 @@ const (
 
 const workflowFinalizeErrorMetadataKey = beadmeta.LastFinalizeErrorMetadataKey
 
+// workflowFailedReason is the gc.failure_reason stamped on a domain parent
+// when a DAG failed but no single bead can be named as the culprit.
+const workflowFailedReason = "workflow_failed"
+
 // ErrControlPending reports that a control bead is not yet processable but
 // should be retried later.
 var ErrControlPending = errors.New("workflow control pending")
@@ -989,6 +993,15 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 		// reason the preflight exists: an error past this point strands the
 		// finalizer closed-as-skipped by the subtree close below. The stamp
 		// is metadata-only and idempotent, so re-running it on retry is safe.
+		//
+		// The parent outlives every DAG launched from it, so the stamp is a
+		// whole-value contract rather than a set of independent keys: each
+		// stamp writes ALL of gc.failure_reason/class/subject (empty for what
+		// the culprit did not supply) so a later, sparser failure cannot leave
+		// the previous DAG's class or subject standing beside it, and the
+		// PASS arm clears all three as it closes the parent
+		// (propagateSourceBeadTerminalMetadata) so a succeeded parent never
+		// carries the failure it superseded.
 		if err := annotateSourceBeadFailure(store, rootID, resolveFinalizeFailureDiagnostics(store, bead), opts); err != nil {
 			return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: marking failed source bead: %w", rootID, err))
 		}
@@ -1075,9 +1088,9 @@ func closeSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOpti
 // cross-store ref with no resolver fails LOUD rather than silently narrowing:
 // the parent would otherwise never learn its DAG failed. An empty ref
 // (same-store parent), a missing root, or a deleted parent is a traced no-op.
-// The stamped keys are all gc.*-namespaced, so they stay disjoint from the
-// pass path's propagateSourceBeadTerminalMetadata, which copies only non-gc
-// metadata.
+// The stamp must be the complete set of failure keys (see failureStamp); the
+// pass path's propagateSourceBeadTerminalMetadata is the other half of that
+// contract and clears the same set as it closes the parent.
 func annotateSourceBeadFailure(rootStore beads.Store, rootID string, failure map[string]string, opts ProcessOptions) error {
 	root, err := rootStore.Get(rootID)
 	if err != nil {
@@ -1199,7 +1212,7 @@ func walkSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptio
 			if !mutate {
 				return nil
 			}
-			if err := propagateSourceBeadTerminalMetadata(nextStore, loaded.ID, current.Metadata); err != nil {
+			if err := propagateSourceBeadTerminalMetadata(nextStore, loaded, current.Metadata); err != nil {
 				return fmt.Errorf("propagating source bead metadata %s in %s: %w", nextID, sourceChainStoreLabel(effectiveRef), err)
 			}
 			if loaded.Status == "closed" {
@@ -1408,13 +1421,25 @@ func closeSourceBeadPreservingOutcome(store beads.Store, bead beads.Bead) error 
 	return store.Update(bead.ID, opts)
 }
 
-func propagateSourceBeadTerminalMetadata(store beads.Store, beadID string, metadata map[string]string) error {
+// propagateSourceBeadTerminalMetadata carries the finished workflow's domain
+// (non-gc) metadata down to a source bead on the PASS path, and clears any
+// failure stamp an earlier failed DAG left on that same parent. Source beads
+// outlive the DAGs launched from them, so a parent about to close
+// gc.outcome=pass must not still advertise the failure it just superseded —
+// that reads as "passed, because postcondition_failed". A parent with nothing
+// to clear and no domain metadata to carry stays a pure no-op.
+func propagateSourceBeadTerminalMetadata(store beads.Store, target beads.Bead, metadata map[string]string) error {
 	batch := make(map[string]string)
 	copyNonGCMetadata(batch, metadata)
+	if hasFailureStamp(target) {
+		for key, value := range clearedFailureStamp() {
+			batch[key] = value
+		}
+	}
 	if len(batch) == 0 {
 		return nil
 	}
-	return store.SetMetadataBatch(beadID, batch)
+	return store.SetMetadataBatch(target.ID, batch)
 }
 
 func recordWorkflowFinalizeError(store beads.Store, finalizerID string, err error) error {
@@ -1771,7 +1796,7 @@ func resolveFinalizeOutcome(store beads.Store, finalizer beads.Bead) (string, er
 	}
 	rootID := strings.TrimSpace(finalizer.Metadata[beadmeta.RootBeadIDMetadataKey])
 	if outcome == beadmeta.OutcomePass && rootID != "" {
-		failed, err := workflowRootHasTerminalAbortScopeFailure(store, rootID, finalizer.ID)
+		_, failed, err := terminalAbortScopeFailureMember(store, rootID, finalizer.ID)
 		if err != nil {
 			return "", err
 		}
@@ -1783,19 +1808,38 @@ func resolveFinalizeOutcome(store beads.Store, finalizer beads.Bead) (string, er
 }
 
 // resolveFinalizeFailureDiagnostics returns the failure metadata to stamp on
-// the domain parent when a workflow finalizes FAILED: the first failed
-// blocker's gc.failure_reason / gc.failure_class, with gc.failure_subject
-// naming that blocker. The root itself only carries gc.outcome=fail — the
-// reason lives on the blocker. Best-effort: a read error or a fail with no
-// failed blocker (e.g. an abort-scope member failure) still yields a generic
-// workflow_failed reason so the parent always carries a marker. Additive over
-// the shared resolveBlockedOutcome/resolveFinalizeOutcome, which stay as they
-// are.
+// the domain parent when a workflow finalizes FAILED. Two routes reach a
+// failed finalize and each names its own culprit:
+//
+//   - a failed direct blocker (resolveBlockedOutcome) — the root itself only
+//     carries gc.outcome=fail, the reason lives on the blocker;
+//   - a terminal abort-scope member (terminalAbortScopeFailureMember) — every
+//     blocker passed, and the failing member is elsewhere in the DAG.
+//
+// Best-effort: a read error, or a fail with no identifiable culprit, still
+// yields the generic workflow_failed reason so the parent always carries a
+// marker. Additive over the shared resolveBlockedOutcome/resolveFinalizeOutcome,
+// which stay as they are.
+//
+// The returned map always carries all three failure-stamp keys — see
+// failureStamp for why.
 func resolveFinalizeFailureDiagnostics(store beads.Store, finalizer beads.Bead) map[string]string {
-	failure := map[string]string{beadmeta.FailureReasonMetadataKey: "workflow_failed"}
+	if blocker, ok := firstFailedFinalizeBlocker(store, finalizer); ok {
+		return failureStampFor(blocker)
+	}
+	rootID := strings.TrimSpace(finalizer.Metadata[beadmeta.RootBeadIDMetadataKey])
+	if rootID != "" {
+		if member, ok, err := terminalAbortScopeFailureMember(store, rootID, finalizer.ID); err == nil && ok {
+			return failureStampFor(member)
+		}
+	}
+	return failureStamp(workflowFailedReason, "", "")
+}
+
+func firstFailedFinalizeBlocker(store beads.Store, finalizer beads.Bead) (beads.Bead, bool) {
 	deps, err := store.DepList(finalizer.ID, "down")
 	if err != nil {
-		return failure
+		return beads.Bead{}, false
 	}
 	for _, dep := range deps {
 		if dep.Type != "blocks" {
@@ -1805,16 +1849,49 @@ func resolveFinalizeFailureDiagnostics(store beads.Store, finalizer beads.Bead) 
 		if err != nil || !beadOutcomeFailed(blocker) {
 			continue
 		}
-		failure[beadmeta.FailureSubjectMetadataKey] = blocker.ID
-		if reason := strings.TrimSpace(blocker.Metadata[beadmeta.FailureReasonMetadataKey]); reason != "" {
-			failure[beadmeta.FailureReasonMetadataKey] = reason
-		}
-		if class := strings.TrimSpace(blocker.Metadata[beadmeta.FailureClassMetadataKey]); class != "" {
-			failure[beadmeta.FailureClassMetadataKey] = class
-		}
-		return failure
+		return blocker, true
 	}
-	return failure
+	return beads.Bead{}, false
+}
+
+// failureStampFor builds the stamp naming subject as the bead that failed,
+// carrying over its own reason and class.
+func failureStampFor(subject beads.Bead) map[string]string {
+	reason := strings.TrimSpace(subject.Metadata[beadmeta.FailureReasonMetadataKey])
+	if reason == "" {
+		reason = workflowFailedReason
+	}
+	return failureStamp(reason, strings.TrimSpace(subject.Metadata[beadmeta.FailureClassMetadataKey]), subject.ID)
+}
+
+// failureStamp builds a complete failure stamp. All three keys are always
+// written, empty for values the culprit did not supply, because the stamp is
+// applied as a per-key metadata merge onto a parent that outlives any one DAG:
+// omitting a key preserves the PREVIOUS attempt's value, and the parent then
+// reports the new subject beside the old class — a diagnosis that never
+// happened. Each stamp is self-consistent on its own.
+func failureStamp(reason, class, subject string) map[string]string {
+	return map[string]string{
+		beadmeta.FailureReasonMetadataKey:  reason,
+		beadmeta.FailureClassMetadataKey:   class,
+		beadmeta.FailureSubjectMetadataKey: subject,
+	}
+}
+
+// clearedFailureStamp is the stamp that erases a superseded failure. Empty
+// values rather than key deletion, matching clearControllerSpawnErrorMetadata:
+// the Store metadata surface has no delete, and every reader trims before
+// testing for presence.
+func clearedFailureStamp() map[string]string {
+	return failureStamp("", "", "")
+}
+
+// hasFailureStamp reports whether a bead carries failure diagnostics worth
+// clearing.
+func hasFailureStamp(bead beads.Bead) bool {
+	return strings.TrimSpace(bead.Metadata[beadmeta.FailureReasonMetadataKey]) != "" ||
+		strings.TrimSpace(bead.Metadata[beadmeta.FailureClassMetadataKey]) != "" ||
+		strings.TrimSpace(bead.Metadata[beadmeta.FailureSubjectMetadataKey]) != ""
 }
 
 func resolveBlockedOutcome(store beads.Store, beadID string) (string, error) {
@@ -1841,20 +1918,23 @@ func resolveBlockedOutcome(store beads.Store, beadID string) (string, error) {
 	return outcome, nil
 }
 
-func workflowRootHasTerminalAbortScopeFailure(store beads.Store, rootID, finalizerID string) (bool, error) {
+// terminalAbortScopeFailureMember returns the direct member whose terminal
+// gc.on_fail=abort_scope failure fails the whole workflow, so callers can both
+// decide the outcome and name the culprit in the domain parent's failure stamp.
+func terminalAbortScopeFailureMember(store beads.Store, rootID, finalizerID string) (beads.Bead, bool, error) {
 	all, err := beads.DirectMembers(store, rootID)
 	if err != nil {
-		return false, err
+		return beads.Bead{}, false, err
 	}
 	for _, candidate := range all {
 		if candidate.ID == finalizerID {
 			continue
 		}
 		if terminalAbortScopeFailure(candidate) {
-			return true, nil
+			return candidate, true, nil
 		}
 	}
-	return false, nil
+	return beads.Bead{}, false, nil
 }
 
 func terminalAbortScopeFailure(bead beads.Bead) bool {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -11677,14 +11677,7 @@ func TestProcessWorkflowFinalizeStampsFailureOnOpenDomainParent(t *testing.T) {
 	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
 	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
 
-	resolver := func(ref string) (beads.Store, error) {
-		if ref == "city:test" {
-			return cityStore, nil
-		}
-		return nil, fmt.Errorf("unknown store ref: %s", ref)
-	}
-
-	result, err := ProcessControl(rigStore, finalizer, ProcessOptions{ResolveStoreRef: resolver})
+	result, err := ProcessControl(rigStore, finalizer, ProcessOptions{ResolveStoreRef: cityStoreRefResolver(cityStore)})
 	if err != nil {
 		t.Fatalf("ProcessControl(workflow-finalize fail): %v", err)
 	}
@@ -11751,13 +11744,7 @@ func TestProcessWorkflowFinalizeFailureStampFallsBackToGenericReason(t *testing.
 	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
 	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
 
-	resolver := func(ref string) (beads.Store, error) {
-		if ref == "city:test" {
-			return cityStore, nil
-		}
-		return nil, fmt.Errorf("unknown store ref: %s", ref)
-	}
-	if _, err := ProcessControl(rigStore, finalizer, ProcessOptions{ResolveStoreRef: resolver}); err != nil {
+	if _, err := ProcessControl(rigStore, finalizer, ProcessOptions{ResolveStoreRef: cityStoreRefResolver(cityStore)}); err != nil {
 		t.Fatalf("ProcessControl(workflow-finalize fail): %v", err)
 	}
 
@@ -11821,4 +11808,235 @@ func TestProcessWorkflowFinalizeFailAnnotationFailsLoudWithoutResolver(t *testin
 	if fin.Status == "closed" {
 		t.Fatal("finalizer closed on a fail-loud annotation error; want open for retry")
 	}
+}
+
+// staleFailureStamp is the failure stamp a previous, superseded DAG left on a
+// domain parent. Every assertion about supersede/clear behavior starts here.
+func staleFailureStamp() map[string]string {
+	return map[string]string{
+		"gc.failure_reason":  "postcondition_failed",
+		"gc.failure_class":   "hard",
+		"gc.failure_subject": "ga-previous-attempt-step",
+	}
+}
+
+// assertFailureStamp checks all three failure-stamp keys at once. A stamp is
+// only meaningful as a set: reading one key without the others is how a stale
+// class or subject from a previous DAG goes unnoticed.
+func assertFailureStamp(t *testing.T, bead beads.Bead, reason, class, subject string) {
+	t.Helper()
+	want := map[string]string{
+		"gc.failure_reason":  reason,
+		"gc.failure_class":   class,
+		"gc.failure_subject": subject,
+	}
+	for key, wantValue := range want {
+		if got := strings.TrimSpace(bead.Metadata[key]); got != wantValue {
+			t.Errorf("%s %s = %q, want %q", bead.ID, key, got, wantValue)
+		}
+	}
+}
+
+func cityStoreRefResolver(store beads.Store) func(string) (beads.Store, error) {
+	return func(ref string) (beads.Store, error) {
+		if ref == "city:test" {
+			return store, nil
+		}
+		return nil, fmt.Errorf("unknown store ref: %s", ref)
+	}
+}
+
+// TestProcessWorkflowFinalizeFailureStampSupersedesStaleDiagnostics: a second
+// DAG for the same domain parent fails with sparser diagnostics than the first
+// (a failed step carrying no gc.failure_reason/class). Because the stamp is
+// applied as a per-key merge, a sparse second stamp must still overwrite every
+// key — otherwise the parent reports the NEW subject next to the OLD DAG's
+// class, a diagnosis that never existed.
+func TestProcessWorkflowFinalizeFailureStampSupersedesStaleDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{
+		Title:    "Adopt PR: gastownhall/example#12",
+		Type:     "task",
+		Metadata: staleFailureStamp(),
+	})
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "mol-adopt-pr-v2 (second attempt)",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+	// Sparse failure: outcome only, no reason and no class.
+	step := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:    "Review",
+		Type:     "task",
+		Status:   "closed",
+		Metadata: map[string]string{"gc.outcome": "fail"},
+	})
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, rigStore, finalizer.ID, step.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(rigStore, finalizer, ProcessOptions{ResolveStoreRef: cityStoreRefResolver(cityStore)})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize fail): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-fail" {
+		t.Fatalf("workflow result = %+v, want processed workflow-fail", result)
+	}
+
+	parent := mustGetBead(t, cityStore, citySource.ID)
+	if parent.Status != "open" {
+		t.Fatalf("domain parent status = %q, want open (failure leaves it redispatchable)", parent.Status)
+	}
+	assertFailureStamp(t, parent, "workflow_failed", "", step.ID)
+}
+
+// TestProcessWorkflowFinalizePassCloseClearsStaleFailureStamp: after an earlier
+// DAG failed and stamped the domain parent, a later DAG for the same parent
+// passes and closes it. The closed parent must not carry gc.outcome=pass next
+// to the superseded failure stamp — that is a self-contradictory audit record.
+func TestProcessWorkflowFinalizePassCloseClearsStaleFailureStamp(t *testing.T) {
+	t.Parallel()
+
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{
+		Title:    "Adopt PR: gastownhall/example#13",
+		Type:     "task",
+		Metadata: staleFailureStamp(),
+	})
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "mol-adopt-pr-v2 (passing retry)",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+	step := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:    "Review",
+		Type:     "task",
+		Status:   "closed",
+		Metadata: map[string]string{"gc.outcome": "pass"},
+	})
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, rigStore, finalizer.ID, step.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(rigStore, finalizer, ProcessOptions{ResolveStoreRef: cityStoreRefResolver(cityStore)})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize pass): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("workflow result = %+v, want processed workflow-pass", result)
+	}
+
+	parent := mustGetBead(t, cityStore, citySource.ID)
+	if parent.Status != "closed" {
+		t.Fatalf("domain parent status = %q, want closed", parent.Status)
+	}
+	if got := parent.Metadata["gc.outcome"]; got != "pass" {
+		t.Fatalf("domain parent gc.outcome = %q, want pass", got)
+	}
+	assertFailureStamp(t, parent, "", "", "")
+}
+
+// TestProcessWorkflowFinalizeFailureStampNamesAbortScopeMember: when the
+// finalize outcome flips to fail via the abort-scope route, every direct
+// blocker passed, so the blocker scan finds nothing. The abort-scope evaluator
+// already identified the exact failing member — its diagnostics must reach the
+// domain parent instead of a bare generic marker.
+func TestProcessWorkflowFinalizeFailureStampNamesAbortScopeMember(t *testing.T) {
+	t.Parallel()
+
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{
+		Title: "Adopt PR: gastownhall/example#14",
+		Type:  "task",
+	})
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "mol-adopt-pr-v2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+	preflight := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:  "Preflight",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id":   workflow.ID,
+			"gc.scope_ref":      "body",
+			"gc.scope_role":     "member",
+			"gc.on_fail":        "abort_scope",
+			"gc.outcome":        "fail",
+			"gc.failure_reason": "preflight_rejected",
+			"gc.failure_class":  "hard",
+		},
+	})
+	cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:  "Clean up worktree",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.kind":         "cleanup",
+			"gc.outcome":      "pass",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	result, err := ProcessControl(rigStore, finalizer, ProcessOptions{ResolveStoreRef: cityStoreRefResolver(cityStore)})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize abort-scope fail): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-fail" {
+		t.Fatalf("workflow result = %+v, want processed workflow-fail", result)
+	}
+
+	parent := mustGetBead(t, cityStore, citySource.ID)
+	if parent.Status != "open" {
+		t.Fatalf("domain parent status = %q, want open", parent.Status)
+	}
+	assertFailureStamp(t, parent, "preflight_rejected", "hard", preflight.ID)
 }

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -11628,3 +11628,197 @@ func TestTeardownTailClosesItselfAfterFailedSettlement(t *testing.T) {
 	}
 	assertNoOpenMembers(t, store, rootID)
 }
+
+// TestProcessWorkflowFinalizeStampsFailureOnOpenDomainParent pins the failed-DAG
+// diagnostics contract: a FAILED workflow finalize stamps the failing step's
+// gc.failure_reason/class/subject onto the cross-store domain parent (the first
+// gc.source_bead_id hop from the root) and leaves it OPEN/redispatchable, so
+// the human-visible source bead shows why the DAG failed instead of sitting
+// open and indistinguishable from never-run.
+func TestProcessWorkflowFinalizeStampsFailureOnOpenDomainParent(t *testing.T) {
+	t.Parallel()
+
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{
+		Title: "Adopt PR: gastownhall/example#9",
+		Type:  "task",
+	})
+
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "mol-adopt-pr-v2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+	cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:  "Review",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome":        "fail",
+			"gc.failure_reason": "postcondition_failed",
+			"gc.failure_class":  "hard",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	resolver := func(ref string) (beads.Store, error) {
+		if ref == "city:test" {
+			return cityStore, nil
+		}
+		return nil, fmt.Errorf("unknown store ref: %s", ref)
+	}
+
+	result, err := ProcessControl(rigStore, finalizer, ProcessOptions{ResolveStoreRef: resolver})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize fail): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-fail" {
+		t.Fatalf("workflow result = %+v, want processed workflow-fail", result)
+	}
+
+	parent, err := cityStore.Get(citySource.ID)
+	if err != nil {
+		t.Fatalf("get domain parent: %v", err)
+	}
+	if parent.Status != "open" {
+		t.Fatalf("domain parent status = %q, want open (failure leaves it redispatchable)", parent.Status)
+	}
+	if got := parent.Metadata["gc.failure_reason"]; got != "postcondition_failed" {
+		t.Fatalf("parent gc.failure_reason = %q, want postcondition_failed (no cross-store failure signal stamped)", got)
+	}
+	if got := parent.Metadata["gc.failure_class"]; got != "hard" {
+		t.Errorf("parent gc.failure_class = %q, want hard", got)
+	}
+	if got := parent.Metadata["gc.failure_subject"]; got != cleanup.ID {
+		t.Errorf("parent gc.failure_subject = %q, want %q", got, cleanup.ID)
+	}
+	if got := parent.Metadata["gc.outcome"]; got != "" {
+		t.Errorf("parent gc.outcome = %q, want unset (the parent is not terminal)", got)
+	}
+}
+
+// TestProcessWorkflowFinalizeFailureStampFallsBackToGenericReason: a failed
+// finalize whose failed blocker carries no gc.failure_reason still stamps a
+// generic workflow_failed marker on the domain parent, so the parent always
+// carries a visible failure signal.
+func TestProcessWorkflowFinalizeFailureStampFallsBackToGenericReason(t *testing.T) {
+	t.Parallel()
+
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{Title: "source", Type: "task"})
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "wf",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+	cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:    "step",
+		Type:     "task",
+		Status:   "closed",
+		Metadata: map[string]string{"gc.outcome": "fail"},
+	})
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "fin",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	resolver := func(ref string) (beads.Store, error) {
+		if ref == "city:test" {
+			return cityStore, nil
+		}
+		return nil, fmt.Errorf("unknown store ref: %s", ref)
+	}
+	if _, err := ProcessControl(rigStore, finalizer, ProcessOptions{ResolveStoreRef: resolver}); err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize fail): %v", err)
+	}
+
+	parent, err := cityStore.Get(citySource.ID)
+	if err != nil {
+		t.Fatalf("get domain parent: %v", err)
+	}
+	if parent.Status != "open" {
+		t.Fatalf("domain parent status = %q, want open", parent.Status)
+	}
+	if got := parent.Metadata["gc.failure_reason"]; got != "workflow_failed" {
+		t.Fatalf("parent gc.failure_reason = %q, want the generic workflow_failed fallback", got)
+	}
+	if got := parent.Metadata["gc.failure_subject"]; got != cleanup.ID {
+		t.Errorf("parent gc.failure_subject = %q, want %q", got, cleanup.ID)
+	}
+}
+
+// TestProcessWorkflowFinalizeFailAnnotationFailsLoudWithoutResolver: a failed
+// DAG whose parent is cross-store but no resolver is wired must fail loud (the
+// finalizer stays open for retry), not silently skip the failure annotation —
+// the parent would otherwise never learn its DAG failed.
+func TestProcessWorkflowFinalizeFailAnnotationFailsLoudWithoutResolver(t *testing.T) {
+	t.Parallel()
+
+	rigStore := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "wf",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   "ga-parent",
+			"gc.source_store_ref": "city:test",
+		},
+	})
+	cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:    "step",
+		Type:     "task",
+		Status:   "closed",
+		Metadata: map[string]string{"gc.outcome": "fail"},
+	})
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "fin",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	if _, err := ProcessControl(rigStore, finalizer, ProcessOptions{}); err == nil {
+		t.Fatal("want a loud error marking a cross-store failed parent with no resolver; got nil")
+	}
+	fin, err := rigStore.Get(finalizer.ID)
+	if err != nil {
+		t.Fatalf("get finalizer: %v", err)
+	}
+	if fin.Status == "closed" {
+		t.Fatal("finalizer closed on a fail-loud annotation error; want open for retry")
+	}
+}


### PR DESCRIPTION
## Summary

Two ports from the cross-store split audit (stranded `feat/domain-infra-store-split` work, re-implemented on main idioms):

**#5 — failed-DAG diagnostics on the domain parent.** When a graph workflow fails, the cross-store source parent stays open/redispatchable (stance preserved) but previously carried no audit of what failed. `processWorkflowFinalize`'s fail-arm now stamps `gc.failure_reason/class/subject` on the parent (resolved via `ResolveStoreRef`, fail-loud on an unresolvable ref). The stamp is a **whole-value contract**: every stamp writes all three keys (empty for unknown) so a sparse re-stamp can't merge stale keys from a dead DAG; a later **passing** DAG clears the stamp at close (guarded — the common pass path takes no new write); the abort-scope route names the actual failing member (reason/class/subject copied from it) instead of a generic `workflow_failed`.

**#14 — retry required-artifact read federated.** The retry lane's source-artifact read now resolves across class stores via the same threading, fail-loud on refusal — on a split city the artifact-bearing bead may live in the other class store.

RED-then-GREEN throughout (incl. stale-stamp supersede, pass-close clear, abort-scope culprit). Fable-council reviewed: sound; its four minors (all the stale-stamp theme) are fixed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)