### PR TITLE
fix(pool): align claim and close actor identity

### DIFF
--- a/cmd/gc/hook_claim_occupant_identity_test.go
+++ b/cmd/gc/hook_claim_occupant_identity_test.go
@@ -294,3 +294,47 @@ func TestPoolWorkerClaimIdentityDistinguishesOccupantsOfOneSlot(t *testing.T) {
 		seen[assignee] = beadID
 	}
 }
+
+// TestPoolWorkerClaimAndCloseIdentity is the full-pipeline regression for the
+// BEADS_ACTOR/claim mismatch: AssigneeIdentifier (and therefore
+// RuntimeEnvWithSessionContext's BEADS_ACTOR) used to fall back to the
+// reusable pool session_name for an unaliased pool worker, even though
+// hookClaimAssigneeIdentity's own precedence claims work under the session
+// bead id. Every bd command a live session runs -- including the close that
+// releases a claim -- is actored by BEADS_ACTOR, not a separately threaded
+// session id, so a claim recorded under the bead id but closed under
+// BEADS_ACTOR=session_name never satisfies bd's actor==assignee check and the
+// close silently fails to release ownership.
+//
+// This proves the whole chain agrees: the runtime projection's BEADS_ACTOR
+// (the close actor), the hook claim's computed assignee, and the unique
+// session bead id are all the same string.
+func TestPoolWorkerClaimAndCloseIdentity(t *testing.T) {
+	const beadID = "gcg-session-pool-worker"
+	info := sessiontest.SeedBead(t, beads.Bead{
+		ID:     beadID,
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:rig/claude-1"},
+		Metadata: map[string]string{
+			"template":             "rig/claude",
+			"agent_name":           "rig/claude-1",
+			"session_name":         "rig--claude-1-pool",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+
+	env := sessionpkg.RuntimeEnvWithSessionContext(info, 1, 1, "tok")
+	if env["GC_ALIAS"] != "" {
+		t.Fatalf("GC_ALIAS = %q, want empty for an unaliased pool slot", env["GC_ALIAS"])
+	}
+
+	assignee := hookClaimAssigneeIdentity(env["GC_ALIAS"], env["GC_SESSION_ID"], env["GC_AGENT"], "", env["GC_SESSION_NAME"])
+	if assignee != beadID {
+		t.Fatalf("hookClaimAssigneeIdentity = %q, want the session bead id %q", assignee, beadID)
+	}
+	if assignee != env["BEADS_ACTOR"] {
+		t.Fatalf("claim assignee %q != runtime BEADS_ACTOR %q -- the close actor must match what the claim was recorded under", assignee, env["BEADS_ACTOR"])
+	}
+}

--- a/cmd/gc/pool_slot_unaliased_test.go
+++ b/cmd/gc/pool_slot_unaliased_test.go
@@ -25,8 +25,12 @@ import (
 // dies. With the slot in GC_ALIAS, pool workers claimed under a name no
 // reconciler guard enumerates, so the drain guard saw no assigned work and
 // drained live claim-holders ~2min in. Restoring the original unaliased-pool
-// design (bc2ee15ac4) puts the claim back on the session name, which every
-// guard already enumerates — no guard change needed.
+// design (bc2ee15ac4) puts the claim back on an identity every guard already
+// enumerates — no guard change needed. AssigneeIdentifier then resolves that
+// unaliased identity to the session bead ID (see that function's doc); bead.ID
+// has always been the leading form in every enumeration
+// (sessionBeadAssigneeIdentities, currentSessionAssigneeIdentities,
+// ComputeAwakeSet).
 //
 // Slot bookkeeping does NOT ride the alias: agent_name, title, the agent:<name>
 // label, pool_slot, and the canonical-instance record all still carry it, and
@@ -169,23 +173,27 @@ func TestPoolSlotStaysUnaliasedAcrossReconcileTicks(t *testing.T) {
 		if env["GC_ALIAS"] != "" {
 			t.Fatalf("tick %d: spawn GC_ALIAS = %q, want empty", tick, env["GC_ALIAS"])
 		}
-		if want := got.Metadata["session_name"]; env["BEADS_ACTOR"] != want {
-			t.Fatalf("tick %d: spawn BEADS_ACTOR = %q, want the session name %q — this is the string the claim writes",
-				tick, env["BEADS_ACTOR"], want)
+		if env["BEADS_ACTOR"] != got.ID {
+			t.Fatalf("tick %d: spawn BEADS_ACTOR = %q, want the session bead id %q — this is the string the claim writes",
+				tick, env["BEADS_ACTOR"], got.ID)
 		}
 	}
 }
 
-// TestPoolSlotSessionRuntimeIdentityIsSessionName pins the end of the chain the
-// claim actually reads. The spawn env is mergeEnv(tp.Env, RuntimeEnvWithSessionContext),
-// so the RUNTIME projection wins — blanking tp.Env alone would be inert. With the
-// bead unaliased, runtimePublicAlias falls to empty and AssigneeIdentifier falls to
-// the persisted session name, which is what `gc hook --claim` then writes as the
-// assignee (hookSessionAgentForQuery: GC_ALIAS -> BEADS_ACTOR -> ...).
-func TestPoolSlotSessionRuntimeIdentityIsSessionName(t *testing.T) {
-	const sessionName = "claude-gcg-session-x"
+// TestPoolSlotSessionRuntimeIdentityIsSessionBeadID pins the end of the chain
+// the claim actually reads. The spawn env is mergeEnv(tp.Env, RuntimeEnvWithSessionContext),
+// so the RUNTIME projection wins — blanking tp.Env alone would be inert. With
+// the bead unaliased, runtimePublicAlias falls to empty and AssigneeIdentifier
+// falls to the unique session bead ID (see that function's doc). `gc hook --claim`
+// writes this same identity as the assignee (hookSessionAgentForQuery: GC_ALIAS ->
+// BEADS_ACTOR -> ...).
+func TestPoolSlotSessionRuntimeIdentityIsSessionBeadID(t *testing.T) {
+	const (
+		sessionID   = "gcg-session-x"
+		sessionName = "claude-gcg-session-x"
+	)
 	info := sessiontest.SeedBead(t, beads.Bead{
-		ID:     "gcg-session-x",
+		ID:     sessionID,
 		Type:   sessionBeadType,
 		Status: "open",
 		Labels: []string{sessionBeadLabel, "agent:rig/claude-1"},
@@ -198,18 +206,18 @@ func TestPoolSlotSessionRuntimeIdentityIsSessionName(t *testing.T) {
 		},
 	})
 
-	if got := sessionpkg.AssigneeIdentifier(info); got != sessionName {
-		t.Fatalf("AssigneeIdentifier = %q, want the session name %q — this is the string BEADS_ACTOR and the claim both use", got, sessionName)
+	if got := sessionpkg.AssigneeIdentifier(info); got != sessionID {
+		t.Fatalf("AssigneeIdentifier = %q, want the session bead id %q — this is the string BEADS_ACTOR and the claim both use", got, sessionID)
 	}
 	env := sessionpkg.RuntimeEnvWithSessionContext(info, 1, 1, "tok")
 	if env["GC_ALIAS"] != "" {
 		t.Fatalf("runtime GC_ALIAS = %q, want empty for an unaliased pool slot", env["GC_ALIAS"])
 	}
-	if env["BEADS_ACTOR"] != sessionName {
-		t.Fatalf("runtime BEADS_ACTOR = %q, want the session name %q", env["BEADS_ACTOR"], sessionName)
+	if env["BEADS_ACTOR"] != sessionID {
+		t.Fatalf("runtime BEADS_ACTOR = %q, want the session bead id %q", env["BEADS_ACTOR"], sessionID)
 	}
-	if env["GC_AGENT"] != sessionName {
-		t.Fatalf("runtime GC_AGENT = %q, want the session name %q", env["GC_AGENT"], sessionName)
+	if env["GC_AGENT"] != sessionID {
+		t.Fatalf("runtime GC_AGENT = %q, want the session bead id %q", env["GC_AGENT"], sessionID)
 	}
 }
 
@@ -273,8 +281,8 @@ func TestCanonicalSingletonPoolKeepsStableAlias(t *testing.T) {
 // TestReleaseOrphanedPoolAssignmentsReopensStaleSlotFormClaim is the deploy
 // self-heal pin. Beads still assigned slot-form when the fix lands map to no
 // live session (pool beads no longer answer to slot names), so orphan release
-// reopens them and a fresh worker re-claims under its session name. No manual
-// bead surgery.
+// reopens them and a fresh worker re-claims under its own session bead ID. No
+// manual bead surgery.
 func TestReleaseOrphanedPoolAssignmentsReopensStaleSlotFormClaim(t *testing.T) {
 	store := beads.NewMemStore()
 	if _, err := store.Create(beads.Bead{

--- a/internal/session/assignee_identities.go
+++ b/internal/session/assignee_identities.go
@@ -46,18 +46,48 @@ func AssigneeIdentities(i Info) []string {
 	return identities
 }
 
+// isPoolManagedIdentity reports whether i is a pool-managed worker session:
+// the reconciler's own pool_managed / pool_slot / session_origin=="ephemeral"
+// markers. It is the session.Info-only subset of cmd/gc's
+// isPoolManagedSessionInfo (which additionally resolves a cfg-driven template
+// fallback) — AssigneeIdentifier has no config to resolve that fallback
+// against, and every pool-managed bead the controller creates stamps one of
+// these three markers directly, so the subset is exact for this decision.
+func isPoolManagedIdentity(i Info) bool {
+	if strings.TrimSpace(i.SessionOrigin) == "ephemeral" {
+		return true
+	}
+	if i.PoolManaged {
+		return true
+	}
+	return strings.TrimSpace(i.PoolSlot) != ""
+}
+
 // AssigneeIdentifier returns the durable agent-facing ownership identity of a
-// session: its current public alias, configured named identity, or runtime
-// session name, falling back to the bead ID when no name metadata is present.
+// session: its current public alias or configured named identity always win.
+// Otherwise, an unaliased pool-managed worker claims under its unique session
+// bead ID — pool session_name is a chair reused by every occupant of a slot,
+// so stamping it as the ownership identity lets a dead occupant's claim look
+// held by whoever the controller seats there next. Non-pool sessions keep the
+// runtime session name, falling back to the bead ID when no name metadata is
+// present.
 // This is the same alias-first identity RuntimeEnvWithSessionContext exposes
 // through GC_ALIAS and BEADS_ACTOR; GC_AGENT mirrors it only for compatibility.
 // Keeping API assignment normalization on this rule prevents one session from
 // owning work under a different exact string than it presents to bd.
 func AssigneeIdentifier(i Info) string {
-	for _, v := range []string{i.Alias, i.ConfiguredNamedIdentity, i.SessionNameMetadata} {
+	for _, v := range []string{i.Alias, i.ConfiguredNamedIdentity} {
 		if v = strings.TrimSpace(v); v != "" {
 			return v
 		}
 	}
-	return i.ID
+	if isPoolManagedIdentity(i) {
+		if id := strings.TrimSpace(i.ID); id != "" {
+			return id
+		}
+	}
+	if sn := strings.TrimSpace(i.SessionNameMetadata); sn != "" {
+		return sn
+	}
+	return strings.TrimSpace(i.ID)
 }

--- a/internal/session/assignee_identities_test.go
+++ b/internal/session/assignee_identities_test.go
@@ -159,6 +159,21 @@ func TestAssigneeIdentifier(t *testing.T) {
 			info: Info{ID: "s1", Alias: "  al  ", SessionNameMetadata: "  sn  "},
 			want: "al",
 		},
+		{
+			name: "unaliased pool-managed session (pool_managed) claims under its bead id, not the reusable session name",
+			info: Info{ID: "s1", SessionNameMetadata: "sn", PoolManaged: true},
+			want: "s1",
+		},
+		{
+			name: "unaliased pool-managed session (pool_slot) claims under its bead id",
+			info: Info{ID: "s1", SessionNameMetadata: "sn", PoolSlot: "3"},
+			want: "s1",
+		},
+		{
+			name: "unaliased pool-managed session (session_origin=ephemeral) claims under its bead id",
+			info: Info{ID: "s1", SessionNameMetadata: "sn", SessionOrigin: "ephemeral"},
+			want: "s1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/session/lifecycle_actor_test.go
+++ b/internal/session/lifecycle_actor_test.go
@@ -30,7 +30,7 @@ func TestRuntimeEnvWithSessionContextAlignsAgentAndBeadsActor(t *testing.T) {
 	}{
 		{name: "canonical alias", alias: "rig/worker", sessionName: "rig--worker", persistedSessionName: "rig--worker", want: "rig/worker"},
 		{name: "configured named identity fallback", configuredIdentity: "rig/worker", sessionName: "rig--worker", persistedSessionName: "rig--worker", want: "rig/worker"},
-		{name: "session name fallback", sessionName: "rig--worker", persistedSessionName: "rig--worker", want: "rig--worker"},
+		{name: "unaliased pool-managed session claims under its bead id, not the reusable session name", sessionName: "rig--worker", persistedSessionName: "rig--worker", want: "session-id"},
 		{name: "bead id fallback", sessionName: "s-session-id", want: "session-id"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

An unaliased pool worker claims work under its unique `GC_SESSION_ID`, but `RuntimeEnvWithSessionContext` sets `BEADS_ACTOR` from the reusable pool `session_name`. `bd` then rejects the worker's normal close because its actor does not equal the assignee.

## Change

- Use the session bead ID as `AssigneeIdentifier` for unaliased pool-managed sessions.
- Keep alias-first and configured named identity behavior unchanged.
- Keep the existing session-name fallback for non-pool sessions.
- Add a regression that compares the real hook claim identity with the runtime close actor.

## Verification

```text
go test ./internal/session ./cmd/gc -run 'TestAssigneeIdentifier|TestRuntimeEnvWithSessionContextAlignsAgentAndBeadsActor|TestPoolSlotSessionRuntimeIdentity|TestPoolWorkerClaimAndCloseIdentity|TestNamedSessionRuntimeIdentityStaysAliasFirst'
ok  github.com/gastownhall/gascity/internal/session  1.197s
ok  github.com/gastownhall/gascity/cmd/gc  1.931s
```