### PR TITLE
docs(herdr): pin a herdr version, and say what the controller does not do yet

### DIFF
--- a/docs/reference/herdr-provider.md
+++ b/docs/reference/herdr-provider.md
@@ -14,12 +14,42 @@ runtime-selection setting that picks tmux, k8s, ssh, or exec.
 Install the `herdr` binary and make sure it is on `PATH`:
 
 ```bash
-herdr --version   # the provider is verified against herdr 0.7.1+
+herdr --version   # 0.7.1 is the recorded live validation; read the version note below
 ```
 
 The backend is registered as a builtin runtime name (`herdr`) — no pack or
 `[runtimes.*]` declaration is needed. If the binary is missing, sessions
 selected onto herdr fail to start; install it before flipping the selector.
+
+**Pin a herdr version in any shared environment**, and check herdr's own release
+list rather than trusting a version named here. The adapter talks to herdr's CLI,
+and minor herdr releases have changed that surface twice: 0.7.4 and 0.7.5 altered
+commands the original adapter depended on, and 0.8.0 renamed the code herdr
+returns for a pane with no named agent. That second one cost a fallback:
+when the agent-prompt call fails on a pane with no registered agent, the adapter
+pastes the text instead, and under the renamed code it stopped recognising that
+case, so the original failure was returned to the caller and the paste never
+happened. Nudge delivery surfaced an error rather than going quiet, but nothing
+in the build or the default test suite went red, so the regression had to be
+noticed in the field.
+
+The adapter reads 0.8's spelling now. One gap is known and tracked: 0.8.0 made
+herdr's agent registry detection-based, so the live journey that drives herdr's
+session-event stream waives itself when the installed herdr reports 0.8 or later
+rather than asserting against a registry it no longer matches
+([#5808](https://github.com/gastownhall/gascity/issues/5808)). That waiver reads
+the version, not the registry: a herdr whose version cannot be read or parsed
+runs the journey, and on 0.8 its registry assertions then fail. The other
+real-herdr journeys (provider lifecycle, pane binding, activity, and the runtime
+conformance suite) do run on 0.8; the kind-launch journey needs an installed
+`claude` binary as well and skips without one. 0.7.1 remains the version the
+recorded end-to-end validation ran against.
+
+That is the reason to pin. The tests that drive a real herdr binary are opt-in
+(`make test-herdr-live`); the default suite runs against a fake, so a change on
+herdr's side cannot fail the build. After a herdr upgrade, run
+`make test-herdr-live` and then put a session through a full work cycle before
+trusting it.
 
 ## Enabling herdr
 
@@ -122,6 +152,18 @@ path:
   `provider` value, plus any agent `session` overrides).
 - Once agents are on herdr, their workspaces and tabs are visible through
   herdr's own UI (`herdr` lists the per-rig/town workspaces and per-agent tabs).
+
+## What is not wired yet
+
+**The controller does not consume herdr's session-event stream.** herdr pushes
+session events and the provider implements the stream
+(`runtime.SessionEventProvider`), but the only consumer today is the provider's
+own activity reporting. The reconciler discovers session state on its periodic
+pass, so a session that goes away is noticed on the next pass rather than when the
+event arrives. That costs latency rather than correctness, because each pass reads
+live state rather than trusting an event. The delay is bounded by the reconcile
+interval only while the controller keeps up: ticks run one at a time, so a busy
+controller stretches it. That is the thing to watch during a pilot.
 
 ## Layout
 


### PR DESCRIPTION
## What this changes

`docs/reference/herdr-provider.md` told readers the provider is "verified against
herdr 0.7.1+". The plus sign is the problem: 0.7.1 is the oldest release with a
recorded end-to-end validation, not a floor above which the surface is known to
hold. Nothing on the page said the surface had moved, and it has moved twice.

The page now makes the pinning argument from what actually happened:

- 0.7.4 and 0.7.5 altered commands the original adapter depended on.
- 0.8.0 renamed the code herdr returns for a pane with no named agent. That is
  the code the adapter reads to decide whether to paste a nudge instead of
  submitting it through the agent. Under the new spelling it stopped recognising
  that case, so the original failure went back to the caller and the paste never
  happened. Delivery reported an error rather than going quiet, but nothing in the
  build or the default suite went red, because the tests that drive a real binary
  are opt-in. The regression had to be noticed in the field.

So: pin a version in any shared environment, read herdr's own release list rather
than a version named in our docs, and after an upgrade run `make test-herdr-live`
and put a session through a full work cycle.

The page no longer names a current herdr release. A reference page cannot keep
that true, and an out-of-date "current version" reads as authoritative.

## The one known coverage gap

0.8.0 made herdr's agent registry detection-based, so the live journey that drives
the session-event stream waives itself when the installed herdr reports 0.8 or
later rather than asserting against a registry it no longer matches
([#5808](https://github.com/gastownhall/gascity/issues/5808)). That waiver reads
the version, not the registry: a herdr whose version cannot be read or parsed runs
the journey, and on 0.8 its registry assertions then fail. The other real-herdr
journeys (provider lifecycle, pane binding, activity, and the runtime conformance
suite) do run on 0.8; the kind-launch journey needs an installed `claude` binary as
well and skips without one. 0.7.1 remains the version the recorded end-to-end
validation ran against.

That distinction matters to a reader deciding whether to pilot this. "Not covered
on 0.8" would tell them to stay on 0.7; one waived journey out of seven tells them
what to watch instead.

## What is not wired yet

A new section, with one entry: the controller does not consume herdr's
session-event stream. herdr pushes session events and the provider implements
`runtime.SessionEventProvider`, but the only consumer today is the provider's own
activity reporting. The reconciler discovers session state on its periodic pass,
so a session that goes away is noticed on the next pass rather than when the event
arrives.

That costs latency rather than correctness, because each pass reads live state
rather than trusting an event. The delay is bounded by the reconcile interval only
while the controller keeps up; ticks run one at a time, so a busy controller
stretches it.

## Claims that came out of earlier drafts

Four statements were removed or corrected because they did not survive checking
against the code. Recording them here so they do not come back:

- That no error appeared when the 0.8.0 fallback broke. `deliverNudge` returns the
  original error; what was missing was anything making it fail a build.
- That the warm-reuse claim nudge bypasses session-store routing. It does not. The
  reconciler unwraps its typed session store (`session_reconciler.go`,
  `store := sessStore.Store`) and threads that down to the nudge, so both the read
  and the marker write already reach a relocated sessions backend.
- That the controller's added latency is the patrol interval. Ticks are serial, so
  the interval bounds it only while the controller keeps up.
- That the live journeys are waived on 0.8 and later. One of seven is, and that
  waiver is keyed to the version string rather than to the registry it is about.

Startup-prompt redelivery across a continuation-epoch bump was also dropped from
this page: it is a test-coverage gap rather than a behavior gap, and belongs with
the tests. Store-maintenance notifications repeating per interval is real and has
nothing to do with herdr.

## Test plan

Docs-only, one file, no Go changes.

```
go build ./... && go vet ./...
go test ./test/docsync/ ./internal/testpolicy/...
make check-docs
```

All green at this head. Every version-behavior claim on the page is cited to the
adapter code or to the test that covers it; the live-journey counts were derived
by listing the callers of the live gate and of the detection-based-registry skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPcPXz8AxpyCCoDcK7Bu5W

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #5273 — rewrites the "verified against herdr 0.7.1+" line that the filed issue called out, so the page now records which herdr releases changed the CLI surface and tells readers to pin a version and re-run the live suite after upgrading; it is docs-only and does not touch the `--no-focus` flag handling the issue reports, nor add the version check or `gc doctor` gate suggested there

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->