### PR TITLE
fix(reaper): stop Step 6 SQL prune from crashing the run on zero matched rows (#6284)

### DIFF
--- a/internal/bootstrap/packs/core/assets/scripts/reaper.sh
+++ b/internal/bootstrap/packs/core/assets/scripts/reaper.sh
@@ -1318,7 +1318,7 @@ if [ -d "$CITY_BEADS_DIR" ]; then
                 TOTAL=0
                 while true; do
                     RAW=$(dolt_sql -r csv -q "USE \`${CITY_DB}\`; SELECT id FROM issues WHERE issue_type='session' AND status='closed' AND closed_at < DATE_SUB(NOW(), INTERVAL ${SESSION_AGE_H} HOUR) LIMIT 500;") 2>/dev/null || break
-                    BATCH_IDS=$(printf '%s\n' "$RAW" | tail -n +2 | grep -v '^$')
+                    BATCH_IDS=$(printf '%s\n' "$RAW" | tail -n +2 | grep -v '^$' || true)
                     BATCH_COUNT=$(printf '%s\n' "$BATCH_IDS" | grep -c . || true)
                     [ "$BATCH_COUNT" -gt 0 ] || break
                     SQL_IDS=$(printf '%s\n' "$BATCH_IDS" | sed "s/.*/'&'/" | tr '\n' ',' | sed 's/,$//')

--- a/test/reaper_session_pattern_test.sh
+++ b/test/reaper_session_pattern_test.sh
@@ -172,4 +172,69 @@ else
     fail "T3: GC_REAPER_SESSION_BEAD_PATTERN='' via env → expected SQL path; bd=$bd_called dolt=$dolt_called"
 fi
 
+# run_step6_sql_empty_batch exercises the #6284 regression: the SQL path's
+# per-batch SELECT returning zero data rows (a CSV header line only, the
+# normal case for the first 30 days of any city) must not abort Step 6.
+# Pre-fix, BATCH_IDS=$(... | grep -v '^$') has no matching lines against a
+# truly empty input and exits 1; under this script's own set -euo pipefail
+# that aborts the whole sourced block, so nothing after the loop -- not even
+# the escalation logic two blocks later -- ever runs. A completed-marker file
+# written immediately after the source line proves execution reached the end.
+run_step6_sql_empty_batch() {
+    local tmpdir dolt_flag completed_flag step6_file run_script exit_code
+    tmpdir=$(mktemp -d)
+    dolt_flag="$tmpdir/dolt_called"
+    completed_flag="$tmpdir/completed"
+    step6_file="$tmpdir/step6.sh"
+    run_script="$tmpdir/run.sh"
+
+    mkdir -p "$tmpdir/.beads/backup"
+    printf '{"dolt_database":"test_db"}' > "$tmpdir/.beads/metadata.json"
+    _NOW_TS=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    printf '{"last_dolt_commit":"test","timestamp":"%s"}\n' "$_NOW_TS" \
+        > "$tmpdir/.beads/backup/backup_state.json"
+
+    printf '%s\n' "$STEP6" > "$step6_file"
+
+    cat > "$run_script" << RUNEOF
+#!/usr/bin/env bash
+set -euo pipefail
+gc()            { printf '{"pruned_count":0}'; }
+dolt_sql()      { touch '$dolt_flag'; printf 'id\n'; }
+record_anomaly(){ :; }
+export -f gc dolt_sql record_anomaly
+CITY_ABS='$tmpdir'
+CITY_BEADS_DIR='$tmpdir/.beads'
+SESSION_BEAD_PATTERN=''
+SESSION_PURGE_AGE='720h'
+DRY_RUN=''
+TOTAL_SESSIONS_PRUNED=0
+SESSION_PRUNE_ATTEMPTED=0
+CITY_DB='test_db'
+GC_BACKUP_MAX_AGE_FOR_BULK_DELETE=86400
+. '$step6_file'
+touch '$completed_flag'
+RUNEOF
+
+    bash "$run_script" >/dev/null 2>&1
+    exit_code=$?
+
+    local completed dolt_result
+    completed=$([ -f "$completed_flag" ] && echo yes || echo no)
+    dolt_result=$([ -f "$dolt_flag" ] && echo yes || echo no)
+    rm -rf "$tmpdir"
+    printf '%s|%s|%s\n' "$exit_code" "$completed" "$dolt_result"
+}
+
+# ── T4: SQL path, zero-row (header-only) dolt result must not abort Step 6 ────
+result=$(run_step6_sql_empty_batch)
+exit_code=$(printf '%s' "$result" | cut -d'|' -f1)
+completed=$(printf '%s' "$result" | cut -d'|' -f2)
+dolt_called=$(printf '%s' "$result" | cut -d'|' -f3)
+if [ "$exit_code" = "0" ] && [ "$completed" = "yes" ] && [ "$dolt_called" = "yes" ]; then
+    pass "T4: SQL path with zero-row dolt result completes Step 6 without aborting"
+else
+    fail "T4: SQL path with zero-row dolt result aborted Step 6 (exit=$exit_code completed=$completed dolt=$dolt_called)"
+fi
+
 [ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## What

`reaper.sh` Step 6's SQL prune path (`GC_REAPER_SESSION_BEAD_PATTERN=""`) crashes the entire script whenever the SELECT returns zero rows — the normal case for the first 30 days of any city, or any quiet period. `BATCH_IDS=$(... | grep -v '^$')` matches nothing against empty input, `grep` exits 1, and under this script's own `set -euo pipefail` that silently aborts the whole step — including the escalation logic two blocks later. So this setting doesn't just fail to prune, it hides every other real anomaly the run would have reported. A reporter `bash -x` trace confirmed it: `+ BATCH_IDS=` / `(exit 1)`.

Fixes #6284.

## Fix

One-line guard, `|| true`, matching the exact precedent already sitting on the very next line (`BATCH_COUNT=$(... | grep -c . || true)`).

Added a real regression test (T4 in `test/reaper_session_pattern_test.sh`) rather than trusting the one-line diff alone: it stubs `dolt_sql` to return a CSV header with zero data rows and asserts Step 6 reaches a completed-marker written immediately after the block — not just that `dolt` was invoked (the existing T1/T3 tests only checked the latter, which is why they never caught this: the crash happens *after* `dolt_sql` is called, so those tests were blind to it). Verified per the standard protocol: temporarily reverted the one-line fix, confirmed T4 fails with exactly the reported symptom (`exit=1 completed=no`), restored, confirmed all four tests pass again. Also ran the three adjacent reaper test files (`reaper_prune_backup_guard_test.sh`, `reaper_expired_rig_nudge_test.sh`, `reaper_rig_name_for_db_test.sh`) — all pass.

### Scope

This is **item 2 of #6284 only.** Item 1 (the session-prune backup-freshness gate reading `.beads/dolt-backup-state.json` / `.beads/backup/backup_state.json`, neither of which `mol-dog-backup`'s order ever writes, causing a MEDIUM escalation every run) needs a maintainer decision between two remedies the reporter names — recognize gc's own `.dolt-backup` artifact as a freshness signal, or downgrade a missing bd-side state file to an info-level skip. Left for a separate pass.

## Testing

`go build -tags gms_pure_go ./...` clean, `gofmt -l` empty on the touched file, T4 + all four `reaper_session_pattern_test.sh` cases pass, and the three adjacent reaper test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
